### PR TITLE
fix: add Gemini fallback to Claude complete() and GET handler for knowledge search

### DIFF
--- a/apps/web/app/api/knowledge/search/route.ts
+++ b/apps/web/app/api/knowledge/search/route.ts
@@ -3,6 +3,35 @@ import { routes, contracts } from '@maiyuri/api';
 import { success, error, handleZodError } from '@/lib/api-utils';
 import { ZodError } from 'zod';
 
+// GET /api/knowledge/search?q=...&limit=10&threshold=0.7 - Semantic search via query params
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('q') || searchParams.get('query');
+    const limit = parseInt(searchParams.get('limit') || '10', 10);
+    const threshold = parseFloat(searchParams.get('threshold') || '0.7');
+
+    if (!query) {
+      return error('Query parameter (q or query) is required', 400);
+    }
+
+    const result = await routes.knowledge.search({
+      query,
+      limit,
+      threshold,
+    });
+
+    if (!result.success) {
+      return error(result.error?.message || 'Search failed', 500);
+    }
+
+    return success(result.data || []);
+  } catch (err) {
+    console.error('Knowledge search error:', err);
+    return error('Failed to search knowledge base', 500);
+  }
+}
+
 // POST /api/knowledge/search - Semantic search across all content
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- Add Gemini fallback to Claude `complete()` function for resilience when Claude API fails (billing issues, rate limits, etc.)
- Add GET handler to `/api/knowledge/search` endpoint to fix 405 error

## Changes
- **apps/api/src/cloudcore/services/ai/claude.ts**: Added Gemini fallback to `complete()` function, matching the existing fallback pattern in `completeJson()`
- **apps/web/app/api/knowledge/search/route.ts**: Added GET handler that accepts query params (`q`, `limit`, `threshold`)

## Test plan
- [ ] Verify GET `/api/knowledge/search?q=bricks` returns 200 with results
- [ ] Temporarily disable Claude API key and verify Gemini fallback activates
- [ ] Check logs show `🔄 Swapping to Fallback: Gemini` message on Claude failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)