### PR TITLE
feat(coaching): AI Sales Coach — Phase 1 (training foundation)

### DIFF
--- a/apps/web/app/(dashboard)/coaching/admin/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/admin/page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card, Button, cn } from "@maiyuri/ui";
+import { toast } from "sonner";
+import type {
+  CoachModule,
+  CoachAssignment,
+  CoachKnowledgeArticle,
+} from "@maiyuri/shared";
+
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+async function getJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Failed to load");
+  return (await res.json()).data as T;
+}
+async function postJSON(url: string, body: unknown) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error((await res.json()).error || "Request failed");
+  return (await res.json()).data;
+}
+
+const TABS = ["Content", "Assignments", "Knowledge", "Learners"] as const;
+type Tab = (typeof TABS)[number];
+
+// ---------------------------------------------------------------- Content tab
+function ContentTab() {
+  const qc = useQueryClient();
+  const { data: modules } = useQuery({ queryKey: ["coaching", "modules", "admin"], queryFn: () => getJSON<CoachModule[]>("/api/coaching/modules") });
+  const [title, setTitle] = useState("");
+  const [desc, setDesc] = useState("");
+  const [selModule, setSelModule] = useState<string>("");
+
+  const createModule = useMutation({
+    mutationFn: () =>
+      postJSON("/api/coaching/modules", {
+        slug: slugify(title),
+        title,
+        description: desc || null,
+        role_applicability: [],
+      }),
+    onSuccess: () => {
+      toast.success("Module created");
+      setTitle(""); setDesc("");
+      qc.invalidateQueries({ queryKey: ["coaching", "modules", "admin"] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <div className="space-y-5">
+      <Card className="space-y-3 p-5">
+        <h3 className="text-sm font-semibold">New module</h3>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Module title"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <input value={desc} onChange={(e) => setDesc(e.target.value)} placeholder="Short description"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <Button size="sm" disabled={!title || createModule.isPending} onClick={() => createModule.mutate()}>
+          {createModule.isPending ? "Creating…" : "Create module"}
+        </Button>
+      </Card>
+
+      <Card className="p-5">
+        <h3 className="mb-2 text-sm font-semibold">Modules</h3>
+        <div className="space-y-1">
+          {(modules || []).map((m) => (
+            <button key={m.id} onClick={() => setSelModule(m.id === selModule ? "" : m.id)}
+              className={cn("flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm",
+                selModule === m.id ? "bg-amber-50 dark:bg-amber-900/20" : "hover:bg-slate-50 dark:hover:bg-slate-800")}>
+              <span>{m.title}</span>
+              <span className="text-xs text-slate-400">{m.is_active ? "active" : "retired"}</span>
+            </button>
+          ))}
+          {(modules || []).length === 0 && <p className="text-sm text-slate-400">No modules yet.</p>}
+        </div>
+      </Card>
+
+      {selModule && <LessonManager moduleId={selModule} />}
+    </div>
+  );
+}
+
+function LessonManager({ moduleId }: { moduleId: string }) {
+  const qc = useQueryClient();
+  const { data } = useQuery({
+    queryKey: ["coaching", "module", moduleId, "admin"],
+    queryFn: () => getJSON<{ module: CoachModule; lessons: { id: string; title: string }[] }>(`/api/coaching/modules/${moduleId}`),
+  });
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [selLesson, setSelLesson] = useState("");
+
+  const createLesson = useMutation({
+    mutationFn: () =>
+      postJSON("/api/coaching/lessons", { module_id: moduleId, slug: slugify(title), title, content }),
+    onSuccess: () => {
+      toast.success("Lesson added");
+      setTitle(""); setContent("");
+      qc.invalidateQueries({ queryKey: ["coaching", "module", moduleId, "admin"] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <Card className="space-y-3 p-5">
+      <h3 className="text-sm font-semibold">Lessons in “{data?.module.title}”</h3>
+      <div className="space-y-1">
+        {(data?.lessons || []).map((l) => (
+          <button key={l.id} onClick={() => setSelLesson(l.id === selLesson ? "" : l.id)}
+            className={cn("flex w-full rounded-md px-3 py-1.5 text-left text-sm",
+              selLesson === l.id ? "bg-amber-50 dark:bg-amber-900/20" : "hover:bg-slate-50 dark:hover:bg-slate-800")}>
+            📘 {l.title}
+          </button>
+        ))}
+      </div>
+      <div className="space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Lesson title"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <textarea value={content} onChange={(e) => setContent(e.target.value)} rows={4} placeholder="Lesson content (markdown)"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <Button size="sm" disabled={!title || createLesson.isPending} onClick={() => createLesson.mutate()}>
+          {createLesson.isPending ? "Adding…" : "Add lesson"}
+        </Button>
+      </div>
+      {selLesson && <QuizManager lessonId={selLesson} />}
+    </Card>
+  );
+}
+
+function QuizManager({ lessonId }: { lessonId: string }) {
+  const [question, setQuestion] = useState("");
+  const [options, setOptions] = useState("A) ...\nB) ...\nC) ...");
+  const [correct, setCorrect] = useState("C");
+
+  const createQuiz = useMutation({
+    mutationFn: () => {
+      const opts = options.split("\n").map((line) => {
+        const m = line.match(/^\s*([A-Za-z0-9]+)[).]\s*(.+)$/);
+        return m ? { key: m[1], label: m[2] } : null;
+      }).filter(Boolean);
+      return postJSON("/api/coaching/quizzes", {
+        slug: slugify(question).slice(0, 60) + "-" + Date.now(),
+        lesson_id: lessonId,
+        question,
+        question_type: "mcq",
+        options_json: opts,
+        correct_answer: correct,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Quiz added");
+      setQuestion("");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <div className="mt-3 space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+      <h4 className="text-xs font-semibold uppercase text-slate-400">Add MCQ quiz</h4>
+      <input value={question} onChange={(e) => setQuestion(e.target.value)} placeholder="Question"
+        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+      <textarea value={options} onChange={(e) => setOptions(e.target.value)} rows={4}
+        className="w-full rounded-md border border-slate-300 px-3 py-2 font-mono text-xs dark:border-slate-600 dark:bg-slate-800" />
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-500">Correct key:</span>
+        <input value={correct} onChange={(e) => setCorrect(e.target.value)}
+          className="w-16 rounded-md border border-slate-300 px-2 py-1 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <Button size="sm" disabled={!question || createQuiz.isPending} onClick={() => createQuiz.mutate()}>
+          {createQuiz.isPending ? "…" : "Add quiz"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ------------------------------------------------------------ Assignments tab
+function AssignmentsAdminTab() {
+  const qc = useQueryClient();
+  const { data } = useQuery({ queryKey: ["coaching", "assignments", "admin"], queryFn: () => getJSON<CoachAssignment[]>("/api/coaching/assignments") });
+  const [title, setTitle] = useState("");
+  const [desc, setDesc] = useState("");
+  const create = useMutation({
+    mutationFn: () => postJSON("/api/coaching/assignments", { slug: slugify(title), title, description: desc || null }),
+    onSuccess: () => { toast.success("Assignment created"); setTitle(""); setDesc(""); qc.invalidateQueries({ queryKey: ["coaching", "assignments", "admin"] }); },
+    onError: (e: Error) => toast.error(e.message),
+  });
+  return (
+    <div className="space-y-4">
+      <Card className="space-y-2 p-5">
+        <h3 className="text-sm font-semibold">New assignment</h3>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <textarea value={desc} onChange={(e) => setDesc(e.target.value)} rows={2} placeholder="Instructions"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <Button size="sm" disabled={!title || create.isPending} onClick={() => create.mutate()}>Create</Button>
+      </Card>
+      <Card className="p-5">
+        <h3 className="mb-2 text-sm font-semibold">Assignments</h3>
+        {(data || []).map((a) => (
+          <div key={a.id} className="border-b border-slate-100 py-2 text-sm dark:border-slate-700">{a.title}</div>
+        ))}
+        {(data || []).length === 0 && <p className="text-sm text-slate-400">None yet.</p>}
+      </Card>
+    </div>
+  );
+}
+
+// -------------------------------------------------------------- Knowledge tab
+function KnowledgeAdminTab() {
+  const qc = useQueryClient();
+  const { data } = useQuery({ queryKey: ["coaching", "knowledge", "admin"], queryFn: () => getJSON<CoachKnowledgeArticle[]>("/api/coaching/knowledge") });
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const create = useMutation({
+    mutationFn: () => postJSON("/api/coaching/knowledge", { slug: slugify(title), title, content, category: "faq" }),
+    onSuccess: () => { toast.success("Article added"); setTitle(""); setContent(""); qc.invalidateQueries({ queryKey: ["coaching", "knowledge", "admin"] }); },
+    onError: (e: Error) => toast.error(e.message),
+  });
+  return (
+    <div className="space-y-4">
+      <Card className="space-y-2 p-5">
+        <h3 className="text-sm font-semibold">New knowledge article</h3>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <textarea value={content} onChange={(e) => setContent(e.target.value)} rows={3} placeholder="Content"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+        <Button size="sm" disabled={!title || create.isPending} onClick={() => create.mutate()}>Create</Button>
+      </Card>
+      <Card className="p-5">
+        <h3 className="mb-2 text-sm font-semibold">Articles</h3>
+        {(data || []).map((k) => (
+          <div key={k.id} className="border-b border-slate-100 py-2 text-sm dark:border-slate-700">
+            <span className="mr-2 rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-500 dark:bg-slate-700">{k.category}</span>
+            {k.title}
+          </div>
+        ))}
+        {(data || []).length === 0 && <p className="text-sm text-slate-400">None yet.</p>}
+      </Card>
+    </div>
+  );
+}
+
+// --------------------------------------------------------------- Learners tab
+interface LearnerReport {
+  userId: string;
+  name: string;
+  training_path: string;
+  progress: { trainingCompletionPct: number; quizAveragePct: number };
+  weakArea: string | null;
+  pendingSubmissions: number;
+}
+function LearnersTab() {
+  const qc = useQueryClient();
+  const { data } = useQuery({ queryKey: ["coaching", "admin", "progress"], queryFn: () => getJSON<LearnerReport[]>("/api/coaching/admin/progress") });
+  const [targetUser, setTargetUser] = useState("");
+  const [targetTitle, setTargetTitle] = useState("");
+
+  const assign = useMutation({
+    mutationFn: () => postJSON("/api/coaching/targets", { user_id: targetUser, title: targetTitle, target_type: "custom", frequency: "daily" }),
+    onSuccess: () => { toast.success("Target assigned"); setTargetTitle(""); qc.invalidateQueries({ queryKey: ["coaching", "admin", "progress"] }); },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return (
+    <div className="space-y-4">
+      <Card className="p-5">
+        <h3 className="mb-3 text-sm font-semibold">Learner progress</h3>
+        <div className="space-y-2">
+          {(data || []).map((r) => (
+            <div key={r.userId} className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
+              <div>
+                <div className="font-medium text-slate-900 dark:text-white">{r.name}</div>
+                <div className="text-xs text-slate-400">
+                  {r.training_path.replace(/_/g, " ")} · {r.progress.trainingCompletionPct}% trained · quiz {r.progress.quizAveragePct}%
+                  {r.weakArea && <span className="text-rose-500"> · weak: {r.weakArea}</span>}
+                  {r.pendingSubmissions > 0 && <span className="text-amber-500"> · {r.pendingSubmissions} to review</span>}
+                </div>
+              </div>
+              <button onClick={() => setTargetUser(r.userId)}
+                className={cn("rounded px-2 py-1 text-xs", targetUser === r.userId ? "bg-amber-500 text-white" : "bg-slate-100 dark:bg-slate-700")}>
+                {targetUser === r.userId ? "Selected" : "Assign target"}
+              </button>
+            </div>
+          ))}
+          {(data || []).length === 0 && <p className="text-sm text-slate-400">No learners yet.</p>}
+        </div>
+      </Card>
+
+      {targetUser && (
+        <Card className="space-y-2 p-5">
+          <h3 className="text-sm font-semibold">Assign daily target</h3>
+          <input value={targetTitle} onChange={(e) => setTargetTitle(e.target.value)} placeholder="e.g. Follow up with 5 leads"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-800" />
+          <Button size="sm" disabled={!targetTitle || assign.isPending} onClick={() => assign.mutate()}>
+            {assign.isPending ? "Assigning…" : "Assign"}
+          </Button>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default function CoachingAdminPage() {
+  const [tab, setTab] = useState<Tab>("Content");
+  const { data: me, isLoading } = useQuery({
+    queryKey: ["coaching", "me"],
+    queryFn: () => getJSON<{ isAdmin: boolean }>("/api/coaching/me"),
+  });
+
+  if (isLoading) return <Card className="p-8 text-center text-sm text-slate-400">Loading…</Card>;
+  if (!me?.isAdmin) {
+    return (
+      <Card className="p-8 text-center text-sm text-slate-500">
+        Admin access required. <Link href="/coaching" className="underline">Back to Coach</Link>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href="/coaching" className="text-xs text-slate-400">← Coach</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Coaching Admin</h1>
+        <p className="text-sm text-slate-500">Manage content, assignments, knowledge and learners.</p>
+      </div>
+
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
+        {TABS.map((t) => (
+          <button key={t} onClick={() => setTab(t)}
+            className={cn("px-4 py-2 text-sm font-medium",
+              tab === t ? "border-b-2 border-amber-500 text-slate-900 dark:text-white" : "text-slate-500")}>
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {tab === "Content" && <ContentTab />}
+      {tab === "Assignments" && <AssignmentsAdminTab />}
+      {tab === "Knowledge" && <KnowledgeAdminTab />}
+      {tab === "Learners" && <LearnersTab />}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/assignments/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/assignments/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card, Button } from "@maiyuri/ui";
+import { toast } from "sonner";
+import type { CoachAssignment, CoachAssignmentSubmission } from "@maiyuri/shared";
+
+type AssignmentRow = CoachAssignment & { mySubmission: CoachAssignmentSubmission | null };
+
+const STATUS_TONE: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  approved: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  needs_improvement: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+  rejected: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+};
+
+function AssignmentCard({ a, onDone }: { a: AssignmentRow; onDone: () => void }) {
+  const [text, setText] = useState("");
+  const submit = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/coaching/assignments/${a.id}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ submission_text: text }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      toast.success("Submitted for review");
+      setText("");
+      onDone();
+    },
+    onError: () => toast.error("Could not submit"),
+  });
+
+  return (
+    <Card className="space-y-3 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-semibold text-slate-900 dark:text-white">{a.title}</div>
+          {a.description && <p className="text-sm text-slate-500">{a.description}</p>}
+        </div>
+        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs capitalize text-slate-500 dark:bg-slate-700">
+          {a.due_frequency}
+        </span>
+      </div>
+
+      {a.mySubmission ? (
+        <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+          <div className="mb-1 flex items-center gap-2">
+            <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_TONE[a.mySubmission.manager_status]}`}>
+              {a.mySubmission.manager_status.replace(/_/g, " ")}
+            </span>
+            <span className="text-xs text-slate-400">Last submission</span>
+          </div>
+          <p className="whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-300">
+            {a.mySubmission.submission_text}
+          </p>
+          {a.mySubmission.manager_comment && (
+            <p className="mt-2 text-xs text-slate-500">Manager: {a.mySubmission.manager_comment}</p>
+          )}
+        </div>
+      ) : null}
+
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={3}
+        placeholder="Write your answer…"
+        className="w-full rounded-lg border border-slate-300 bg-white p-3 text-sm dark:border-slate-600 dark:bg-slate-800"
+      />
+      <div className="flex justify-end">
+        <Button onClick={() => submit.mutate()} disabled={!text || submit.isPending}>
+          {submit.isPending ? "Submitting…" : a.mySubmission ? "Resubmit" : "Submit"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+export default function AssignmentsPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["coaching", "assignments"],
+    queryFn: async (): Promise<AssignmentRow[]> => {
+      const res = await fetch("/api/coaching/assignments");
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data;
+    },
+  });
+
+  const refetch = () => qc.invalidateQueries({ queryKey: ["coaching", "assignments"] });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Link href="/coaching" className="text-xs text-slate-400">← Coach</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Assignments</h1>
+        <p className="text-sm text-slate-500">Practice, then submit for your manager's review.</p>
+      </div>
+      {isLoading ? (
+        <Card className="p-8 text-center text-sm text-slate-400">Loading…</Card>
+      ) : !data || data.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-slate-400">No assignments yet.</Card>
+      ) : (
+        <div className="space-y-3">
+          {data.map((a) => (
+            <AssignmentCard key={a.id} a={a} onDone={refetch} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/learn/[lessonId]/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/learn/[lessonId]/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card, Button } from "@maiyuri/ui";
+import { toast } from "sonner";
+import type { CoachLesson, CoachQuiz } from "@maiyuri/shared";
+
+interface LessonBundle {
+  lesson: CoachLesson;
+  quizzes: CoachQuiz[];
+  completed: boolean;
+}
+
+function Block({ title, body }: { title: string; body?: string | null }) {
+  if (!body) return null;
+  return (
+    <div>
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">{title}</h3>
+      <div className="whitespace-pre-wrap text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+export default function LessonDetailPage() {
+  const { lessonId } = useParams<{ lessonId: string }>();
+  const qc = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["coaching", "lesson", lessonId],
+    queryFn: async (): Promise<LessonBundle> => {
+      const res = await fetch(`/api/coaching/lessons/${lessonId}`);
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data;
+    },
+  });
+
+  const complete = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/coaching/lessons/${lessonId}/complete`, { method: "POST" });
+      if (!res.ok) throw new Error("Failed to mark complete");
+      return res.json();
+    },
+    onSuccess: () => {
+      toast.success("Lesson marked complete");
+      qc.invalidateQueries({ queryKey: ["coaching", "lesson", lessonId] });
+      qc.invalidateQueries({ queryKey: ["coaching", "me"] });
+    },
+    onError: () => toast.error("Could not mark complete"),
+  });
+
+  if (isLoading || !data) {
+    return <Card className="p-8 text-center text-sm text-slate-400">Loading lesson…</Card>;
+  }
+
+  const { lesson, quizzes, completed } = data;
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href="/coaching/learn" className="text-xs text-slate-400">← Library</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">{lesson.title}</h1>
+        {lesson.objective && <p className="text-sm text-slate-500">{lesson.objective}</p>}
+      </div>
+
+      <Card className="space-y-5 p-5">
+        <Block title="Lesson" body={lesson.content} />
+        <Block title="Example" body={lesson.examples} />
+        <Block title="Do / Don't" body={lesson.do_dont_notes} />
+      </Card>
+
+      {quizzes.length > 0 && (
+        <Card className="p-5">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+            Test yourself
+          </h2>
+          <ul className="space-y-2">
+            {quizzes.map((q) => (
+              <li key={q.id}>
+                <Link
+                  href={`/coaching/quiz/${q.id}`}
+                  className="flex items-center gap-3 rounded-lg border border-slate-200 px-3 py-2.5 text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                >
+                  <span>📝</span>
+                  <span className="text-slate-800 dark:text-slate-200">{q.question}</span>
+                  <span className="ml-auto text-xs text-slate-400">Take →</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      <div className="flex justify-end">
+        <Button onClick={() => complete.mutate()} disabled={complete.isPending || completed}>
+          {completed ? "✓ Completed" : complete.isPending ? "Saving…" : "Mark lesson complete"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/learn/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/learn/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card } from "@maiyuri/ui";
+import type { CoachLesson, CoachModule } from "@maiyuri/shared";
+
+async function fetchModules(): Promise<CoachModule[]> {
+  const res = await fetch("/api/coaching/modules");
+  if (!res.ok) throw new Error("Failed to load modules");
+  return (await res.json()).data;
+}
+
+type LessonWithDone = CoachLesson & { completed: boolean };
+
+function ModuleCard({ module }: { module: CoachModule }) {
+  const [open, setOpen] = useState(false);
+  const { data: detail } = useQuery({
+    queryKey: ["coaching", "module", module.id],
+    queryFn: async () => {
+      const res = await fetch(`/api/coaching/modules/${module.id}`);
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data as { module: CoachModule; lessons: LessonWithDone[] };
+    },
+    enabled: open,
+  });
+
+  return (
+    <Card className="overflow-hidden">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between gap-3 p-4 text-left"
+      >
+        <div>
+          <div className="font-semibold text-slate-900 dark:text-white">{module.title}</div>
+          {module.description && (
+            <div className="text-xs text-slate-500">{module.description}</div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-slate-400">
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 capitalize dark:bg-slate-700">
+            {module.difficulty}
+          </span>
+          <span>{open ? "▲" : "▼"}</span>
+        </div>
+      </button>
+      {open && (
+        <div className="border-t border-slate-200 dark:border-slate-700">
+          {!detail ? (
+            <div className="p-4 text-sm text-slate-400">Loading lessons…</div>
+          ) : detail.lessons.length === 0 ? (
+            <div className="p-4 text-sm text-slate-400">No lessons yet.</div>
+          ) : (
+            <ul>
+              {detail.lessons.map((l) => (
+                <li key={l.id}>
+                  <Link
+                    href={`/coaching/learn/${l.id}`}
+                    className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                  >
+                    <span>{l.completed ? "✅" : "📘"}</span>
+                    <span className="text-slate-800 dark:text-slate-200">{l.title}</span>
+                    <span className="ml-auto text-xs text-slate-400">{l.estimated_minutes} min</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default function LearnLibraryPage() {
+  const { data: modules, isLoading } = useQuery({
+    queryKey: ["coaching", "modules"],
+    queryFn: fetchModules,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Link href="/coaching" className="text-xs text-slate-400">← Coach</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Learning Library</h1>
+        <p className="text-sm text-slate-500">Work through each module, then test yourself.</p>
+      </div>
+      {isLoading ? (
+        <Card className="p-8 text-center text-sm text-slate-400">Loading modules…</Card>
+      ) : !modules || modules.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-slate-400">No modules yet.</Card>
+      ) : (
+        <div className="space-y-3">
+          {modules.map((m) => (
+            <ModuleCard key={m.id} module={m} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/page.tsx
@@ -1,1322 +1,160 @@
 "use client";
 
-import { useState, useEffect, useCallback, Suspense } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
-import { cn } from "@maiyuri/ui";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card } from "@maiyuri/ui";
 import { HelpButton } from "@/components/help";
+import type {
+  CoachProgressScore,
+  CoachTodayPlanItem,
+  CoachTarget,
+  CoachUser,
+} from "@maiyuri/shared";
 
-// Tutorial Modal Component
-function TutorialModal({
-  isOpen,
-  onClose,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-}) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      <div className="relative min-h-screen flex items-center justify-center p-4">
-        <div className="relative bg-white dark:bg-slate-800 rounded-xl shadow-2xl max-w-3xl w-full max-h-[85vh] overflow-hidden">
-          {/* Header */}
-          <div className="sticky top-0 bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
-                <BookOpenIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-              </div>
-              <h2 className="text-xl font-bold text-slate-900 dark:text-white">
-                Coaching Tutorial
-              </h2>
-            </div>
-            <button
-              onClick={onClose}
-              className="p-2 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
-            >
-              <XIcon className="h-5 w-5 text-slate-500" />
-            </button>
-          </div>
-
-          {/* Content */}
-          <div className="overflow-y-auto max-h-[calc(85vh-80px)] px-6 py-6 space-y-8">
-            {/* What is Coaching */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <SparklesIcon className="h-5 w-5 text-purple-500" />
-                What is the Coaching Module?
-              </h3>
-              <p className="text-slate-600 dark:text-slate-300 mb-4">
-                The Coaching Module uses AI to analyze your lead management
-                performance and provide personalized recommendations to help you
-                improve.
-              </p>
-              <div className="grid grid-cols-2 gap-3">
-                {[
-                  "Leads handled",
-                  "Conversion rate",
-                  "Response time",
-                  "Follow-up completion",
-                ].map((item) => (
-                  <div
-                    key={item}
-                    className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
-                  >
-                    <CheckCircleIcon className="h-4 w-4 text-green-500" />
-                    {item}
-                  </div>
-                ))}
-              </div>
-            </section>
-
-            {/* How to Access */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <MapIcon className="h-5 w-5 text-blue-500" />
-                How to Access
-              </h3>
-              <ol className="space-y-3">
-                {[
-                  "Log in to your account",
-                  'Click "Coaching" in the sidebar menu',
-                  "View Team Overview or Individual Coaching",
-                ].map((step, idx) => (
-                  <li key={idx} className="flex items-start gap-3">
-                    <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                      {idx + 1}
-                    </span>
-                    <span className="text-slate-600 dark:text-slate-300">
-                      {step}
-                    </span>
-                  </li>
-                ))}
-              </ol>
-            </section>
-
-            {/* Understanding Team View */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <UsersIcon className="h-5 w-5 text-indigo-500" />
-                Team Overview
-              </h3>
-              <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-4">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="text-left text-slate-500 dark:text-slate-400">
-                      <th className="pb-2">Metric</th>
-                      <th className="pb-2">What It Means</th>
-                    </tr>
-                  </thead>
-                  <tbody className="text-slate-600 dark:text-slate-300">
-                    <tr>
-                      <td className="py-1 font-medium">Total Leads</td>
-                      <td>Leads managed by the team</td>
-                    </tr>
-                    <tr>
-                      <td className="py-1 font-medium">Conversion Rate</td>
-                      <td>Leads converted to customers</td>
-                    </tr>
-                    <tr>
-                      <td className="py-1 font-medium">Top Performer</td>
-                      <td>Best performing team member</td>
-                    </tr>
-                    <tr>
-                      <td className="py-1 font-medium">Weekly Trend</td>
-                      <td>Performance direction</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </section>
-
-            {/* Performance Score */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <ChartIcon className="h-5 w-5 text-green-500" />
-                Performance Score
-              </h3>
-              <div className="space-y-2">
-                <div className="flex items-center gap-3">
-                  <span className="w-20 h-8 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center text-sm font-bold">
-                    80-100
-                  </span>
-                  <span className="text-slate-600 dark:text-slate-300">
-                    Excellent - Keep up the great work!
-                  </span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="w-20 h-8 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-600 dark:text-yellow-400 rounded-full flex items-center justify-center text-sm font-bold">
-                    60-79
-                  </span>
-                  <span className="text-slate-600 dark:text-slate-300">
-                    Good - Some areas for improvement
-                  </span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="w-20 h-8 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center text-sm font-bold">
-                    &lt;60
-                  </span>
-                  <span className="text-slate-600 dark:text-slate-300">
-                    Needs attention - Focus on recommendations
-                  </span>
-                </div>
-              </div>
-            </section>
-
-            {/* AI Recommendations */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <LightbulbIcon className="h-5 w-5 text-yellow-500" />
-                AI Recommendations
-              </h3>
-              <p className="text-slate-600 dark:text-slate-300 mb-3">
-                Each recommendation includes:
-              </p>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Priority
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    High, Medium, or Low
-                  </p>
-                </div>
-                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Area
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Which aspect to improve
-                  </p>
-                </div>
-                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Action
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Steps you can take
-                  </p>
-                </div>
-                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Impact
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Expected improvement
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            {/* Tips for Improvement */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <ArrowUpIcon className="h-5 w-5 text-orange-500" />
-                Tips to Improve Quickly
-              </h3>
-              <ul className="space-y-2">
-                {[
-                  "Respond to leads within 2 hours",
-                  "Complete all scheduled follow-ups",
-                  "Keep detailed notes on every interaction",
-                  "Prioritize hot leads first",
-                  "Review coaching weekly on Mondays",
-                ].map((tip, idx) => (
-                  <li
-                    key={idx}
-                    className="flex items-start gap-2 text-slate-600 dark:text-slate-300"
-                  >
-                    <span className="text-green-500 mt-0.5">+</span>
-                    {tip}
-                  </li>
-                ))}
-              </ul>
-            </section>
-
-            {/* FAQ */}
-            <section>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
-                <QuestionIcon className="h-5 w-5 text-slate-500" />
-                Frequently Asked Questions
-              </h3>
-              <div className="space-y-4">
-                <div>
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    How often is data updated?
-                  </p>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    Data is analyzed in real-time each time you view the page.
-                  </p>
-                </div>
-                <div>
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Why is my score low?
-                  </p>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    Check recommendations to see which specific areas need
-                    improvement.
-                  </p>
-                </div>
-                <div>
-                  <p className="font-medium text-slate-900 dark:text-white text-sm">
-                    Can my manager see my data?
-                  </p>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    Yes, managers can view team coaching data.
-                  </p>
-                </div>
-              </div>
-            </section>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+interface MeBundle {
+  coachUser: CoachUser;
+  isAdmin: boolean;
+  progress: CoachProgressScore;
+  todayPlan: CoachTodayPlanItem[];
+  targets: CoachTarget[];
 }
 
-interface TeamMember {
-  id: string;
-  name: string;
-  role: string;
-  metrics: {
-    leadsHandled: number;
-    conversionRate: number;
-    avgResponseTime: string;
-    activeLeads: number;
-  };
-  strengths: string[];
-  areasForImprovement: string[];
-  recommendations: string[];
-  performanceScore: number;
+async function fetchMe(): Promise<MeBundle> {
+  const res = await fetch("/api/coaching/me");
+  if (!res.ok) throw new Error("Failed to load coaching dashboard");
+  return (await res.json()).data;
 }
 
-interface TeamCoaching {
-  teamMetrics: {
-    totalLeads: number;
-    avgConversionRate: number;
-    topPerformer: string;
-    weeklyTrend: "up" | "down" | "stable";
-  };
-  teamRecommendations: string[];
-  members: TeamMember[];
-}
+const PATH_LABEL: Record<string, string> = {
+  production_supervisor: "Production Supervisor",
+  sales_executive: "Sales Executive",
+  factory_coordinator: "Factory Coordinator",
+  site_engineer: "Site Engineer",
+  accounts_assistant: "Accounts Assistant",
+  delivery_coordinator: "Delivery Coordinator",
+};
 
-// API response types
-interface ApiTeamMetrics {
-  leadsHandled: number;
-  conversionRate: number;
-  averageResponseTime: number;
-  followUpCompletionRate: number;
-  notesPerLead: number;
-  activeLeads: number;
-}
-
-interface ApiTopPerformer {
-  staffId: string;
-  staffName: string;
-  score: number;
-}
-
-interface ApiImprovementArea {
-  area: string;
-  description: string;
-}
-
-interface ApiTeamCoachingResponse {
-  teamMetrics: ApiTeamMetrics;
-  topPerformers: ApiTopPerformer[];
-  improvementAreas: ApiImprovementArea[];
-}
-
-interface ApiRecommendation {
-  priority: string;
-  area: string;
-  action: string;
-  expectedImpact: string;
-}
-
-interface ApiIndividualCoaching {
-  staffId: string;
-  staffName: string;
-  period: string;
-  metrics: ApiTeamMetrics;
-  insights: Array<{
-    type: "strength" | "improvement" | "alert";
-    title: string;
-    description: string;
-    metric: string;
-    value: number;
-  }>;
-  recommendations: ApiRecommendation[];
-  overallScore: number;
-}
-
-interface CoachingCallInsight {
-  id: string;
-  insight_type: "correction" | "missed_opportunity" | "kudos";
-  quote_text?: string | null;
-  suggestion?: string | null;
-  created_at: string;
-  lead?: {
-    id: string;
-    name: string;
-    contact?: string | null;
-  } | null;
-}
-
-export default function CoachingPage() {
-  return (
-    <Suspense fallback={<CoachingLoadingFallback />}>
-      <CoachingContent />
-    </Suspense>
-  );
-}
-
-function CoachingLoadingFallback() {
-  return (
-    <div className="flex items-center justify-center min-h-96">
-      <div className="text-center">
-        <LoadingSpinner className="h-8 w-8 mx-auto text-blue-600" />
-        <p className="mt-4 text-slate-500 dark:text-slate-400">
-          Loading coaching insights...
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function CoachingContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [coaching, setCoaching] = useState<TeamCoaching | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [callInsights, setCallInsights] = useState<CoachingCallInsight[]>([]);
-  const [isLoadingInsights, setIsLoadingInsights] = useState(false);
-  const [showTutorial, setShowTutorial] = useState(false);
-
-  // Read selected member from URL search params for persistence
-  const selectedMember = searchParams.get("member");
-  const activeView =
-    searchParams.get("view") === "individual" ? "individual" : "team";
-
-  // Update URL when member is selected
-  const setSelectedMember = useCallback(
-    (memberId: string | null) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (memberId) {
-        params.set("member", memberId);
-        params.set("view", "individual");
-      } else {
-        params.delete("member");
-      }
-      router.push(`/coaching?${params.toString()}`, { scroll: false });
-    },
-    [searchParams, router],
-  );
-
-  // Update URL when view changes
-  const setActiveView = useCallback(
-    (view: "team" | "individual") => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (view === "individual") {
-        params.set("view", "individual");
-      } else {
-        params.delete("view");
-        params.delete("member");
-      }
-      router.push(`/coaching?${params.toString()}`, { scroll: false });
-    },
-    [searchParams, router],
-  );
-
-  const fetchCoaching = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch("/api/coaching");
-      const result = await response.json();
-
-      // API returns {data: {...}, error: null} format
-      if (result.data && !result.error) {
-        const apiData = result.data as ApiTeamCoachingResponse;
-
-        // Fetch individual coaching for each top performer to get full member details
-        const memberPromises = apiData.topPerformers.map(async (performer) => {
-          try {
-            const memberResponse = await fetch(
-              `/api/coaching/${performer.staffId}`,
-            );
-            const memberResult = await memberResponse.json();
-
-            if (memberResult.data && !memberResult.error) {
-              const memberData = memberResult.data as ApiIndividualCoaching;
-              return {
-                id: memberData.staffId,
-                name: memberData.staffName,
-                role: "Sales Staff",
-                metrics: {
-                  leadsHandled: memberData.metrics.leadsHandled,
-                  conversionRate: memberData.metrics.conversionRate,
-                  avgResponseTime: `${memberData.metrics.averageResponseTime}h`,
-                  activeLeads: memberData.metrics.activeLeads,
-                },
-                strengths: memberData.insights
-                  .filter((i) => i.type === "strength")
-                  .map((i) => i.description),
-                areasForImprovement: memberData.insights
-                  .filter((i) => i.type === "improvement" || i.type === "alert")
-                  .map((i) => i.description),
-                recommendations: (memberData.recommendations || []).map((r) =>
-                  typeof r === "string" ? r : r.action,
-                ),
-                performanceScore: Math.round(memberData.overallScore * 100),
-              } as TeamMember;
-            }
-
-            // Fallback if individual fetch fails
-            return {
-              id: performer.staffId,
-              name: performer.staffName,
-              role: "Sales Staff",
-              metrics: {
-                leadsHandled: 0,
-                conversionRate: 0,
-                avgResponseTime: "N/A",
-                activeLeads: 0,
-              },
-              strengths: [],
-              areasForImprovement: [],
-              recommendations: [],
-              performanceScore: Math.round(performer.score * 100), // Convert 0-1 score to 0-100
-            } as TeamMember;
-          } catch {
-            return {
-              id: performer.staffId,
-              name: performer.staffName,
-              role: "Sales Staff",
-              metrics: {
-                leadsHandled: 0,
-                conversionRate: 0,
-                avgResponseTime: "N/A",
-                activeLeads: 0,
-              },
-              strengths: [],
-              areasForImprovement: [],
-              recommendations: [],
-              performanceScore: Math.round(performer.score * 100),
-            } as TeamMember;
-          }
-        });
-
-        const members = await Promise.all(memberPromises);
-
-        // Transform API response to expected interface
-        const coaching: TeamCoaching = {
-          teamMetrics: {
-            totalLeads: apiData.teamMetrics?.leadsHandled || 0,
-            avgConversionRate: apiData.teamMetrics?.conversionRate || 0,
-            topPerformer: apiData.topPerformers?.[0]?.staffName || "N/A",
-            weeklyTrend: "stable", // API doesn't provide trend, default to stable
-          },
-          teamRecommendations:
-            apiData.improvementAreas?.map(
-              (area) => `${area.area}: ${area.description}`,
-            ) || [],
-          members,
-        };
-
-        setCoaching(coaching);
-      }
-    } catch (err) {
-      console.error("Failed to fetch coaching data:", err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchCoaching();
-  }, [fetchCoaching]);
-
-  useEffect(() => {
-    if (activeView !== "individual" || !selectedMember) {
-      setCallInsights([]);
-      return;
-    }
-
-    const fetchInsights = async () => {
-      setIsLoadingInsights(true);
-      try {
-        const response = await fetch(
-          `/api/coaching/insights?staff_id=${selectedMember}`,
-        );
-        const result = await response.json();
-        if (response.ok && result.data) {
-          setCallInsights(result.data as CoachingCallInsight[]);
-        }
-      } catch {
-        setCallInsights([]);
-      } finally {
-        setIsLoadingInsights(false);
-      }
-    };
-
-    fetchInsights();
-  }, [activeView, selectedMember]);
-
-  const selectedMemberData = coaching?.members.find(
-    (m) => m.id === selectedMember,
-  );
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-96">
-        <div className="text-center">
-          <LoadingSpinner className="h-8 w-8 mx-auto text-blue-600" />
-          <p className="mt-4 text-slate-500 dark:text-slate-400">
-            Loading coaching insights...
-          </p>
-        </div>
-      </div>
-    );
+const planHref = (item: CoachTodayPlanItem): string => {
+  switch (item.kind) {
+    case "lesson":
+      return `/coaching/learn/${item.refId}`;
+    case "quiz":
+      return `/coaching/quiz/${item.refId}`;
+    case "assignment":
+      return `/coaching/assignments`;
+    default:
+      return `/coaching/targets`;
   }
+};
+
+const PLAN_ICON: Record<string, string> = {
+  lesson: "📘",
+  quiz: "📝",
+  assignment: "✍️",
+  target: "🎯",
+};
+
+function ScoreCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card className="p-4">
+      <div className="text-2xl font-bold text-slate-900 dark:text-white">{value}</div>
+      <div className="text-xs text-slate-500">{label}</div>
+    </Card>
+  );
+}
+
+const NAV = [
+  { href: "/coaching/learn", icon: "📚", title: "Learn", desc: "Modules & lessons" },
+  { href: "/coaching/assignments", icon: "✍️", title: "Assignments", desc: "Practice & submit" },
+  { href: "/coaching/targets", icon: "🎯", title: "Targets", desc: "Daily & weekly goals" },
+  { href: "/coaching/review", icon: "📈", title: "Weekly Review", desc: "Your progress" },
+  { href: "/coaching/performance", icon: "🤖", title: "AI Feedback", desc: "Lead-handling coach" },
+];
+
+export default function CoachingHubPage() {
+  const { data, isLoading } = useQuery({ queryKey: ["coaching", "me"], queryFn: fetchMe });
+
+  if (isLoading || !data) {
+    return <Card className="p-8 text-center text-sm text-slate-400">Loading your coaching plan…</Card>;
+  }
+
+  const { progress, todayPlan, isAdmin, coachUser } = data;
 
   return (
     <div className="space-y-6">
-      {/* Page Header */}
-      <div className="flex items-center justify-between">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
-            Coaching Dashboard
-          </h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            AI-powered performance insights and recommendations
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">AI Sales Coach</h1>
+          <p className="text-sm text-slate-500">
+            {PATH_LABEL[coachUser.training_path] ?? coachUser.training_path} · Train, practice, improve every day
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <HelpButton section="coaching" variant="icon" />
-          <button
-            onClick={() => setShowTutorial(true)}
-            className="px-4 py-2 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
-          >
-            <HelpCircleIcon className="h-4 w-4" />
-            Tutorial
-          </button>
-          <button
-            onClick={fetchCoaching}
-            className="px-4 py-2 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
-          >
-            <RefreshIcon className="h-4 w-4" />
-            Refresh
-          </button>
-        </div>
-      </div>
-
-      {/* Tutorial Modal */}
-      <TutorialModal
-        isOpen={showTutorial}
-        onClose={() => setShowTutorial(false)}
-      />
-
-      {/* View Toggle */}
-      <div className="flex gap-2">
-        <button
-          onClick={() => setActiveView("team")}
-          className={cn(
-            "px-4 py-2 rounded-lg font-medium text-sm",
-            activeView === "team"
-              ? "bg-blue-600 text-white"
-              : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600",
-          )}
-        >
-          Team Overview
-        </button>
-        <button
-          onClick={() => setActiveView("individual")}
-          className={cn(
-            "px-4 py-2 rounded-lg font-medium text-sm",
-            activeView === "individual"
-              ? "bg-blue-600 text-white"
-              : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600",
-          )}
-        >
-          Individual Coaching
-        </button>
-      </div>
-
-      {/* Team Overview */}
-      {activeView === "team" && coaching && (
-        <div className="space-y-6">
-          {/* Team Metrics */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <MetricCard
-              label="Total Leads"
-              value={coaching.teamMetrics.totalLeads.toString()}
-              icon={<UsersIcon className="h-5 w-5" />}
-            />
-            <MetricCard
-              label="Avg Conversion Rate"
-              value={`${coaching.teamMetrics.avgConversionRate}%`}
-              icon={<ChartIcon className="h-5 w-5" />}
-            />
-            <MetricCard
-              label="Top Performer"
-              value={coaching.teamMetrics.topPerformer}
-              icon={<TrophyIcon className="h-5 w-5" />}
-            />
-            <MetricCard
-              label="Weekly Trend"
-              value={coaching.teamMetrics.weeklyTrend}
-              icon={
-                <TrendIcon
-                  direction={coaching.teamMetrics.weeklyTrend}
-                  className="h-5 w-5"
-                />
-              }
-              trend={coaching.teamMetrics.weeklyTrend}
-            />
-          </div>
-
-          {/* Team Recommendations */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
-              Team Recommendations
-            </h3>
-            <ul className="space-y-3">
-              {coaching.teamRecommendations.map((rec, idx) => (
-                <li key={idx} className="flex items-start gap-3">
-                  <LightbulbIcon className="h-5 w-5 text-yellow-500 mt-0.5 shrink-0" />
-                  <span className="text-slate-600 dark:text-slate-300">
-                    {rec}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Team Members Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {coaching.members.map((member) => (
-              <div
-                key={member.id}
-                className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 cursor-pointer hover:border-blue-500 transition-colors"
-                onClick={() => {
-                  setSelectedMember(member.id);
-                  setActiveView("individual");
-                }}
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h4 className="font-semibold text-slate-900 dark:text-white">
-                      {member.name}
-                    </h4>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
-                      {member.role}
-                    </p>
-                  </div>
-                  <PerformanceScore score={member.performanceScore} />
-                </div>
-                <div className="grid grid-cols-2 gap-4 text-sm">
-                  <div>
-                    <span className="text-slate-500 dark:text-slate-400">
-                      Leads
-                    </span>
-                    <p className="font-medium text-slate-900 dark:text-white">
-                      {member.metrics.leadsHandled}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-slate-500 dark:text-slate-400">
-                      Conversion
-                    </span>
-                    <p className="font-medium text-slate-900 dark:text-white">
-                      {member.metrics.conversionRate}%
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Individual Coaching */}
-      {activeView === "individual" && (
-        <div className="space-y-6">
-          {/* Member Selector */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-              Select Team Member
-            </label>
-            <select
-              value={selectedMember ?? ""}
-              onChange={(e) => setSelectedMember(e.target.value || null)}
-              className="w-full max-w-xs rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 py-2 text-slate-900 dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
+          {isAdmin && (
+            <Link
+              href="/coaching/admin"
+              className="rounded-lg bg-slate-900 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-700 dark:bg-white dark:text-slate-900"
             >
-              <option value="">Select a member...</option>
-              {coaching?.members.map((member) => (
-                <option key={member.id} value={member.id}>
-                  {member.name} - {member.role}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {selectedMemberData ? (
-            <>
-              {/* Member Performance Overview */}
-              <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-                <div className="flex items-center justify-between mb-6">
-                  <div>
-                    <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
-                      {selectedMemberData.name}
-                    </h3>
-                    <p className="text-slate-500 dark:text-slate-400">
-                      {selectedMemberData.role}
-                    </p>
-                  </div>
-                  <PerformanceScore
-                    score={selectedMemberData.performanceScore}
-                    size="lg"
-                  />
-                </div>
-
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-                  <div>
-                    <span className="text-sm text-slate-500 dark:text-slate-400">
-                      Leads Handled
-                    </span>
-                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
-                      {selectedMemberData.metrics.leadsHandled}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-sm text-slate-500 dark:text-slate-400">
-                      Conversion Rate
-                    </span>
-                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
-                      {selectedMemberData.metrics.conversionRate}%
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-sm text-slate-500 dark:text-slate-400">
-                      Avg Response Time
-                    </span>
-                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
-                      {selectedMemberData.metrics.avgResponseTime}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-sm text-slate-500 dark:text-slate-400">
-                      Active Leads
-                    </span>
-                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
-                      {selectedMemberData.metrics.activeLeads}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Strengths and Improvements */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-                  <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
-                    <CheckCircleIcon className="h-5 w-5 text-green-500" />
-                    Strengths
-                  </h4>
-                  <ul className="space-y-2">
-                    {selectedMemberData.strengths.map((strength, idx) => (
-                      <li
-                        key={idx}
-                        className="text-slate-600 dark:text-slate-300 flex items-start gap-2"
-                      >
-                        <span className="text-green-500 mt-1">+</span>
-                        {strength}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-                  <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
-                    <ArrowUpIcon className="h-5 w-5 text-orange-500" />
-                    Areas for Improvement
-                  </h4>
-                  <ul className="space-y-2">
-                    {selectedMemberData.areasForImprovement.map((area, idx) => (
-                      <li
-                        key={idx}
-                        className="text-slate-600 dark:text-slate-300 flex items-start gap-2"
-                      >
-                        <span className="text-orange-500 mt-1">*</span>
-                        {area}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-
-              {/* AI Recommendations */}
-              <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg border border-blue-200 dark:border-blue-800 p-6">
-                <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
-                  <SparklesIcon className="h-5 w-5 text-blue-500" />
-                  AI Coaching Recommendations
-                </h4>
-                <ul className="space-y-3">
-                  {selectedMemberData.recommendations.map((rec, idx) => (
-                    <li key={idx} className="flex items-start gap-3">
-                      <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                        {idx + 1}
-                      </span>
-                      <span className="text-slate-700 dark:text-slate-300">
-                        {rec}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              {/* Call Coaching Insights */}
-              <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <h4 className="font-semibold text-slate-900 dark:text-white">
-                    Call Coaching Insights
-                  </h4>
-                  {isLoadingInsights && (
-                    <span className="text-xs text-slate-500">Loading...</span>
-                  )}
-                </div>
-                {callInsights.length === 0 ? (
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    No coaching insights from recent calls yet.
-                  </p>
-                ) : (
-                  <ul className="space-y-3">
-                    {callInsights.map((insight) => (
-                      <li
-                        key={insight.id}
-                        className="rounded-lg border border-slate-200 dark:border-slate-700 p-3"
-                      >
-                        <div className="flex items-center justify-between">
-                          <span className="text-xs uppercase text-slate-500 dark:text-slate-400">
-                            {insight.insight_type.replace("_", " ")}
-                          </span>
-                          <span className="text-xs text-slate-400">
-                            {new Date(insight.created_at).toLocaleDateString()}
-                          </span>
-                        </div>
-                        {insight.lead?.name && (
-                          <p className="text-xs text-slate-500 mt-1">
-                            Lead: {insight.lead.name}
-                          </p>
-                        )}
-                        {insight.quote_text && (
-                          <p className="text-sm text-slate-700 dark:text-slate-300 mt-2">
-                            “{insight.quote_text}”
-                          </p>
-                        )}
-                        {insight.suggestion && (
-                          <p className="text-sm text-slate-600 dark:text-slate-400 mt-2">
-                            Suggestion: {insight.suggestion}
-                          </p>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            </>
-          ) : (
-            <div className="text-center py-12">
-              <UsersIcon className="mx-auto h-12 w-12 text-slate-400" />
-              <h3 className="mt-4 text-lg font-medium text-slate-900 dark:text-white">
-                Select a team member
-              </h3>
-              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                Choose a team member to view their coaching insights and
-                recommendations.
-              </p>
-            </div>
+              ⚙️ Admin
+            </Link>
           )}
+          <HelpButton section="coaching" variant="icon" />
         </div>
-      )}
-    </div>
-  );
-}
-
-// Metric Card Component
-function MetricCard({
-  label,
-  value,
-  icon,
-  trend,
-}: {
-  label: string;
-  value: string;
-  icon: React.ReactNode;
-  trend?: "up" | "down" | "stable";
-}) {
-  return (
-    <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
-      <div className="flex items-center justify-between">
-        <span className="text-slate-500 dark:text-slate-400 text-sm">
-          {label}
-        </span>
-        <span className="text-slate-400">{icon}</span>
       </div>
-      <p
-        className={cn(
-          "mt-2 text-2xl font-bold",
-          trend === "up"
-            ? "text-green-600 dark:text-green-400"
-            : trend === "down"
-              ? "text-red-600 dark:text-red-400"
-              : "text-slate-900 dark:text-white",
+
+      {/* Progress score */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <ScoreCard label="Training complete" value={`${progress.trainingCompletionPct}%`} />
+        <ScoreCard label="Quiz average" value={`${progress.quizAveragePct}%`} />
+        <ScoreCard
+          label="Today's targets"
+          value={`${progress.todayTargetsCompleted}/${progress.todayTargetsTotal}`}
+        />
+        <ScoreCard label="This week" value={`${progress.weekTargetCompletionPct}%`} />
+      </div>
+
+      {/* Today's plan */}
+      <Card className="p-5">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Today's Coaching Plan
+        </h2>
+        {todayPlan.length === 0 ? (
+          <p className="text-sm text-slate-400">
+            All caught up 🎉 — explore the learning library to keep improving.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {todayPlan.map((item, i) => (
+              <li key={`${item.kind}-${item.refId}-${i}`}>
+                <Link
+                  href={planHref(item)}
+                  className="flex items-center gap-3 rounded-lg border border-slate-200 px-3 py-2.5 text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                >
+                  <span>{PLAN_ICON[item.kind]}</span>
+                  <span className={item.done ? "text-slate-400 line-through" : "text-slate-800 dark:text-slate-200"}>
+                    {item.title}
+                  </span>
+                  <span className="ml-auto text-xs text-slate-400">{item.done ? "Done" : "Start →"}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         )}
-      >
-        {value}
-      </p>
+      </Card>
+
+      {/* Navigation */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        {NAV.map((n) => (
+          <Link key={n.href} href={n.href}>
+            <Card className="p-4 transition hover:shadow-md">
+              <div className="text-xl">{n.icon}</div>
+              <div className="mt-1 font-semibold text-slate-900 dark:text-white">{n.title}</div>
+              <div className="text-xs text-slate-500">{n.desc}</div>
+            </Card>
+          </Link>
+        ))}
+      </div>
     </div>
-  );
-}
-
-// Performance Score Component
-function PerformanceScore({
-  score,
-  size = "sm",
-}: {
-  score: number;
-  size?: "sm" | "lg";
-}) {
-  const getColor = (s: number) => {
-    if (s >= 80)
-      return "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30";
-    if (s >= 60)
-      return "text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30";
-    return "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30";
-  };
-
-  return (
-    <div
-      className={cn(
-        "rounded-full flex items-center justify-center font-bold",
-        getColor(score),
-        size === "lg" ? "w-16 h-16 text-xl" : "w-10 h-10 text-sm",
-      )}
-    >
-      {score}
-    </div>
-  );
-}
-
-// Icon Components
-function UsersIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
-      />
-    </svg>
-  );
-}
-
-function ChartIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
-      />
-    </svg>
-  );
-}
-
-function TrophyIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0"
-      />
-    </svg>
-  );
-}
-
-function TrendIcon({
-  direction,
-  className,
-}: {
-  direction: "up" | "down" | "stable";
-  className?: string;
-}) {
-  if (direction === "up") {
-    return (
-      <svg
-        className={cn(className, "text-green-500")}
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={1.5}
-        stroke="currentColor"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941"
-        />
-      </svg>
-    );
-  }
-  if (direction === "down") {
-    return (
-      <svg
-        className={cn(className, "text-red-500")}
-        fill="none"
-        viewBox="0 0 24 24"
-        strokeWidth={1.5}
-        stroke="currentColor"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M2.25 6L9 12.75l4.286-4.286a11.948 11.948 0 014.306 6.43l.776 2.898m0 0l3.182-5.511m-3.182 5.51l-5.511-3.181"
-        />
-      </svg>
-    );
-  }
-  return (
-    <svg
-      className={cn(className, "text-slate-400")}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 12h-15" />
-    </svg>
-  );
-}
-
-function RefreshIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
-      />
-    </svg>
-  );
-}
-
-function LightbulbIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
-      />
-    </svg>
-  );
-}
-
-function CheckCircleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-      />
-    </svg>
-  );
-}
-
-function ArrowUpIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18"
-      />
-    </svg>
-  );
-}
-
-function SparklesIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
-      />
-    </svg>
-  );
-}
-
-function LoadingSpinner({ className }: { className?: string }) {
-  return (
-    <svg className={cn("animate-spin", className)} viewBox="0 0 24 24">
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-        fill="none"
-      />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      />
-    </svg>
-  );
-}
-
-function HelpCircleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
-      />
-    </svg>
-  );
-}
-
-function BookOpenIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
-      />
-    </svg>
-  );
-}
-
-function XIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M6 18L18 6M6 6l12 12"
-      />
-    </svg>
-  );
-}
-
-function MapIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z"
-      />
-    </svg>
-  );
-}
-
-function QuestionIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"
-      />
-    </svg>
   );
 }

--- a/apps/web/app/(dashboard)/coaching/performance/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/performance/page.tsx
@@ -1,0 +1,1322 @@
+"use client";
+
+import { useState, useEffect, useCallback, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { cn } from "@maiyuri/ui";
+import { HelpButton } from "@/components/help";
+
+// Tutorial Modal Component
+function TutorialModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative min-h-screen flex items-center justify-center p-4">
+        <div className="relative bg-white dark:bg-slate-800 rounded-xl shadow-2xl max-w-3xl w-full max-h-[85vh] overflow-hidden">
+          {/* Header */}
+          <div className="sticky top-0 bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
+                <BookOpenIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <h2 className="text-xl font-bold text-slate-900 dark:text-white">
+                Coaching Tutorial
+              </h2>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
+            >
+              <XIcon className="h-5 w-5 text-slate-500" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="overflow-y-auto max-h-[calc(85vh-80px)] px-6 py-6 space-y-8">
+            {/* What is Coaching */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <SparklesIcon className="h-5 w-5 text-purple-500" />
+                What is the Coaching Module?
+              </h3>
+              <p className="text-slate-600 dark:text-slate-300 mb-4">
+                The Coaching Module uses AI to analyze your lead management
+                performance and provide personalized recommendations to help you
+                improve.
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  "Leads handled",
+                  "Conversion rate",
+                  "Response time",
+                  "Follow-up completion",
+                ].map((item) => (
+                  <div
+                    key={item}
+                    className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
+                  >
+                    <CheckCircleIcon className="h-4 w-4 text-green-500" />
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* How to Access */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <MapIcon className="h-5 w-5 text-blue-500" />
+                How to Access
+              </h3>
+              <ol className="space-y-3">
+                {[
+                  "Log in to your account",
+                  'Click "Coaching" in the sidebar menu',
+                  "View Team Overview or Individual Coaching",
+                ].map((step, idx) => (
+                  <li key={idx} className="flex items-start gap-3">
+                    <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                      {idx + 1}
+                    </span>
+                    <span className="text-slate-600 dark:text-slate-300">
+                      {step}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </section>
+
+            {/* Understanding Team View */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <UsersIcon className="h-5 w-5 text-indigo-500" />
+                Team Overview
+              </h3>
+              <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-4">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-slate-500 dark:text-slate-400">
+                      <th className="pb-2">Metric</th>
+                      <th className="pb-2">What It Means</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-slate-600 dark:text-slate-300">
+                    <tr>
+                      <td className="py-1 font-medium">Total Leads</td>
+                      <td>Leads managed by the team</td>
+                    </tr>
+                    <tr>
+                      <td className="py-1 font-medium">Conversion Rate</td>
+                      <td>Leads converted to customers</td>
+                    </tr>
+                    <tr>
+                      <td className="py-1 font-medium">Top Performer</td>
+                      <td>Best performing team member</td>
+                    </tr>
+                    <tr>
+                      <td className="py-1 font-medium">Weekly Trend</td>
+                      <td>Performance direction</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            {/* Performance Score */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <ChartIcon className="h-5 w-5 text-green-500" />
+                Performance Score
+              </h3>
+              <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                  <span className="w-20 h-8 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center text-sm font-bold">
+                    80-100
+                  </span>
+                  <span className="text-slate-600 dark:text-slate-300">
+                    Excellent - Keep up the great work!
+                  </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="w-20 h-8 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-600 dark:text-yellow-400 rounded-full flex items-center justify-center text-sm font-bold">
+                    60-79
+                  </span>
+                  <span className="text-slate-600 dark:text-slate-300">
+                    Good - Some areas for improvement
+                  </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="w-20 h-8 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center text-sm font-bold">
+                    &lt;60
+                  </span>
+                  <span className="text-slate-600 dark:text-slate-300">
+                    Needs attention - Focus on recommendations
+                  </span>
+                </div>
+              </div>
+            </section>
+
+            {/* AI Recommendations */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <LightbulbIcon className="h-5 w-5 text-yellow-500" />
+                AI Recommendations
+              </h3>
+              <p className="text-slate-600 dark:text-slate-300 mb-3">
+                Each recommendation includes:
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Priority
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    High, Medium, or Low
+                  </p>
+                </div>
+                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Area
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Which aspect to improve
+                  </p>
+                </div>
+                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Action
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Steps you can take
+                  </p>
+                </div>
+                <div className="bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3">
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Impact
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Expected improvement
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            {/* Tips for Improvement */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <ArrowUpIcon className="h-5 w-5 text-orange-500" />
+                Tips to Improve Quickly
+              </h3>
+              <ul className="space-y-2">
+                {[
+                  "Respond to leads within 2 hours",
+                  "Complete all scheduled follow-ups",
+                  "Keep detailed notes on every interaction",
+                  "Prioritize hot leads first",
+                  "Review coaching weekly on Mondays",
+                ].map((tip, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-start gap-2 text-slate-600 dark:text-slate-300"
+                  >
+                    <span className="text-green-500 mt-0.5">+</span>
+                    {tip}
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            {/* FAQ */}
+            <section>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-3 flex items-center gap-2">
+                <QuestionIcon className="h-5 w-5 text-slate-500" />
+                Frequently Asked Questions
+              </h3>
+              <div className="space-y-4">
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    How often is data updated?
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Data is analyzed in real-time each time you view the page.
+                  </p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Why is my score low?
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Check recommendations to see which specific areas need
+                    improvement.
+                  </p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-white text-sm">
+                    Can my manager see my data?
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Yes, managers can view team coaching data.
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  metrics: {
+    leadsHandled: number;
+    conversionRate: number;
+    avgResponseTime: string;
+    activeLeads: number;
+  };
+  strengths: string[];
+  areasForImprovement: string[];
+  recommendations: string[];
+  performanceScore: number;
+}
+
+interface TeamCoaching {
+  teamMetrics: {
+    totalLeads: number;
+    avgConversionRate: number;
+    topPerformer: string;
+    weeklyTrend: "up" | "down" | "stable";
+  };
+  teamRecommendations: string[];
+  members: TeamMember[];
+}
+
+// API response types
+interface ApiTeamMetrics {
+  leadsHandled: number;
+  conversionRate: number;
+  averageResponseTime: number;
+  followUpCompletionRate: number;
+  notesPerLead: number;
+  activeLeads: number;
+}
+
+interface ApiTopPerformer {
+  staffId: string;
+  staffName: string;
+  score: number;
+}
+
+interface ApiImprovementArea {
+  area: string;
+  description: string;
+}
+
+interface ApiTeamCoachingResponse {
+  teamMetrics: ApiTeamMetrics;
+  topPerformers: ApiTopPerformer[];
+  improvementAreas: ApiImprovementArea[];
+}
+
+interface ApiRecommendation {
+  priority: string;
+  area: string;
+  action: string;
+  expectedImpact: string;
+}
+
+interface ApiIndividualCoaching {
+  staffId: string;
+  staffName: string;
+  period: string;
+  metrics: ApiTeamMetrics;
+  insights: Array<{
+    type: "strength" | "improvement" | "alert";
+    title: string;
+    description: string;
+    metric: string;
+    value: number;
+  }>;
+  recommendations: ApiRecommendation[];
+  overallScore: number;
+}
+
+interface CoachingCallInsight {
+  id: string;
+  insight_type: "correction" | "missed_opportunity" | "kudos";
+  quote_text?: string | null;
+  suggestion?: string | null;
+  created_at: string;
+  lead?: {
+    id: string;
+    name: string;
+    contact?: string | null;
+  } | null;
+}
+
+export default function CoachingPage() {
+  return (
+    <Suspense fallback={<CoachingLoadingFallback />}>
+      <CoachingContent />
+    </Suspense>
+  );
+}
+
+function CoachingLoadingFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-96">
+      <div className="text-center">
+        <LoadingSpinner className="h-8 w-8 mx-auto text-blue-600" />
+        <p className="mt-4 text-slate-500 dark:text-slate-400">
+          Loading coaching insights...
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CoachingContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [coaching, setCoaching] = useState<TeamCoaching | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [callInsights, setCallInsights] = useState<CoachingCallInsight[]>([]);
+  const [isLoadingInsights, setIsLoadingInsights] = useState(false);
+  const [showTutorial, setShowTutorial] = useState(false);
+
+  // Read selected member from URL search params for persistence
+  const selectedMember = searchParams.get("member");
+  const activeView =
+    searchParams.get("view") === "individual" ? "individual" : "team";
+
+  // Update URL when member is selected
+  const setSelectedMember = useCallback(
+    (memberId: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (memberId) {
+        params.set("member", memberId);
+        params.set("view", "individual");
+      } else {
+        params.delete("member");
+      }
+      router.push(`/coaching/performance?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, router],
+  );
+
+  // Update URL when view changes
+  const setActiveView = useCallback(
+    (view: "team" | "individual") => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (view === "individual") {
+        params.set("view", "individual");
+      } else {
+        params.delete("view");
+        params.delete("member");
+      }
+      router.push(`/coaching/performance?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, router],
+  );
+
+  const fetchCoaching = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/coaching");
+      const result = await response.json();
+
+      // API returns {data: {...}, error: null} format
+      if (result.data && !result.error) {
+        const apiData = result.data as ApiTeamCoachingResponse;
+
+        // Fetch individual coaching for each top performer to get full member details
+        const memberPromises = apiData.topPerformers.map(async (performer) => {
+          try {
+            const memberResponse = await fetch(
+              `/api/coaching/${performer.staffId}`,
+            );
+            const memberResult = await memberResponse.json();
+
+            if (memberResult.data && !memberResult.error) {
+              const memberData = memberResult.data as ApiIndividualCoaching;
+              return {
+                id: memberData.staffId,
+                name: memberData.staffName,
+                role: "Sales Staff",
+                metrics: {
+                  leadsHandled: memberData.metrics.leadsHandled,
+                  conversionRate: memberData.metrics.conversionRate,
+                  avgResponseTime: `${memberData.metrics.averageResponseTime}h`,
+                  activeLeads: memberData.metrics.activeLeads,
+                },
+                strengths: memberData.insights
+                  .filter((i) => i.type === "strength")
+                  .map((i) => i.description),
+                areasForImprovement: memberData.insights
+                  .filter((i) => i.type === "improvement" || i.type === "alert")
+                  .map((i) => i.description),
+                recommendations: (memberData.recommendations || []).map((r) =>
+                  typeof r === "string" ? r : r.action,
+                ),
+                performanceScore: Math.round(memberData.overallScore * 100),
+              } as TeamMember;
+            }
+
+            // Fallback if individual fetch fails
+            return {
+              id: performer.staffId,
+              name: performer.staffName,
+              role: "Sales Staff",
+              metrics: {
+                leadsHandled: 0,
+                conversionRate: 0,
+                avgResponseTime: "N/A",
+                activeLeads: 0,
+              },
+              strengths: [],
+              areasForImprovement: [],
+              recommendations: [],
+              performanceScore: Math.round(performer.score * 100), // Convert 0-1 score to 0-100
+            } as TeamMember;
+          } catch {
+            return {
+              id: performer.staffId,
+              name: performer.staffName,
+              role: "Sales Staff",
+              metrics: {
+                leadsHandled: 0,
+                conversionRate: 0,
+                avgResponseTime: "N/A",
+                activeLeads: 0,
+              },
+              strengths: [],
+              areasForImprovement: [],
+              recommendations: [],
+              performanceScore: Math.round(performer.score * 100),
+            } as TeamMember;
+          }
+        });
+
+        const members = await Promise.all(memberPromises);
+
+        // Transform API response to expected interface
+        const coaching: TeamCoaching = {
+          teamMetrics: {
+            totalLeads: apiData.teamMetrics?.leadsHandled || 0,
+            avgConversionRate: apiData.teamMetrics?.conversionRate || 0,
+            topPerformer: apiData.topPerformers?.[0]?.staffName || "N/A",
+            weeklyTrend: "stable", // API doesn't provide trend, default to stable
+          },
+          teamRecommendations:
+            apiData.improvementAreas?.map(
+              (area) => `${area.area}: ${area.description}`,
+            ) || [],
+          members,
+        };
+
+        setCoaching(coaching);
+      }
+    } catch (err) {
+      console.error("Failed to fetch coaching data:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCoaching();
+  }, [fetchCoaching]);
+
+  useEffect(() => {
+    if (activeView !== "individual" || !selectedMember) {
+      setCallInsights([]);
+      return;
+    }
+
+    const fetchInsights = async () => {
+      setIsLoadingInsights(true);
+      try {
+        const response = await fetch(
+          `/api/coaching/insights?staff_id=${selectedMember}`,
+        );
+        const result = await response.json();
+        if (response.ok && result.data) {
+          setCallInsights(result.data as CoachingCallInsight[]);
+        }
+      } catch {
+        setCallInsights([]);
+      } finally {
+        setIsLoadingInsights(false);
+      }
+    };
+
+    fetchInsights();
+  }, [activeView, selectedMember]);
+
+  const selectedMemberData = coaching?.members.find(
+    (m) => m.id === selectedMember,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-96">
+        <div className="text-center">
+          <LoadingSpinner className="h-8 w-8 mx-auto text-blue-600" />
+          <p className="mt-4 text-slate-500 dark:text-slate-400">
+            Loading coaching insights...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+            Coaching Dashboard
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            AI-powered performance insights and recommendations
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <HelpButton section="coaching" variant="icon" />
+          <button
+            onClick={() => setShowTutorial(true)}
+            className="px-4 py-2 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
+          >
+            <HelpCircleIcon className="h-4 w-4" />
+            Tutorial
+          </button>
+          <button
+            onClick={fetchCoaching}
+            className="px-4 py-2 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
+          >
+            <RefreshIcon className="h-4 w-4" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Tutorial Modal */}
+      <TutorialModal
+        isOpen={showTutorial}
+        onClose={() => setShowTutorial(false)}
+      />
+
+      {/* View Toggle */}
+      <div className="flex gap-2">
+        <button
+          onClick={() => setActiveView("team")}
+          className={cn(
+            "px-4 py-2 rounded-lg font-medium text-sm",
+            activeView === "team"
+              ? "bg-blue-600 text-white"
+              : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600",
+          )}
+        >
+          Team Overview
+        </button>
+        <button
+          onClick={() => setActiveView("individual")}
+          className={cn(
+            "px-4 py-2 rounded-lg font-medium text-sm",
+            activeView === "individual"
+              ? "bg-blue-600 text-white"
+              : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-300 dark:border-slate-600",
+          )}
+        >
+          Individual Coaching
+        </button>
+      </div>
+
+      {/* Team Overview */}
+      {activeView === "team" && coaching && (
+        <div className="space-y-6">
+          {/* Team Metrics */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <MetricCard
+              label="Total Leads"
+              value={coaching.teamMetrics.totalLeads.toString()}
+              icon={<UsersIcon className="h-5 w-5" />}
+            />
+            <MetricCard
+              label="Avg Conversion Rate"
+              value={`${coaching.teamMetrics.avgConversionRate}%`}
+              icon={<ChartIcon className="h-5 w-5" />}
+            />
+            <MetricCard
+              label="Top Performer"
+              value={coaching.teamMetrics.topPerformer}
+              icon={<TrophyIcon className="h-5 w-5" />}
+            />
+            <MetricCard
+              label="Weekly Trend"
+              value={coaching.teamMetrics.weeklyTrend}
+              icon={
+                <TrendIcon
+                  direction={coaching.teamMetrics.weeklyTrend}
+                  className="h-5 w-5"
+                />
+              }
+              trend={coaching.teamMetrics.weeklyTrend}
+            />
+          </div>
+
+          {/* Team Recommendations */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+              Team Recommendations
+            </h3>
+            <ul className="space-y-3">
+              {coaching.teamRecommendations.map((rec, idx) => (
+                <li key={idx} className="flex items-start gap-3">
+                  <LightbulbIcon className="h-5 w-5 text-yellow-500 mt-0.5 shrink-0" />
+                  <span className="text-slate-600 dark:text-slate-300">
+                    {rec}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Team Members Grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {coaching.members.map((member) => (
+              <div
+                key={member.id}
+                className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 cursor-pointer hover:border-blue-500 transition-colors"
+                onClick={() => {
+                  setSelectedMember(member.id);
+                  setActiveView("individual");
+                }}
+              >
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <h4 className="font-semibold text-slate-900 dark:text-white">
+                      {member.name}
+                    </h4>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                      {member.role}
+                    </p>
+                  </div>
+                  <PerformanceScore score={member.performanceScore} />
+                </div>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <span className="text-slate-500 dark:text-slate-400">
+                      Leads
+                    </span>
+                    <p className="font-medium text-slate-900 dark:text-white">
+                      {member.metrics.leadsHandled}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-slate-500 dark:text-slate-400">
+                      Conversion
+                    </span>
+                    <p className="font-medium text-slate-900 dark:text-white">
+                      {member.metrics.conversionRate}%
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Individual Coaching */}
+      {activeView === "individual" && (
+        <div className="space-y-6">
+          {/* Member Selector */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Select Team Member
+            </label>
+            <select
+              value={selectedMember ?? ""}
+              onChange={(e) => setSelectedMember(e.target.value || null)}
+              className="w-full max-w-xs rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-4 py-2 text-slate-900 dark:text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
+            >
+              <option value="">Select a member...</option>
+              {coaching?.members.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.name} - {member.role}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {selectedMemberData ? (
+            <>
+              {/* Member Performance Overview */}
+              <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+                <div className="flex items-center justify-between mb-6">
+                  <div>
+                    <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
+                      {selectedMemberData.name}
+                    </h3>
+                    <p className="text-slate-500 dark:text-slate-400">
+                      {selectedMemberData.role}
+                    </p>
+                  </div>
+                  <PerformanceScore
+                    score={selectedMemberData.performanceScore}
+                    size="lg"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+                  <div>
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      Leads Handled
+                    </span>
+                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                      {selectedMemberData.metrics.leadsHandled}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      Conversion Rate
+                    </span>
+                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                      {selectedMemberData.metrics.conversionRate}%
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      Avg Response Time
+                    </span>
+                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                      {selectedMemberData.metrics.avgResponseTime}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      Active Leads
+                    </span>
+                    <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                      {selectedMemberData.metrics.activeLeads}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Strengths and Improvements */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+                  <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                    <CheckCircleIcon className="h-5 w-5 text-green-500" />
+                    Strengths
+                  </h4>
+                  <ul className="space-y-2">
+                    {selectedMemberData.strengths.map((strength, idx) => (
+                      <li
+                        key={idx}
+                        className="text-slate-600 dark:text-slate-300 flex items-start gap-2"
+                      >
+                        <span className="text-green-500 mt-1">+</span>
+                        {strength}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+                  <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                    <ArrowUpIcon className="h-5 w-5 text-orange-500" />
+                    Areas for Improvement
+                  </h4>
+                  <ul className="space-y-2">
+                    {selectedMemberData.areasForImprovement.map((area, idx) => (
+                      <li
+                        key={idx}
+                        className="text-slate-600 dark:text-slate-300 flex items-start gap-2"
+                      >
+                        <span className="text-orange-500 mt-1">*</span>
+                        {area}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              {/* AI Recommendations */}
+              <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg border border-blue-200 dark:border-blue-800 p-6">
+                <h4 className="font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                  <SparklesIcon className="h-5 w-5 text-blue-500" />
+                  AI Coaching Recommendations
+                </h4>
+                <ul className="space-y-3">
+                  {selectedMemberData.recommendations.map((rec, idx) => (
+                    <li key={idx} className="flex items-start gap-3">
+                      <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                        {idx + 1}
+                      </span>
+                      <span className="text-slate-700 dark:text-slate-300">
+                        {rec}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Call Coaching Insights */}
+              <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h4 className="font-semibold text-slate-900 dark:text-white">
+                    Call Coaching Insights
+                  </h4>
+                  {isLoadingInsights && (
+                    <span className="text-xs text-slate-500">Loading...</span>
+                  )}
+                </div>
+                {callInsights.length === 0 ? (
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    No coaching insights from recent calls yet.
+                  </p>
+                ) : (
+                  <ul className="space-y-3">
+                    {callInsights.map((insight) => (
+                      <li
+                        key={insight.id}
+                        className="rounded-lg border border-slate-200 dark:border-slate-700 p-3"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs uppercase text-slate-500 dark:text-slate-400">
+                            {insight.insight_type.replace("_", " ")}
+                          </span>
+                          <span className="text-xs text-slate-400">
+                            {new Date(insight.created_at).toLocaleDateString()}
+                          </span>
+                        </div>
+                        {insight.lead?.name && (
+                          <p className="text-xs text-slate-500 mt-1">
+                            Lead: {insight.lead.name}
+                          </p>
+                        )}
+                        {insight.quote_text && (
+                          <p className="text-sm text-slate-700 dark:text-slate-300 mt-2">
+                            “{insight.quote_text}”
+                          </p>
+                        )}
+                        {insight.suggestion && (
+                          <p className="text-sm text-slate-600 dark:text-slate-400 mt-2">
+                            Suggestion: {insight.suggestion}
+                          </p>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="text-center py-12">
+              <UsersIcon className="mx-auto h-12 w-12 text-slate-400" />
+              <h3 className="mt-4 text-lg font-medium text-slate-900 dark:text-white">
+                Select a team member
+              </h3>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                Choose a team member to view their coaching insights and
+                recommendations.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Metric Card Component
+function MetricCard({
+  label,
+  value,
+  icon,
+  trend,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  trend?: "up" | "down" | "stable";
+}) {
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-slate-500 dark:text-slate-400 text-sm">
+          {label}
+        </span>
+        <span className="text-slate-400">{icon}</span>
+      </div>
+      <p
+        className={cn(
+          "mt-2 text-2xl font-bold",
+          trend === "up"
+            ? "text-green-600 dark:text-green-400"
+            : trend === "down"
+              ? "text-red-600 dark:text-red-400"
+              : "text-slate-900 dark:text-white",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+// Performance Score Component
+function PerformanceScore({
+  score,
+  size = "sm",
+}: {
+  score: number;
+  size?: "sm" | "lg";
+}) {
+  const getColor = (s: number) => {
+    if (s >= 80)
+      return "text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30";
+    if (s >= 60)
+      return "text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900/30";
+    return "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30";
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-full flex items-center justify-center font-bold",
+        getColor(score),
+        size === "lg" ? "w-16 h-16 text-xl" : "w-10 h-10 text-sm",
+      )}
+    >
+      {score}
+    </div>
+  );
+}
+
+// Icon Components
+function UsersIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+      />
+    </svg>
+  );
+}
+
+function ChartIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+      />
+    </svg>
+  );
+}
+
+function TrophyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 012.916.52 6.003 6.003 0 01-5.395 4.972m0 0a6.726 6.726 0 01-2.749 1.35m0 0a6.772 6.772 0 01-3.044 0"
+      />
+    </svg>
+  );
+}
+
+function TrendIcon({
+  direction,
+  className,
+}: {
+  direction: "up" | "down" | "stable";
+  className?: string;
+}) {
+  if (direction === "up") {
+    return (
+      <svg
+        className={cn(className, "text-green-500")}
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941"
+        />
+      </svg>
+    );
+  }
+  if (direction === "down") {
+    return (
+      <svg
+        className={cn(className, "text-red-500")}
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M2.25 6L9 12.75l4.286-4.286a11.948 11.948 0 014.306 6.43l.776 2.898m0 0l3.182-5.511m-3.182 5.51l-5.511-3.181"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className={cn(className, "text-slate-400")}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 12h-15" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+      />
+    </svg>
+  );
+}
+
+function LightbulbIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+      />
+    </svg>
+  );
+}
+
+function CheckCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+function ArrowUpIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18"
+      />
+    </svg>
+  );
+}
+
+function SparklesIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+      />
+    </svg>
+  );
+}
+
+function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <svg className={cn("animate-spin", className)} viewBox="0 0 24 24">
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+        fill="none"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+function HelpCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+      />
+    </svg>
+  );
+}
+
+function BookOpenIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
+function MapIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z"
+      />
+    </svg>
+  );
+}
+
+function QuestionIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"
+      />
+    </svg>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card, Button, cn } from "@maiyuri/ui";
+import type { CoachQuiz, CoachQuizOption } from "@maiyuri/shared";
+
+interface AttemptResult {
+  is_correct: boolean | null;
+  score: number;
+  pending: boolean;
+  correct_answer: string | null;
+  explanation: string | null;
+  suggested_lesson_id: string | null;
+}
+
+export default function QuizRunnerPage() {
+  const { quizId } = useParams<{ quizId: string }>();
+  const qc = useQueryClient();
+  const [answer, setAnswer] = useState("");
+  const [result, setResult] = useState<AttemptResult | null>(null);
+
+  const { data: quiz, isLoading } = useQuery({
+    queryKey: ["coaching", "quiz", quizId],
+    queryFn: async (): Promise<CoachQuiz> => {
+      const res = await fetch(`/api/coaching/quizzes/${quizId}`);
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data;
+    },
+  });
+
+  const submit = useMutation({
+    mutationFn: async (): Promise<AttemptResult> => {
+      const res = await fetch(`/api/coaching/quizzes/${quizId}/attempt`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selected_answer: answer }),
+      });
+      if (!res.ok) throw new Error("Failed to submit");
+      return (await res.json()).data;
+    },
+    onSuccess: (r) => {
+      setResult(r);
+      qc.invalidateQueries({ queryKey: ["coaching", "me"] });
+    },
+  });
+
+  if (isLoading || !quiz) {
+    return <Card className="p-8 text-center text-sm text-slate-400">Loading quiz…</Card>;
+  }
+
+  const isChoice = quiz.question_type === "mcq";
+  const options = (quiz.options_json as CoachQuizOption[]) || [];
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5">
+      <div>
+        <Link href="/coaching/learn" className="text-xs text-slate-400">← Library</Link>
+        <h1 className="text-xl font-bold text-slate-900 dark:text-white">Quick Quiz</h1>
+      </div>
+
+      <Card className="space-y-4 p-5">
+        <p className="text-base font-medium text-slate-900 dark:text-white">{quiz.question}</p>
+
+        {isChoice ? (
+          <div className="space-y-2">
+            {options.map((opt) => (
+              <button
+                key={opt.key}
+                disabled={!!result}
+                onClick={() => setAnswer(opt.key)}
+                className={cn(
+                  "flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm",
+                  answer === opt.key
+                    ? "border-amber-500 bg-amber-50 dark:bg-amber-900/20"
+                    : "border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800",
+                )}
+              >
+                <span className="font-semibold text-slate-500">{opt.key}.</span>
+                <span className="text-slate-800 dark:text-slate-200">{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <textarea
+            value={answer}
+            disabled={!!result}
+            onChange={(e) => setAnswer(e.target.value)}
+            rows={4}
+            placeholder="Type your answer…"
+            className="w-full rounded-lg border border-slate-300 bg-white p-3 text-sm dark:border-slate-600 dark:bg-slate-800"
+          />
+        )}
+
+        {!result ? (
+          <Button onClick={() => submit.mutate()} disabled={!answer || submit.isPending} className="w-full">
+            {submit.isPending ? "Checking…" : "Submit answer"}
+          </Button>
+        ) : (
+          <div
+            className={cn(
+              "rounded-lg p-4 text-sm",
+              result.pending
+                ? "bg-blue-50 text-blue-800 dark:bg-blue-900/20 dark:text-blue-200"
+                : result.is_correct
+                  ? "bg-emerald-50 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-200"
+                  : "bg-rose-50 text-rose-800 dark:bg-rose-900/20 dark:text-rose-200",
+            )}
+          >
+            <div className="font-semibold">
+              {result.pending
+                ? "📝 Submitted for review"
+                : result.is_correct
+                  ? "✅ Correct!"
+                  : "❌ Not quite"}
+            </div>
+            {result.explanation && <p className="mt-1">{result.explanation}</p>}
+            {result.suggested_lesson_id && (
+              <Link
+                href={`/coaching/learn/${result.suggested_lesson_id}`}
+                className="mt-2 inline-block font-medium underline"
+              >
+                Revise the related lesson →
+              </Link>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/review/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/review/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card } from "@maiyuri/ui";
+import type { CoachProgressScore, CoachTarget } from "@maiyuri/shared";
+
+interface MeBundle {
+  progress: CoachProgressScore;
+  targets: CoachTarget[];
+}
+
+export default function WeeklyReviewPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["coaching", "me"],
+    queryFn: async (): Promise<MeBundle> => {
+      const res = await fetch("/api/coaching/me");
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data;
+    },
+  });
+
+  if (isLoading || !data) {
+    return <Card className="p-8 text-center text-sm text-slate-400">Loading review…</Card>;
+  }
+
+  const { progress, targets } = data;
+  const weekly = targets.filter((t) => t.frequency === "weekly");
+  const weeklyDone = weekly.filter((t) => t.status === "completed").length;
+  const missed = targets.filter((t) => t.status === "missed");
+
+  const rows: { label: string; value: string }[] = [
+    { label: "Training completion", value: `${progress.trainingCompletionPct}%` },
+    { label: "Lessons completed", value: `${progress.lessonsCompleted}/${progress.lessonsTotal}` },
+    { label: "Quiz average", value: `${progress.quizAveragePct}%` },
+    { label: "Weekly targets done", value: `${weeklyDone}/${weekly.length}` },
+    { label: "This week completion", value: `${progress.weekTargetCompletionPct}%` },
+  ];
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href="/coaching" className="text-xs text-slate-400">← Coach</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Weekly Review</h1>
+        <p className="text-sm text-slate-500">Where you stand this week.</p>
+      </div>
+
+      <Card className="divide-y divide-slate-100 dark:divide-slate-700">
+        {rows.map((r) => (
+          <div key={r.label} className="flex items-center justify-between px-5 py-3 text-sm">
+            <span className="text-slate-500">{r.label}</span>
+            <span className="font-semibold text-slate-900 dark:text-white">{r.value}</span>
+          </div>
+        ))}
+      </Card>
+
+      {missed.length > 0 && (
+        <Card className="p-5">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-rose-500">Missed</h2>
+          <ul className="list-inside list-disc text-sm text-slate-600 dark:text-slate-300">
+            {missed.map((t) => (
+              <li key={t.id}>{t.title}</li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/coaching/targets/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/targets/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Card, Button, cn } from "@maiyuri/ui";
+import { toast } from "sonner";
+import type { CoachTarget } from "@maiyuri/shared";
+
+const STATUS_TONE: Record<string, string> = {
+  not_started: "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300",
+  in_progress: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  completed: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  missed: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+  needs_review: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+};
+
+function TargetRow({ t, onChange }: { t: CoachTarget; onChange: () => void }) {
+  const update = useMutation({
+    mutationFn: async (status: string) => {
+      const res = await fetch(`/api/coaching/targets/${t.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      toast.success("Target updated");
+      onChange();
+    },
+    onError: () => toast.error("Could not update target"),
+  });
+
+  return (
+    <Card className="flex items-center justify-between gap-3 p-4">
+      <div>
+        <div className="font-medium text-slate-900 dark:text-white">{t.title}</div>
+        <div className="flex items-center gap-2 text-xs text-slate-400">
+          <span className="capitalize">{t.frequency}</span>
+          {t.due_date && <span>· due {t.due_date}</span>}
+          <span className={cn("rounded-full px-2 py-0.5 font-medium", STATUS_TONE[t.status])}>
+            {t.status.replace(/_/g, " ")}
+          </span>
+        </div>
+      </div>
+      {t.status !== "completed" ? (
+        <Button size="sm" onClick={() => update.mutate("completed")} disabled={update.isPending}>
+          {update.isPending ? "…" : "Mark done"}
+        </Button>
+      ) : (
+        <span className="text-sm text-emerald-600">✓</span>
+      )}
+    </Card>
+  );
+}
+
+export default function TargetsPage() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["coaching", "targets"],
+    queryFn: async (): Promise<CoachTarget[]> => {
+      const res = await fetch("/api/coaching/targets");
+      if (!res.ok) throw new Error("Failed");
+      return (await res.json()).data;
+    },
+  });
+
+  const refetch = () => {
+    qc.invalidateQueries({ queryKey: ["coaching", "targets"] });
+    qc.invalidateQueries({ queryKey: ["coaching", "me"] });
+  };
+
+  const daily = (data || []).filter((t) => t.frequency === "daily");
+  const weekly = (data || []).filter((t) => t.frequency === "weekly");
+  const other = (data || []).filter((t) => t.frequency === "once");
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href="/coaching" className="text-xs text-slate-400">← Coach</Link>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">My Targets</h1>
+        <p className="text-sm text-slate-500">Daily and weekly goals assigned by your manager.</p>
+      </div>
+
+      {isLoading ? (
+        <Card className="p-8 text-center text-sm text-slate-400">Loading…</Card>
+      ) : !data || data.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-slate-400">No targets assigned yet.</Card>
+      ) : (
+        <>
+          {[
+            { title: "Today / Daily", rows: daily },
+            { title: "This Week", rows: weekly },
+            { title: "One-off", rows: other },
+          ]
+            .filter((g) => g.rows.length > 0)
+            .map((g) => (
+              <div key={g.title} className="space-y-2">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">{g.title}</h2>
+                {g.rows.map((t) => (
+                  <TargetRow key={t.id} t={t} onChange={refetch} />
+                ))}
+              </div>
+            ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -84,9 +84,9 @@ const roleModuleAccess: Record<UserRole, string[]> = {
     "design",
     "projects",
   ],
-  sales: ["dashboard", "leads", "tasks", "settings", "knowledge"],
+  sales: ["dashboard", "leads", "tasks", "settings", "knowledge", "coaching"],
   driver: ["dashboard", "deliveries", "settings"],
-  production_supervisor: ["dashboard", "production", "deliveries", "settings", "projects"],
+  production_supervisor: ["dashboard", "production", "deliveries", "settings", "projects", "coaching"],
 };
 
 function getNavigationForRole(role: UserRole | undefined): NavItem[] {

--- a/apps/web/app/(dashboard)/leads/page.tsx
+++ b/apps/web/app/(dashboard)/leads/page.tsx
@@ -289,6 +289,7 @@ export default function LeadsPage() {
   const [showFilters, setShowFilters] = useState(false);
   const [groupBy, setGroupBy] = useState<GroupKey>("temperature");
   const [actionLead, setActionLead] = useState<Lead | null>(null);
+  const [aiSummaryLead, setAiSummaryLead] = useState<Lead | null>(null);
 
   const activeFilterCount =
     (statusFilter ? 1 : 0) +
@@ -394,6 +395,12 @@ export default function LeadsPage() {
     e.preventDefault();
     e.stopPropagation();
     setActionLead(lead);
+  };
+
+  const handleAiSummary = (e: React.MouseEvent, lead: Lead) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setAiSummaryLead(lead);
   };
 
   const toggleSort = (field: typeof sortBy) => {
@@ -883,6 +890,7 @@ export default function LeadsPage() {
                           onWhatsApp={(e) => handleWhatsApp(e, lead.contact)}
                           onCall={(e) => handleCall(e, lead.contact)}
                           onMore={(e) => handleMore(e, lead)}
+                          onAiSummary={(e) => handleAiSummary(e, lead)}
                         />
                       ))}
                     </div>
@@ -937,13 +945,19 @@ export default function LeadsPage() {
       {actionLead && (
         <LeadQuickActions
           lead={actionLead}
-          users={staffUsers}
           busy={quickPatch.isPending || generateQuote.isPending}
           onClose={() => setActionLead(null)}
           onPatch={(body) =>
             quickPatch.mutate({ id: actionLead.id, body })
           }
           onGenerateQuote={() => generateQuote.mutate(actionLead.id)}
+        />
+      )}
+
+      {aiSummaryLead && (
+        <LeadAISummarySheet
+          lead={aiSummaryLead}
+          onClose={() => setAiSummaryLead(null)}
         />
       )}
     </div>
@@ -996,6 +1010,7 @@ function LeadRow({
   onWhatsApp,
   onCall,
   onMore,
+  onAiSummary,
 }: {
   lead: Lead;
   onHover: (lead: Lead | null) => void;
@@ -1004,6 +1019,7 @@ function LeadRow({
   onWhatsApp: (e: React.MouseEvent) => void;
   onCall: (e: React.MouseEvent) => void;
   onMore: (e: React.MouseEvent) => void;
+  onAiSummary: (e: React.MouseEvent) => void;
 }) {
   const status = statusConfig[lead.lead_status];
   const isCreatedToday = isToday(lead.created_at);
@@ -1094,29 +1110,45 @@ function LeadRow({
               )}
             </div>
 
-            {nextAction && (
+            {/* Stored next_action (purple) or computed urgency hint */}
+            {lead.next_action ? (
+              <p className="mt-1.5 text-xs font-medium flex items-center gap-1 text-purple-600 dark:text-purple-400">
+                <span>→</span>
+                {lead.next_action}
+              </p>
+            ) : nextAction ? (
               <p
                 className={`mt-1.5 text-xs font-medium flex items-center gap-1 ${URGENCY_STYLES[nextAction.urgency]}`}
               >
                 <span>→</span>
                 {nextAction.text}
               </p>
-            )}
+            ) : null}
           </div>
         </div>
 
         <div className="mt-3 flex items-center justify-between gap-2 border-t border-slate-200/60 dark:border-slate-700/60 pt-2.5">
-          <div className="text-xs text-slate-400 dark:text-slate-500 flex items-center gap-2 min-w-0">
-            <span className="truncate">
+          <div className="text-xs flex items-center gap-2 min-w-0">
+            <span className="truncate text-slate-400 dark:text-slate-500">
               {isCreatedToday ? "🆕 Added today" : `Updated ${formatDate(lead.updated_at)}`}
             </span>
             {lead.follow_up_date && (
-              <span className="flex items-center gap-0.5 whitespace-nowrap">
-                📞 {formatDate(lead.follow_up_date)}
+              <span className="flex items-center gap-0.5 whitespace-nowrap font-semibold text-purple-600 dark:text-purple-400">
+                📅 {formatDate(lead.follow_up_date)}
               </span>
             )}
           </div>
           <div className="flex items-center gap-1.5 flex-shrink-0">
+            {(lead.ai_summary || lead.ai_score) && (
+              <button
+                onClick={onAiSummary}
+                aria-label="AI Summary"
+                className="w-10 h-10 flex items-center justify-center rounded-full bg-violet-50 dark:bg-violet-900/30 text-violet-600 active:bg-violet-100 text-base"
+                title="View AI Summary"
+              >
+                ✨
+              </button>
+            )}
             <button
               onClick={onCall}
               aria-label="Call"
@@ -1283,6 +1315,186 @@ function LeadRow({
       </div>
       </div>
     </Link>
+  );
+}
+
+// ============================================================================
+// AI SUMMARY SHEET
+// ============================================================================
+
+function LeadAISummarySheet({
+  lead,
+  onClose,
+}: {
+  lead: Lead;
+  onClose: () => void;
+}) {
+  const score = lead.ai_score ? Math.round(lead.ai_score * 100) : null;
+  const ringColor = lead.ai_score
+    ? lead.ai_score >= 0.7
+      ? "#22c55e"
+      : lead.ai_score >= 0.4
+        ? "#f59e0b"
+        : "#ef4444"
+    : "#94a3b8";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center"
+      role="dialog"
+      aria-modal="true"
+    >
+      <button
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+      />
+      <div className="relative w-full sm:max-w-md bg-white dark:bg-slate-900 rounded-t-2xl sm:rounded-2xl shadow-2xl max-h-[80vh] overflow-y-auto animate-in slide-in-from-bottom-4 sm:zoom-in-95">
+        {/* Handle */}
+        <div className="sm:hidden flex justify-center pt-2.5">
+          <div className="w-10 h-1.5 rounded-full bg-slate-300 dark:bg-slate-700" />
+        </div>
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100 dark:border-slate-800 sticky top-0 bg-white dark:bg-slate-900 z-10">
+          <div className="flex items-center gap-2">
+            <span className="text-base">✨</span>
+            <div>
+              <h3 className="font-semibold text-slate-900 dark:text-white text-sm">
+                AI Summary — {lead.name}
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400 font-mono">
+                {lead.contact}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-full text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-4 py-4 space-y-4">
+          {/* Score */}
+          {score !== null && (
+            <div className="flex items-center gap-4 p-3 bg-slate-50 dark:bg-slate-800 rounded-xl">
+              <div
+                className="w-14 h-14 rounded-full flex items-center justify-center flex-shrink-0"
+                style={{
+                  background: `conic-gradient(${ringColor} ${(lead.ai_score ?? 0) * 360}deg, #e5e7eb 0deg)`,
+                }}
+              >
+                <span className="bg-white dark:bg-slate-900 w-11 h-11 rounded-full flex items-center justify-center text-sm font-bold text-slate-900 dark:text-white">
+                  {score}
+                </span>
+              </div>
+              <div>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  AI Lead Score
+                </p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                  {score >= 70 ? "High potential" : score >= 40 ? "Moderate" : "Low priority"}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Summary */}
+          {lead.ai_summary ? (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2">
+                Summary
+              </p>
+              <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap">
+                {lead.ai_summary}
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 dark:text-slate-400 text-center py-4">
+              No AI summary yet. Open the lead detail and run AI Analyze.
+            </p>
+          )}
+
+          {/* AI factors — shape: { factor, impact } */}
+          {lead.ai_factors && lead.ai_factors.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2">
+                Key Factors
+              </p>
+              <div className="space-y-1.5">
+                {lead.ai_factors.slice(0, 5).map((f, i) => (
+                  <div
+                    key={i}
+                    className={`flex items-start gap-2 text-xs p-2 rounded-lg ${
+                      f.impact === "positive"
+                        ? "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400"
+                        : f.impact === "negative"
+                          ? "bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400"
+                          : "bg-slate-50 dark:bg-slate-800 text-slate-600 dark:text-slate-400"
+                    }`}
+                  >
+                    <span className="flex-shrink-0">
+                      {f.impact === "positive" ? "✅" : f.impact === "negative" ? "⚠️" : "ℹ️"}
+                    </span>
+                    <span>{f.factor}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* AI Suggestions — shape: { type, content, priority } */}
+          {lead.ai_suggestions && lead.ai_suggestions.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2">
+                Suggestions
+              </p>
+              <div className="space-y-1.5">
+                {lead.ai_suggestions.slice(0, 4).map((s, i) => (
+                  <div
+                    key={i}
+                    className={`flex items-start gap-2 text-xs p-2 rounded-lg ${
+                      s.priority === "high"
+                        ? "bg-violet-50 dark:bg-violet-900/20 text-violet-700 dark:text-violet-300"
+                        : "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
+                    }`}
+                  >
+                    <span className="flex-shrink-0">💡</span>
+                    <span>{s.content}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Dominant objection */}
+          {lead.dominant_objection && (
+            <div className="p-3 bg-orange-50 dark:bg-orange-900/20 rounded-xl">
+              <p className="text-xs font-semibold text-orange-700 dark:text-orange-400 mb-0.5">
+                Key Objection
+              </p>
+              <p className="text-sm text-orange-800 dark:text-orange-300">
+                {lead.dominant_objection}
+              </p>
+            </div>
+          )}
+
+          {/* Best lever */}
+          {lead.best_conversion_lever && (
+            <div className="p-3 bg-green-50 dark:bg-green-900/20 rounded-xl">
+              <p className="text-xs font-semibold text-green-700 dark:text-green-400 mb-0.5">
+                Best Conversion Lever
+              </p>
+              <p className="text-sm text-green-800 dark:text-green-300">
+                {lead.best_conversion_lever}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/app/api/coaching/admin/progress/route.ts
+++ b/apps/web/app/api/coaching/admin/progress/route.ts
@@ -1,0 +1,108 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { computeProgressScore } from "@/lib/coaching/progress";
+import type { CoachTarget } from "@maiyuri/shared";
+
+/** Compute one learner's progress + weak area (lowest module quiz accuracy). */
+async function buildReport(userId: string) {
+  const admin = getSupabaseAdmin();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [{ data: lessons }, { data: progress }, { data: attempts }, { data: targets }, { data: subs }] =
+    await Promise.all([
+      admin.from("coach_lessons").select("id,module_id,title").eq("is_active", true),
+      admin.from("coach_lesson_progress").select("lesson_id,status").eq("user_id", userId),
+      admin.from("coach_quiz_attempts").select("quiz_id,is_correct,score").eq("user_id", userId),
+      admin.from("coach_targets").select("*").eq("user_id", userId),
+      admin.from("coach_assignment_submissions").select("manager_status").eq("user_id", userId),
+    ]);
+
+  const lessonRows = (lessons as { id: string; module_id: string; title: string }[]) || [];
+  const completed = new Set(
+    ((progress as { lesson_id: string; status: string }[]) || [])
+      .filter((p) => p.status === "completed")
+      .map((p) => p.lesson_id),
+  );
+  const graded = ((attempts as { quiz_id: string; is_correct: boolean | null; score: number }[]) || []).filter(
+    (a) => a.is_correct !== null,
+  );
+
+  const score = computeProgressScore({
+    lessonsTotal: lessonRows.length,
+    lessonsCompleted: lessonRows.filter((l) => completed.has(l.id)).length,
+    gradedQuizScores: graded.map((a) => Number(a.score) || 0),
+    targets: (targets as CoachTarget[]) || [],
+    today,
+  });
+
+  // Weak area: module with the most incorrect graded attempts.
+  const { data: quizzes } = graded.length
+    ? await admin.from("coach_quizzes").select("id,module_id,lesson_id").in("id", graded.map((a) => a.quiz_id))
+    : { data: [] as { id: string; module_id: string | null; lesson_id: string | null }[] };
+  const lessonModule = new Map(lessonRows.map((l) => [l.id, l.module_id]));
+  const wrongByModule = new Map<string, number>();
+  for (const a of graded) {
+    if (a.is_correct) continue;
+    const quiz = ((quizzes as { id: string; module_id: string | null; lesson_id: string | null }[]) || []).find(
+      (q) => q.id === a.quiz_id,
+    );
+    const moduleId = quiz?.module_id ?? (quiz?.lesson_id ? lessonModule.get(quiz.lesson_id) : null);
+    if (moduleId) wrongByModule.set(moduleId, (wrongByModule.get(moduleId) ?? 0) + 1);
+  }
+  let weakModuleId: string | null = null;
+  let weakCount = 0;
+  for (const [m, c] of wrongByModule) if (c > weakCount) { weakModuleId = m; weakCount = c; }
+  let weakArea: string | null = null;
+  if (weakModuleId) {
+    const { data: m } = await admin.from("coach_modules").select("title").eq("id", weakModuleId).single();
+    weakArea = (m?.title as string) ?? null;
+  }
+
+  const pendingSubs = ((subs as { manager_status: string }[]) || []).filter(
+    (s) => s.manager_status === "pending",
+  ).length;
+
+  return { userId, progress: score, weakArea, pendingSubmissions: pendingSubs };
+}
+
+// GET /api/coaching/admin/progress[?userId=] — per-employee progress (admin)
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Admins only");
+
+    const userId = new URL(request.url).searchParams.get("userId");
+    if (userId) {
+      return success(await buildReport(userId));
+    }
+
+    // List mode: a report per provisioned learner (+ their name).
+    const admin = getSupabaseAdmin();
+    const { data: coachUsers } = await admin
+      .from("coach_users")
+      .select("user_id,training_path,active_status");
+    const rows = (coachUsers as { user_id: string; training_path: string; active_status: boolean }[]) || [];
+
+    const reports = await Promise.all(
+      rows.map(async (r) => {
+        const rep = await buildReport(r.user_id);
+        const { data: u } = await admin.from("users").select("name,email").eq("id", r.user_id).maybeSingle();
+        return {
+          ...rep,
+          training_path: r.training_path,
+          active_status: r.active_status,
+          name: (u?.name as string) ?? (u?.email as string) ?? r.user_id,
+        };
+      }),
+    );
+    return success(reports);
+  } catch (err) {
+    console.error("coaching/admin/progress GET error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/assignments/[id]/route.ts
+++ b/apps/web/app/api/coaching/assignments/[id]/route.ts
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachAssignmentSchema, type CoachAssignment } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// PATCH /api/coaching/assignments/[id] — update (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, updateCoachAssignmentSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(parsed.data)) {
+      if (v !== undefined) patch[k] = v;
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_assignments")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update assignment", 500);
+    return success<CoachAssignment>(data as CoachAssignment);
+  } catch (err) {
+    console.error("coaching/assignments/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/coaching/assignments/[id] — soft-retire (admin)
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_assignments")
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (dbErr) return error("Failed to retire assignment", 500);
+    return success({ retired: true });
+  } catch (err) {
+    console.error("coaching/assignments/[id] DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/assignments/[id]/submit/route.ts
+++ b/apps/web/app/api/coaching/assignments/[id]/submit/route.ts
@@ -1,0 +1,50 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import type { CoachAssignmentSubmission } from "@maiyuri/shared";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  submission_text: z.string().optional(),
+  attachment_url: z.string().optional(),
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// POST /api/coaching/assignments/[id]/submit — learner submits (manager review pending; AI score Phase 2)
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+
+    const parsed = await parseBody(request, bodySchema);
+    if (parsed.error) return parsed.error;
+    if (!parsed.data.submission_text && !parsed.data.attachment_url) {
+      return error("Provide a written answer or an attachment", 400);
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_assignment_submissions")
+      .insert({
+        assignment_id: id,
+        user_id: ctx.userId,
+        submission_text: parsed.data.submission_text ?? null,
+        attachment_url: parsed.data.attachment_url ?? null,
+        manager_status: "pending",
+      })
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching assignment submit error:", dbErr);
+      return error("Failed to submit assignment", 500);
+    }
+    return success<CoachAssignmentSubmission>(data as CoachAssignmentSubmission);
+  } catch (err) {
+    console.error("coaching/assignments/[id]/submit POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/assignments/route.ts
+++ b/apps/web/app/api/coaching/assignments/route.ts
@@ -1,0 +1,71 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import {
+  createCoachAssignmentSchema,
+  type CoachAssignment,
+  type CoachAssignmentSubmission,
+} from "@maiyuri/shared";
+
+// GET /api/coaching/assignments — active assignments + this learner's latest submission
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const admin = getSupabaseAdmin();
+
+    let q = admin.from("coach_assignments").select("*").order("created_at", { ascending: false });
+    if (!ctx.isAdmin) q = q.eq("is_active", true);
+    const { data: assignments, error: aErr } = await q;
+    if (aErr) return error("Failed to load assignments", 500);
+
+    const { data: subs } = await admin
+      .from("coach_assignment_submissions")
+      .select("*")
+      .eq("user_id", ctx.userId)
+      .order("submitted_at", { ascending: false });
+
+    const latestByAssignment = new Map<string, CoachAssignmentSubmission>();
+    for (const s of (subs as CoachAssignmentSubmission[]) || []) {
+      if (!latestByAssignment.has(s.assignment_id)) latestByAssignment.set(s.assignment_id, s);
+    }
+
+    const result = ((assignments as CoachAssignment[]) || []).map((a) => ({
+      ...a,
+      mySubmission: latestByAssignment.get(a.id) ?? null,
+    }));
+    return success(result);
+  } catch (err) {
+    console.error("coaching/assignments GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// POST /api/coaching/assignments — create (admin)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+
+    const parsed = await parseBody(request, createCoachAssignmentSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_assignments")
+      .insert(parsed.data)
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/assignments insert error:", dbErr);
+      return error(`Failed to create assignment: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachAssignment>(data as CoachAssignment);
+  } catch (err) {
+    console.error("coaching/assignments POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/knowledge/[id]/route.ts
+++ b/apps/web/app/api/coaching/knowledge/[id]/route.ts
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachKnowledgeSchema, type CoachKnowledgeArticle } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// PATCH /api/coaching/knowledge/[id] — update (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, updateCoachKnowledgeSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(parsed.data)) {
+      if (v !== undefined) patch[k] = v;
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_knowledge_base")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update article", 500);
+    return success<CoachKnowledgeArticle>(data as CoachKnowledgeArticle);
+  } catch (err) {
+    console.error("coaching/knowledge/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/coaching/knowledge/[id] — soft-retire (admin)
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_knowledge_base")
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (dbErr) return error("Failed to retire article", 500);
+    return success({ retired: true });
+  } catch (err) {
+    console.error("coaching/knowledge/[id] DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/knowledge/route.ts
+++ b/apps/web/app/api/coaching/knowledge/route.ts
@@ -1,0 +1,56 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { createCoachKnowledgeSchema, type CoachKnowledgeArticle } from "@maiyuri/shared";
+
+// GET /api/coaching/knowledge — list (optional ?category=)
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+
+    const category = new URL(request.url).searchParams.get("category");
+    let q = getSupabaseAdmin()
+      .from("coach_knowledge_base")
+      .select("*")
+      .order("category", { ascending: true });
+    if (!ctx.isAdmin) q = q.eq("is_active", true);
+    if (category) q = q.eq("category", category);
+
+    const { data, error: dbErr } = await q;
+    if (dbErr) return error("Failed to load knowledge base", 500);
+    return success<CoachKnowledgeArticle[]>((data as CoachKnowledgeArticle[]) || []);
+  } catch (err) {
+    console.error("coaching/knowledge GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// POST /api/coaching/knowledge — create (admin)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+
+    const parsed = await parseBody(request, createCoachKnowledgeSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_knowledge_base")
+      .insert(parsed.data)
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/knowledge insert error:", dbErr);
+      return error(`Failed to create article: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachKnowledgeArticle>(data as CoachKnowledgeArticle);
+  } catch (err) {
+    console.error("coaching/knowledge POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/lessons/[id]/complete/route.ts
+++ b/apps/web/app/api/coaching/lessons/[id]/complete/route.ts
@@ -1,0 +1,37 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// POST /api/coaching/lessons/[id]/complete — mark lesson complete for this learner
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_lesson_progress")
+      .upsert(
+        {
+          user_id: ctx.userId,
+          lesson_id: id,
+          status: "completed",
+          completed_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id,lesson_id" },
+      );
+    if (dbErr) {
+      console.error("coaching lesson complete error:", dbErr);
+      return error("Failed to mark lesson complete", 500);
+    }
+    return success({ completed: true });
+  } catch (err) {
+    console.error("coaching/lessons/[id]/complete POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/lessons/[id]/route.ts
+++ b/apps/web/app/api/coaching/lessons/[id]/route.ts
@@ -1,0 +1,104 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import {
+  success,
+  error,
+  notFound,
+  unauthorized,
+  forbidden,
+  parseBody,
+} from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachLessonSchema, type CoachLesson, type CoachQuiz } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// GET /api/coaching/lessons/[id] — lesson + its quizzes (answers hidden for learners)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+    const admin = getSupabaseAdmin();
+
+    const { data: lesson, error: lErr } = await admin
+      .from("coach_lessons")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (lErr || !lesson) return notFound("Lesson not found");
+
+    const [{ data: quizzes }, { data: progress }] = await Promise.all([
+      admin.from("coach_quizzes").select("*").eq("lesson_id", id).eq("is_active", true).order("sequence_order", { ascending: true }),
+      admin.from("coach_lesson_progress").select("status").eq("user_id", ctx.userId).eq("lesson_id", id).maybeSingle(),
+    ]);
+
+    // Never leak correct answers/explanations to a learner taking the quiz.
+    const quizList = ((quizzes as CoachQuiz[]) || []).map((q) =>
+      ctx.isAdmin
+        ? q
+        : { ...q, correct_answer: null, explanation: null, suggested_lesson_id: null },
+    );
+
+    return success({
+      lesson: lesson as CoachLesson,
+      quizzes: quizList,
+      completed: (progress as { status: string } | null)?.status === "completed",
+    });
+  } catch (err) {
+    console.error("coaching/lessons/[id] GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// PATCH /api/coaching/lessons/[id] — update (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, updateCoachLessonSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(parsed.data)) {
+      if (v !== undefined) patch[k] = v;
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_lessons")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update lesson", 500);
+    return success<CoachLesson>(data as CoachLesson);
+  } catch (err) {
+    console.error("coaching/lessons/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/coaching/lessons/[id] — soft-retire (admin)
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_lessons")
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (dbErr) return error("Failed to retire lesson", 500);
+    return success({ retired: true });
+  } catch (err) {
+    console.error("coaching/lessons/[id] DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/lessons/route.ts
+++ b/apps/web/app/api/coaching/lessons/route.ts
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { createCoachLessonSchema, type CoachLesson } from "@maiyuri/shared";
+
+// POST /api/coaching/lessons — create a lesson under a module (admin)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+
+    const parsed = await parseBody(request, createCoachLessonSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_lessons")
+      .insert(parsed.data)
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/lessons insert error:", dbErr);
+      return error(`Failed to create lesson: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachLesson>(data as CoachLesson);
+  } catch (err) {
+    console.error("coaching/lessons POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/me/route.ts
+++ b/apps/web/app/api/coaching/me/route.ts
@@ -1,0 +1,114 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext, getOrCreateCoachUser } from "@/lib/coaching/context";
+import { computeProgressScore } from "@/lib/coaching/progress";
+import type {
+  CoachLesson,
+  CoachModule,
+  CoachTarget,
+  CoachTodayPlanItem,
+} from "@maiyuri/shared";
+
+/** A module applies to a learner if it lists their path or targets everyone. */
+function applies(mod: CoachModule, path: string): boolean {
+  return (
+    !mod.role_applicability ||
+    mod.role_applicability.length === 0 ||
+    mod.role_applicability.includes(path)
+  );
+}
+
+// GET /api/coaching/me — learner dashboard bundle (no AI)
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+
+    const admin = getSupabaseAdmin();
+    const coachUser = await getOrCreateCoachUser(ctx.userId, ctx.role);
+    const path = coachUser.training_path;
+    const today = new Date().toISOString().slice(0, 10);
+
+    const [{ data: modules }, { data: targets }] = await Promise.all([
+      admin.from("coach_modules").select("*").eq("is_active", true).order("sequence_order", { ascending: true }),
+      admin.from("coach_targets").select("*").eq("user_id", ctx.userId),
+    ]);
+
+    const applicable = ((modules as CoachModule[]) || []).filter((m) => applies(m, path));
+    const moduleIds = applicable.map((m) => m.id);
+
+    const { data: lessons } = moduleIds.length
+      ? await admin
+          .from("coach_lessons")
+          .select("*")
+          .in("module_id", moduleIds)
+          .eq("is_active", true)
+          .order("sequence_order", { ascending: true })
+      : { data: [] as CoachLesson[] };
+
+    const lessonList = (lessons as CoachLesson[]) || [];
+    const lessonIds = lessonList.map((l) => l.id);
+
+    const [{ data: progress }, { data: attempts }, { data: assignments }] =
+      await Promise.all([
+        lessonIds.length
+          ? admin.from("coach_lesson_progress").select("lesson_id,status").eq("user_id", ctx.userId).in("lesson_id", lessonIds)
+          : Promise.resolve({ data: [] as { lesson_id: string; status: string }[] }),
+        admin.from("coach_quiz_attempts").select("score,is_correct").eq("user_id", ctx.userId).not("is_correct", "is", null),
+        admin.from("coach_assignments").select("id,title,is_active").eq("is_active", true),
+      ]);
+
+    const completedIds = new Set(
+      ((progress as { lesson_id: string; status: string }[]) || [])
+        .filter((p) => p.status === "completed")
+        .map((p) => p.lesson_id),
+    );
+    const gradedQuizScores = ((attempts as { score: number; is_correct: boolean | null }[]) || []).map(
+      (a) => Number(a.score) || 0,
+    );
+
+    const score = computeProgressScore({
+      lessonsTotal: lessonList.length,
+      lessonsCompleted: completedIds.size,
+      gradedQuizScores,
+      targets: (targets as CoachTarget[]) || [],
+      today,
+    });
+
+    // Today's plan: next 2 incomplete lessons + today's daily targets + active assignments.
+    const todayPlan: CoachTodayPlanItem[] = [];
+    for (const l of lessonList) {
+      if (!completedIds.has(l.id)) {
+        todayPlan.push({ kind: "lesson", refId: l.id, title: l.title, done: false });
+        if (todayPlan.length >= 2) break;
+      }
+    }
+    for (const t of ((targets as CoachTarget[]) || []).filter(
+      (t) => t.frequency === "daily" && (t.due_date ?? today) === today,
+    )) {
+      todayPlan.push({
+        kind: "target",
+        refId: t.id,
+        title: t.title,
+        done: t.status === "completed",
+      });
+    }
+    for (const a of ((assignments as { id: string; title: string }[]) || []).slice(0, 2)) {
+      todayPlan.push({ kind: "assignment", refId: a.id, title: a.title, done: false });
+    }
+
+    return success({
+      coachUser,
+      isAdmin: ctx.isAdmin,
+      progress: score,
+      todayPlan,
+      targets: (targets as CoachTarget[]) || [],
+    });
+  } catch (err) {
+    console.error("coaching/me GET error:", err);
+    return error("Failed to load coaching dashboard", 500);
+  }
+}

--- a/apps/web/app/api/coaching/modules/[id]/route.ts
+++ b/apps/web/app/api/coaching/modules/[id]/route.ts
@@ -1,0 +1,113 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import {
+  success,
+  error,
+  notFound,
+  unauthorized,
+  forbidden,
+  parseBody,
+} from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachModuleSchema, type CoachLesson, type CoachModule } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// GET /api/coaching/modules/[id] — module + its lessons (+ completion for learner)
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+    const admin = getSupabaseAdmin();
+
+    const { data: module, error: mErr } = await admin
+      .from("coach_modules")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (mErr || !module) return notFound("Module not found");
+
+    const { data: lessons } = await admin
+      .from("coach_lessons")
+      .select("*")
+      .eq("module_id", id)
+      .eq("is_active", true)
+      .order("sequence_order", { ascending: true });
+
+    const lessonList = (lessons as CoachLesson[]) || [];
+    const { data: progress } = lessonList.length
+      ? await admin
+          .from("coach_lesson_progress")
+          .select("lesson_id,status")
+          .eq("user_id", ctx.userId)
+          .in("lesson_id", lessonList.map((l) => l.id))
+      : { data: [] as { lesson_id: string; status: string }[] };
+
+    const completed = new Set(
+      ((progress as { lesson_id: string; status: string }[]) || [])
+        .filter((p) => p.status === "completed")
+        .map((p) => p.lesson_id),
+    );
+
+    return success({
+      module: module as CoachModule,
+      lessons: lessonList.map((l) => ({ ...l, completed: completed.has(l.id) })),
+    });
+  } catch (err) {
+    console.error("coaching/modules/[id] GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// PATCH /api/coaching/modules/[id] — update (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, updateCoachModuleSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(parsed.data)) {
+      if (v !== undefined) patch[k] = v;
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_modules")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update module", 500);
+    return success<CoachModule>(data as CoachModule);
+  } catch (err) {
+    console.error("coaching/modules/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/coaching/modules/[id] — soft-retire (admin)
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_modules")
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (dbErr) return error("Failed to retire module", 500);
+    return success({ retired: true });
+  } catch (err) {
+    console.error("coaching/modules/[id] DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/modules/route.ts
+++ b/apps/web/app/api/coaching/modules/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { createCoachModuleSchema, type CoachModule } from "@maiyuri/shared";
+
+// GET /api/coaching/modules — list active modules (admins see all)
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+
+    let q = getSupabaseAdmin()
+      .from("coach_modules")
+      .select("*")
+      .order("sequence_order", { ascending: true });
+    if (!ctx.isAdmin) q = q.eq("is_active", true);
+
+    const { data, error: dbErr } = await q;
+    if (dbErr) {
+      console.error("coaching/modules list error:", dbErr);
+      return error("Failed to load modules", 500);
+    }
+    return success<CoachModule[]>((data as CoachModule[]) || []);
+  } catch (err) {
+    console.error("coaching/modules GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// POST /api/coaching/modules — create (admin only)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+
+    const parsed = await parseBody(request, createCoachModuleSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_modules")
+      .insert(parsed.data)
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/modules insert error:", dbErr);
+      return error(`Failed to create module: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachModule>(data as CoachModule);
+  } catch (err) {
+    console.error("coaching/modules POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
+++ b/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
@@ -1,0 +1,67 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import {
+  success,
+  error,
+  notFound,
+  unauthorized,
+  parseBody,
+} from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { gradeQuizAnswer } from "@/lib/coaching/grading";
+import type { CoachQuiz } from "@maiyuri/shared";
+import { z } from "zod";
+
+const attemptSchema = z.object({ selected_answer: z.string().min(1, "An answer is required") });
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// POST /api/coaching/quizzes/[id]/attempt — grade (deterministic) + store + return result
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+
+    const parsed = await parseBody(request, attemptSchema);
+    if (parsed.error) return parsed.error;
+
+    const admin = getSupabaseAdmin();
+    const { data: quiz, error: qErr } = await admin
+      .from("coach_quizzes")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (qErr || !quiz) return notFound("Quiz not found");
+
+    const q = quiz as CoachQuiz;
+    const grade = gradeQuizAnswer(q, parsed.data.selected_answer);
+
+    const { error: insErr } = await admin.from("coach_quiz_attempts").insert({
+      user_id: ctx.userId,
+      quiz_id: id,
+      selected_answer: parsed.data.selected_answer,
+      is_correct: grade.isCorrect,
+      score: grade.score,
+    });
+    if (insErr) {
+      console.error("coaching quiz attempt insert error:", insErr);
+      return error("Failed to record attempt", 500);
+    }
+
+    // Surface the explanation + suggested revision lesson only AFTER answering.
+    return success({
+      is_correct: grade.isCorrect,
+      score: grade.score,
+      pending: grade.pending,
+      correct_answer: grade.pending ? null : q.correct_answer,
+      explanation: q.explanation ?? null,
+      suggested_lesson_id: grade.isCorrect ? null : q.suggested_lesson_id ?? null,
+    });
+  } catch (err) {
+    console.error("coaching/quizzes/[id]/attempt POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/quizzes/[id]/route.ts
+++ b/apps/web/app/api/coaching/quizzes/[id]/route.ts
@@ -1,0 +1,92 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import {
+  success,
+  error,
+  notFound,
+  unauthorized,
+  forbidden,
+  parseBody,
+} from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachQuizSchema, type CoachQuiz } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// GET /api/coaching/quizzes/[id] — answers hidden for learners
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+
+    const { data: quiz, error: qErr } = await getSupabaseAdmin()
+      .from("coach_quizzes")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (qErr || !quiz) return notFound("Quiz not found");
+
+    const q = quiz as CoachQuiz;
+    return success(
+      ctx.isAdmin
+        ? q
+        : { ...q, correct_answer: null, explanation: null, suggested_lesson_id: null },
+    );
+  } catch (err) {
+    console.error("coaching/quizzes/[id] GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// PATCH /api/coaching/quizzes/[id] — update (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, updateCoachQuizSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(parsed.data)) {
+      if (v !== undefined) patch[k] = v;
+    }
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_quizzes")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update quiz", 500);
+    return success<CoachQuiz>(data as CoachQuiz);
+  } catch (err) {
+    console.error("coaching/quizzes/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/coaching/quizzes/[id] — soft-retire (admin)
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+    const { id } = await params;
+
+    const { error: dbErr } = await getSupabaseAdmin()
+      .from("coach_quizzes")
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (dbErr) return error("Failed to retire quiz", 500);
+    return success({ retired: true });
+  } catch (err) {
+    console.error("coaching/quizzes/[id] DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/quizzes/route.ts
+++ b/apps/web/app/api/coaching/quizzes/route.ts
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { createCoachQuizSchema, type CoachQuiz } from "@maiyuri/shared";
+
+// POST /api/coaching/quizzes — create (admin)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can manage content");
+
+    const parsed = await parseBody(request, createCoachQuizSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_quizzes")
+      .insert(parsed.data)
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/quizzes insert error:", dbErr);
+      return error(`Failed to create quiz: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachQuiz>(data as CoachQuiz);
+  } catch (err) {
+    console.error("coaching/quizzes POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/submissions/[id]/route.ts
+++ b/apps/web/app/api/coaching/submissions/[id]/route.ts
@@ -1,0 +1,37 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { reviewSubmissionSchema, type CoachAssignmentSubmission } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// PATCH /api/coaching/submissions/[id] — manager reviews a submission (admin)
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can review submissions");
+    const { id } = await params;
+
+    const parsed = await parseBody(request, reviewSubmissionSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_assignment_submissions")
+      .update({
+        manager_status: parsed.data.manager_status,
+        manager_comment: parsed.data.manager_comment ?? null,
+      })
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to review submission", 500);
+    return success<CoachAssignmentSubmission>(data as CoachAssignmentSubmission);
+  } catch (err) {
+    console.error("coaching/submissions/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/targets/[id]/route.ts
+++ b/apps/web/app/api/coaching/targets/[id]/route.ts
@@ -1,0 +1,55 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import {
+  success,
+  error,
+  notFound,
+  unauthorized,
+  forbidden,
+  parseBody,
+} from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { updateCoachTargetSchema, type CoachTarget } from "@maiyuri/shared";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// PATCH /api/coaching/targets/[id] — learner updates own progress; admin any
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    const { id } = await params;
+    const admin = getSupabaseAdmin();
+
+    const { data: target, error: tErr } = await admin
+      .from("coach_targets")
+      .select("user_id")
+      .eq("id", id)
+      .single();
+    if (tErr || !target) return notFound("Target not found");
+    if (!ctx.isAdmin && target.user_id !== ctx.userId) {
+      return forbidden("You can only update your own targets");
+    }
+
+    const parsed = await parseBody(request, updateCoachTargetSchema);
+    if (parsed.error) return parsed.error;
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (parsed.data.status !== undefined) patch.status = parsed.data.status;
+    if (parsed.data.completion_value !== undefined) patch.completion_value = parsed.data.completion_value;
+
+    const { data, error: dbErr } = await admin
+      .from("coach_targets")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (dbErr || !data) return error("Failed to update target", 500);
+    return success<CoachTarget>(data as CoachTarget);
+  } catch (err) {
+    console.error("coaching/targets/[id] PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/coaching/targets/route.ts
+++ b/apps/web/app/api/coaching/targets/route.ts
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, unauthorized, forbidden, parseBody } from "@/lib/api-utils";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import { getCoachContext } from "@/lib/coaching/context";
+import { createCoachTargetSchema, type CoachTarget } from "@maiyuri/shared";
+
+// GET /api/coaching/targets — own targets (admins may pass ?userId=)
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+
+    const requested = new URL(request.url).searchParams.get("userId");
+    const userId = ctx.isAdmin && requested ? requested : ctx.userId;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_targets")
+      .select("*")
+      .eq("user_id", userId)
+      .order("due_date", { ascending: true });
+    if (dbErr) return error("Failed to load targets", 500);
+    return success<CoachTarget[]>((data as CoachTarget[]) || []);
+  } catch (err) {
+    console.error("coaching/targets GET error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// POST /api/coaching/targets — assign a target to a learner (admin)
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCoachContext(request);
+    if (!ctx) return unauthorized();
+    if (!ctx.isAdmin) return forbidden("Only founders/owners can assign targets");
+
+    const parsed = await parseBody(request, createCoachTargetSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await getSupabaseAdmin()
+      .from("coach_targets")
+      .insert({
+        ...parsed.data,
+        target_value: parsed.data.target_value ?? 1,
+        created_by: ctx.userId,
+      })
+      .select()
+      .single();
+    if (dbErr || !data) {
+      console.error("coaching/targets insert error:", dbErr);
+      return error(`Failed to assign target: ${dbErr?.message ?? "unknown"}`, 500);
+    }
+    return success<CoachTarget>(data as CoachTarget);
+  } catch (err) {
+    console.error("coaching/targets POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/scripts/seed-coaching.ts
+++ b/apps/web/scripts/seed-coaching.ts
@@ -1,0 +1,112 @@
+/**
+ * Idempotent seeder for the AI Sales Coach (Phase 1).
+ * Upserts modules → lessons → quizzes, plus assignments + knowledge, by stable
+ * `slug`. Safe to re-run. Run AFTER the migration:
+ *
+ *   cd apps/web && bun run scripts/seed-coaching.ts
+ *
+ * Reads NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (Bun auto-loads
+ * .env.local). Mirrors the other scripts in this folder.
+ */
+import { createClient } from "@supabase/supabase-js";
+import {
+  SEED_MODULES,
+  SEED_ASSIGNMENTS,
+  SEED_KNOWLEDGE,
+} from "../src/lib/coaching/seed/content";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || "";
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+if (!url || !key) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+const db = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+async function upsert<T extends Record<string, unknown>>(table: string, row: T): Promise<{ id: string }> {
+  const { data, error } = await db.from(table).upsert(row, { onConflict: "slug" }).select("id").single();
+  if (error) throw new Error(`${table} upsert (${String(row.slug)}): ${error.message}`);
+  return data as { id: string };
+}
+
+async function main() {
+  let modules = 0, lessons = 0, quizzes = 0, assignments = 0, knowledge = 0;
+
+  for (const m of SEED_MODULES) {
+    const mod = await upsert("coach_modules", {
+      slug: m.slug,
+      title: m.title,
+      description: m.description,
+      role_applicability: m.role_applicability,
+      sequence_order: m.sequence_order,
+      is_active: true,
+    });
+    modules++;
+
+    for (let li = 0; li < m.lessons.length; li++) {
+      const l = m.lessons[li];
+      const lesson = await upsert("coach_lessons", {
+        slug: l.slug,
+        module_id: mod.id,
+        title: l.title,
+        objective: l.objective ?? null,
+        content: l.content,
+        examples: l.examples ?? null,
+        do_dont_notes: l.do_dont_notes ?? null,
+        sequence_order: li + 1,
+        is_active: true,
+      });
+      lessons++;
+
+      for (let qi = 0; qi < (l.quizzes ?? []).length; qi++) {
+        const q = l.quizzes![qi];
+        await upsert("coach_quizzes", {
+          slug: q.slug,
+          lesson_id: lesson.id,
+          module_id: mod.id,
+          question: q.question,
+          question_type: q.question_type,
+          options_json: q.options ?? [],
+          correct_answer: q.correct_answer ?? null,
+          explanation: q.explanation ?? null,
+          sequence_order: qi + 1,
+          is_active: true,
+        });
+        quizzes++;
+      }
+    }
+  }
+
+  for (const a of SEED_ASSIGNMENTS) {
+    await upsert("coach_assignments", {
+      slug: a.slug,
+      title: a.title,
+      description: a.description,
+      assignment_type: a.assignment_type,
+      due_frequency: a.due_frequency,
+      evaluation_method: "manager",
+      is_active: true,
+    });
+    assignments++;
+  }
+
+  for (const k of SEED_KNOWLEDGE) {
+    await upsert("coach_knowledge_base", {
+      slug: k.slug,
+      category: k.category,
+      title: k.title,
+      content: k.content,
+      is_active: true,
+    });
+    knowledge++;
+  }
+
+  console.log(
+    `✓ Seeded coaching: ${modules} modules, ${lessons} lessons, ${quizzes} quizzes, ${assignments} assignments, ${knowledge} knowledge articles.`,
+  );
+}
+
+main().catch((e) => {
+  console.error("Seed failed:", e);
+  process.exit(1);
+});

--- a/apps/web/src/components/leads/FeedbackQRCard.tsx
+++ b/apps/web/src/components/leads/FeedbackQRCard.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { QRCodeCanvas } from "qrcode.react";
 import { Card, Button, Badge } from "@maiyuri/ui";
+import { buildWhatsAppUrl } from "@maiyuri/shared";
 import type { Lead, LanguagePreference } from "@maiyuri/shared";
 
 interface FeedbackQRCardProps {
@@ -62,12 +63,10 @@ export function FeedbackQRCard({ lead }: FeedbackQRCardProps) {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const shareWhatsApp = () => {
+  const shareWhatsAppBusiness = () => {
     if (!feedbackUrl) return;
-    const text = encodeURIComponent(
-      `Hi ${lead.name ?? "there"},\n\nThank you for visiting Maiyuri Bricks! 🧱\n\nWe'd love a moment of your feedback — it takes under a minute:\n${feedbackUrl}`,
-    );
-    window.open(`https://wa.me/${lead.contact}?text=${text}`, "_blank");
+    const message = `Hi ${lead.name ?? "there"},\n\nThank you for visiting Maiyuri Bricks! 🧱\n\nWe'd love a moment of your feedback — it takes under a minute:\n${feedbackUrl}`;
+    window.open(buildWhatsAppUrl(lead.contact, message), "_blank");
   };
 
   const downloadPng = () => {
@@ -185,11 +184,11 @@ export function FeedbackQRCard({ lead }: FeedbackQRCardProps) {
               <Button
                 size="sm"
                 variant="secondary"
-                onClick={shareWhatsApp}
+                onClick={shareWhatsAppBusiness}
                 className="text-green-600 hover:text-green-700"
               >
                 <WhatsAppIcon className="h-3 w-3 mr-1" />
-                WhatsApp
+                WhatsApp Business
               </Button>
             )}
           </div>

--- a/apps/web/src/components/leads/LeadQuickActions.tsx
+++ b/apps/web/src/components/leads/LeadQuickActions.tsx
@@ -2,23 +2,21 @@
 
 /**
  * LeadQuickActions — a bottom-sheet (mobile) / centered modal (desktop) that
- * lets a rep act on a lead WITHOUT opening the detail page: advance the
- * pipeline stage, set temperature, snooze the follow-up, reassign, or generate
- * a Smart Quote. Dumb component — the page wires the callbacks to mutations.
+ * lets a rep act on a lead WITHOUT opening the detail page: change status,
+ * advance the pipeline stage, set temperature, snooze the follow-up, add a
+ * quick note, set the next action, or generate a Smart Quote.
+ * Dumb component — the page wires the callbacks to mutations.
  */
 import { useState } from "react";
-import type { Lead, PipelineStage, LeadTemperature } from "@maiyuri/shared";
-import { PIPELINE_STAGES, LEAD_TEMPERATURES } from "@/lib/lead-taxonomy";
-
-interface StaffUser {
-  id: string;
-  name: string;
-  role?: string;
-}
+import type { Lead, PipelineStage, LeadTemperature, LeadStatus } from "@maiyuri/shared";
+import {
+  PIPELINE_STAGES,
+  LEAD_TEMPERATURES,
+  LEAD_STATUSES,
+} from "@/lib/lead-taxonomy";
 
 export interface LeadQuickActionsProps {
   lead: Lead;
-  users: StaffUser[];
   busy?: boolean;
   onClose: () => void;
   onPatch: (body: Record<string, unknown>) => void;
@@ -53,17 +51,39 @@ function Section({
 
 export function LeadQuickActions({
   lead,
-  users,
   busy,
   onClose,
   onPatch,
   onGenerateQuote,
 }: LeadQuickActionsProps) {
   const [showAllStages, setShowAllStages] = useState(false);
+  const [noteText, setNoteText] = useState("");
+  const [nextActionText, setNextActionText] = useState(lead.next_action ?? "");
+
   const activeStages = PIPELINE_STAGES.filter(
     (s) => s.value !== "order_won" && s.value !== "closed_lost",
   );
   const stagesToShow = showAllStages ? PIPELINE_STAGES : activeStages;
+
+  const handleSaveNote = () => {
+    if (!noteText.trim()) return;
+    const timestamp = new Date().toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+    const newNote = `[${timestamp}] ${noteText.trim()}`;
+    const combined = lead.staff_notes
+      ? `${newNote}\n\n${lead.staff_notes}`
+      : newNote;
+    onPatch({ staff_notes: combined });
+    setNoteText("");
+  };
+
+  const handleSaveNextAction = () => {
+    if (nextActionText.trim() === (lead.next_action ?? "")) return;
+    onPatch({ next_action: nextActionText.trim() || null });
+  };
 
   return (
     <div
@@ -79,7 +99,7 @@ export function LeadQuickActions({
       />
 
       {/* Sheet */}
-      <div className="relative w-full sm:max-w-md bg-white dark:bg-slate-900 rounded-t-2xl sm:rounded-2xl shadow-2xl max-h-[85vh] overflow-y-auto animate-in slide-in-from-bottom-4 sm:zoom-in-95">
+      <div className="relative w-full sm:max-w-md bg-white dark:bg-slate-900 rounded-t-2xl sm:rounded-2xl shadow-2xl max-h-[88vh] overflow-y-auto animate-in slide-in-from-bottom-4 sm:zoom-in-95">
         {/* Grab handle (mobile) */}
         <div className="sm:hidden flex justify-center pt-2.5">
           <div className="w-10 h-1.5 rounded-full bg-slate-300 dark:bg-slate-700" />
@@ -106,6 +126,32 @@ export function LeadQuickActions({
         {busy && (
           <div className="h-0.5 bg-blue-500 animate-pulse" aria-hidden />
         )}
+
+        {/* Status */}
+        <Section title="Status">
+          <div className="grid grid-cols-2 gap-2">
+            {LEAD_STATUSES.map((s) => {
+              const isCurrent = s.value === lead.lead_status;
+              return (
+                <button
+                  key={s.value}
+                  disabled={busy || isCurrent}
+                  onClick={() =>
+                    onPatch({ lead_status: s.value as LeadStatus })
+                  }
+                  className={`flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-xs font-medium text-left transition-colors ${
+                    isCurrent
+                      ? "ring-2 ring-blue-500 " + s.bg + " " + s.color
+                      : "bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
+                  }`}
+                >
+                  <span>{s.emoji}</span>
+                  <span className="truncate">{s.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </Section>
 
         {/* Advance stage */}
         <Section title="Move to stage">
@@ -170,8 +216,8 @@ export function LeadQuickActions({
           </div>
         </Section>
 
-        {/* Snooze / schedule follow-up */}
-        <Section title="Follow-up">
+        {/* Follow-up date */}
+        <Section title="Follow-up Due Date">
           <div className="grid grid-cols-4 gap-2">
             {[
               { label: "Today", days: 0 },
@@ -189,32 +235,54 @@ export function LeadQuickActions({
               </button>
             ))}
           </div>
+          {lead.follow_up_date && (
+            <p className="mt-1.5 text-xs text-purple-600 dark:text-purple-400 font-medium">
+              Current: {new Date(lead.follow_up_date).toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}
+            </p>
+          )}
         </Section>
 
-        {/* Reassign */}
-        {users.length > 0 && (
-          <Section title="Assign to">
-            <div className="flex flex-wrap gap-2">
-              {users.map((u) => {
-                const isCurrent = u.id === lead.assigned_staff;
-                return (
-                  <button
-                    key={u.id}
-                    disabled={busy || isCurrent}
-                    onClick={() => onPatch({ assigned_staff: u.id })}
-                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                      isCurrent
-                        ? "ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
-                        : "bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
-                    }`}
-                  >
-                    {u.name}
-                  </button>
-                );
-              })}
-            </div>
-          </Section>
-        )}
+        {/* Next Action */}
+        <Section title="Next Action">
+          <textarea
+            rows={2}
+            value={nextActionText}
+            onChange={(e) => setNextActionText(e.target.value)}
+            placeholder="e.g. Share quote, schedule factory visit…"
+            className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"
+          />
+          <button
+            disabled={busy || nextActionText.trim() === (lead.next_action ?? "")}
+            onClick={handleSaveNextAction}
+            className="mt-2 w-full py-2 rounded-lg text-xs font-semibold bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50 transition-colors"
+          >
+            Save Next Action
+          </button>
+        </Section>
+
+        {/* Add Note */}
+        <Section title="Add Note">
+          <textarea
+            rows={3}
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+            placeholder="Quick note about this lead…"
+            className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          />
+          <button
+            disabled={busy || !noteText.trim()}
+            onClick={handleSaveNote}
+            className="mt-2 w-full py-2 rounded-lg text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors"
+          >
+            Add Note
+          </button>
+          {lead.staff_notes && (
+            <p className="mt-1.5 text-xs text-slate-500 dark:text-slate-400 line-clamp-2">
+              Last note: {lead.staff_notes.slice(0, 80)}
+              {lead.staff_notes.length > 80 ? "…" : ""}
+            </p>
+          )}
+        </Section>
 
         {/* Smart Quote */}
         <Section title="Smart Quote">

--- a/apps/web/src/lib/coaching/context.ts
+++ b/apps/web/src/lib/coaching/context.ts
@@ -1,0 +1,77 @@
+/**
+ * Coaching auth/context helpers. Resolves the current user + role, exposes an
+ * admin check (founder/owner), and lazily provisions the learner's coach_users
+ * row so every authenticated user can use the Coach immediately.
+ */
+import { NextRequest } from "next/server";
+import { getUserFromRequest } from "@/lib/supabase-server";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+import type { CoachUser } from "@maiyuri/shared";
+
+const ADMIN_ROLES = new Set(["founder", "owner"]);
+
+export interface CoachContext {
+  userId: string;
+  role: string | null;
+  isAdmin: boolean;
+}
+
+/** Returns the auth context, or null when unauthenticated. */
+export async function getCoachContext(
+  request: NextRequest,
+): Promise<CoachContext | null> {
+  const user = await getUserFromRequest(request);
+  if (!user) return null;
+
+  let role: string | null = null;
+  try {
+    const { data } = await getSupabaseAdmin()
+      .from("users")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+    role = (data?.role as string) ?? null;
+  } catch {
+    role = null;
+  }
+
+  return { userId: user.id, role, isAdmin: role ? ADMIN_ROLES.has(role) : false };
+}
+
+/**
+ * Ensure a coach_users profile exists for this user; returns it.
+ * Default training path is derived from their app role when recognisable.
+ */
+export async function getOrCreateCoachUser(
+  userId: string,
+  appRole?: string | null,
+): Promise<CoachUser> {
+  const admin = getSupabaseAdmin();
+  const { data: existing } = await admin
+    .from("coach_users")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (existing) return existing as CoachUser;
+
+  const trainingPath =
+    appRole === "sales"
+      ? "sales_executive"
+      : appRole === "engineer"
+        ? "site_engineer"
+        : appRole === "accountant"
+          ? "accounts_assistant"
+          : appRole === "driver"
+            ? "delivery_coordinator"
+            : "production_supervisor";
+
+  const { data: created, error } = await admin
+    .from("coach_users")
+    .insert({ user_id: userId, role: appRole ?? null, training_path: trainingPath })
+    .select()
+    .single();
+  if (error || !created) {
+    throw new Error(`Failed to provision coach_users: ${error?.message ?? "unknown"}`);
+  }
+  return created as CoachUser;
+}

--- a/apps/web/src/lib/coaching/grading.test.ts
+++ b/apps/web/src/lib/coaching/grading.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { gradeQuizAnswer, normalizeAnswer } from "./grading";
+
+describe("normalizeAnswer", () => {
+  it("lowercases, trims, strips punctuation, collapses spaces", () => {
+    expect(normalizeAnswer("  Wall! ")).toBe("wall");
+    expect(normalizeAnswer("Total  WALL, value.")).toBe("total wall value");
+    expect(normalizeAnswer("WALL")).toBe(normalizeAnswer("wall"));
+  });
+});
+
+describe("gradeQuizAnswer", () => {
+  it("grades MCQ by exact key match", () => {
+    const quiz = { question_type: "mcq" as const, correct_answer: "C" };
+    expect(gradeQuizAnswer(quiz, "C")).toEqual({ isCorrect: true, score: 100, pending: false });
+    expect(gradeQuizAnswer(quiz, "A")).toEqual({ isCorrect: false, score: 0, pending: false });
+  });
+
+  it("MCQ with no correct answer configured is never correct", () => {
+    const quiz = { question_type: "mcq" as const, correct_answer: null };
+    expect(gradeQuizAnswer(quiz, "A")).toEqual({ isCorrect: false, score: 0, pending: false });
+  });
+
+  it("grades fill_blank case/punctuation/space-insensitively", () => {
+    const quiz = { question_type: "fill_blank" as const, correct_answer: "wall" };
+    expect(gradeQuizAnswer(quiz, "Wall").isCorrect).toBe(true);
+    expect(gradeQuizAnswer(quiz, "  WALL! ").isCorrect).toBe(true);
+    expect(gradeQuizAnswer(quiz, "floor").isCorrect).toBe(false);
+    expect(gradeQuizAnswer(quiz, "wall").score).toBe(100);
+  });
+
+  it("leaves scenario answers pending for review", () => {
+    const quiz = { question_type: "scenario" as const, correct_answer: null };
+    expect(gradeQuizAnswer(quiz, "a long open answer")).toEqual({
+      isCorrect: null,
+      score: 0,
+      pending: true,
+    });
+  });
+
+  it("leaves voice_text answers pending", () => {
+    const quiz = { question_type: "voice_text" as const, correct_answer: null };
+    expect(gradeQuizAnswer(quiz, "spoken answer").pending).toBe(true);
+  });
+});

--- a/apps/web/src/lib/coaching/grading.ts
+++ b/apps/web/src/lib/coaching/grading.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic quiz grading for the AI Sales Coach (Phase 1 — no AI).
+ *
+ * - mcq        → exact match of the selected option key vs correct_answer
+ * - fill_blank → normalized (case/space/punctuation-insensitive) text match
+ * - scenario / voice_text → cannot be auto-graded; left pending (is_correct=null)
+ *   for manager review (and AI scoring in Phase 2).
+ */
+import type { CoachQuiz } from "@maiyuri/shared";
+
+export interface GradeResult {
+  /** true / false for auto-gradable types; null when pending review. */
+  isCorrect: boolean | null;
+  /** 0–100. 0 while pending. */
+  score: number;
+  pending: boolean;
+}
+
+/** Lowercase, trim, strip punctuation, collapse internal whitespace. */
+export function normalizeAnswer(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, "") // drop punctuation/symbols, keep letters+numbers
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function gradeQuizAnswer(
+  quiz: Pick<CoachQuiz, "question_type" | "correct_answer">,
+  selectedAnswer: string,
+): GradeResult {
+  const selected = (selectedAnswer ?? "").toString();
+
+  switch (quiz.question_type) {
+    case "mcq": {
+      const correct = (quiz.correct_answer ?? "").toString().trim();
+      const isCorrect = correct.length > 0 && selected.trim() === correct;
+      return { isCorrect, score: isCorrect ? 100 : 0, pending: false };
+    }
+    case "fill_blank": {
+      const correct = quiz.correct_answer ?? "";
+      const isCorrect =
+        correct.trim().length > 0 &&
+        normalizeAnswer(selected) === normalizeAnswer(correct);
+      return { isCorrect, score: isCorrect ? 100 : 0, pending: false };
+    }
+    case "scenario":
+    case "voice_text":
+    default:
+      // Open-ended → store the answer, mark pending for manager/AI review.
+      return { isCorrect: null, score: 0, pending: true };
+  }
+}

--- a/apps/web/src/lib/coaching/progress.test.ts
+++ b/apps/web/src/lib/coaching/progress.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { computeProgressScore } from "./progress";
+import type { CoachTarget } from "@maiyuri/shared";
+
+const target = (over: Partial<CoachTarget>): CoachTarget =>
+  ({
+    id: Math.random().toString(),
+    user_id: "u1",
+    target_type: "custom",
+    title: "t",
+    frequency: "daily",
+    status: "not_started",
+    completion_value: 0,
+    target_value: 1,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  }) as CoachTarget;
+
+describe("computeProgressScore", () => {
+  it("computes training completion + quiz average as rounded percentages", () => {
+    const score = computeProgressScore({
+      lessonsTotal: 8,
+      lessonsCompleted: 2,
+      gradedQuizScores: [100, 0, 100], // avg 66.67 -> 67
+      targets: [],
+      today: "2026-06-06",
+    });
+    expect(score.trainingCompletionPct).toBe(25);
+    expect(score.quizAveragePct).toBe(67);
+    expect(score.lessonsCompleted).toBe(2);
+    expect(score.lessonsTotal).toBe(8);
+  });
+
+  it("handles empty inputs without dividing by zero", () => {
+    const score = computeProgressScore({
+      lessonsTotal: 0,
+      lessonsCompleted: 0,
+      gradedQuizScores: [],
+      targets: [],
+      today: "2026-06-06",
+    });
+    expect(score.trainingCompletionPct).toBe(0);
+    expect(score.quizAveragePct).toBe(0);
+    expect(score.weekTargetCompletionPct).toBe(0);
+  });
+
+  it("counts today's daily targets (by due_date or undated)", () => {
+    const score = computeProgressScore({
+      lessonsTotal: 1,
+      lessonsCompleted: 0,
+      gradedQuizScores: [],
+      targets: [
+        target({ frequency: "daily", status: "completed", due_date: "2026-06-06" }),
+        target({ frequency: "daily", status: "not_started", due_date: null }),
+        target({ frequency: "daily", status: "completed", due_date: "2026-06-05" }), // not today
+      ],
+      today: "2026-06-06",
+    });
+    expect(score.todayTargetsTotal).toBe(2);
+    expect(score.todayTargetsCompleted).toBe(1);
+  });
+
+  it("computes weekly target completion percentage", () => {
+    const score = computeProgressScore({
+      lessonsTotal: 1,
+      lessonsCompleted: 1,
+      gradedQuizScores: [],
+      targets: [
+        target({ frequency: "weekly", status: "completed" }),
+        target({ frequency: "weekly", status: "completed" }),
+        target({ frequency: "weekly", status: "not_started" }),
+        target({ frequency: "weekly", status: "missed" }),
+      ],
+      today: "2026-06-06",
+    });
+    expect(score.weekTargetCompletionPct).toBe(50); // 2 of 4
+  });
+});

--- a/apps/web/src/lib/coaching/progress.ts
+++ b/apps/web/src/lib/coaching/progress.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure progress-aggregation helpers for the AI Sales Coach dashboard.
+ * No DB / no AI — fed plain rows so they are easily unit-tested.
+ */
+import type { CoachProgressScore, CoachTarget } from "@maiyuri/shared";
+
+export interface ProgressInputs {
+  lessonsTotal: number;
+  lessonsCompleted: number;
+  /** Scores (0–100) of graded quiz attempts (exclude pending). */
+  gradedQuizScores: number[];
+  /** All of this learner's targets (any frequency/date). */
+  targets: Pick<CoachTarget, "frequency" | "status" | "due_date">[];
+  /** ISO date (YYYY-MM-DD) treated as "today". */
+  today: string;
+}
+
+function pct(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 100);
+}
+
+export function computeProgressScore(input: ProgressInputs): CoachProgressScore {
+  const {
+    lessonsTotal,
+    lessonsCompleted,
+    gradedQuizScores,
+    targets,
+    today,
+  } = input;
+
+  const quizAveragePct =
+    gradedQuizScores.length > 0
+      ? Math.round(
+          gradedQuizScores.reduce((a, b) => a + b, 0) / gradedQuizScores.length,
+        )
+      : 0;
+
+  const todays = targets.filter(
+    (t) => t.frequency === "daily" && (t.due_date ?? today) === today,
+  );
+  const todayDone = todays.filter((t) => t.status === "completed").length;
+
+  const weekly = targets.filter((t) => t.frequency === "weekly");
+  const weeklyDone = weekly.filter((t) => t.status === "completed").length;
+
+  return {
+    trainingCompletionPct: pct(lessonsCompleted, lessonsTotal),
+    quizAveragePct,
+    lessonsCompleted,
+    lessonsTotal,
+    todayTargetsCompleted: todayDone,
+    todayTargetsTotal: todays.length,
+    weekTargetCompletionPct: pct(weeklyDone, weekly.length),
+  };
+}

--- a/apps/web/src/lib/coaching/seed/content.ts
+++ b/apps/web/src/lib/coaching/seed/content.ts
@@ -1,0 +1,351 @@
+/**
+ * AI Sales Coach — seed content (Phase 1).
+ *
+ * Sourced from the PRD's Maiyuri-approved examples + the Maiyuri Bricks
+ * Knowledge Wiki (brand/product/objection/sales-coach), with gap topics
+ * authored here (engineer call, lead-temperature criteria, pricing/discount,
+ * factory-visit script). Everything keys off a stable `slug` so the seed
+ * script can upsert idempotently. Admins refine all of this via the CMS.
+ *
+ * Brand guardrails (from the wiki CLAUDE.md): proof-backed claims only — never
+ * "guaranteed cooler", "zero plastering", "100% waterproof", "carbon negative";
+ * structural suitability is "subject to engineer approval"; no competitor
+ * attacks; always end on a next step.
+ */
+
+export interface SeedQuiz {
+  slug: string;
+  question: string;
+  question_type: "mcq" | "fill_blank" | "scenario";
+  options?: { key: string; label: string }[];
+  correct_answer?: string;
+  explanation?: string;
+}
+export interface SeedLesson {
+  slug: string;
+  title: string;
+  objective?: string;
+  content: string;
+  examples?: string;
+  do_dont_notes?: string;
+  quizzes?: SeedQuiz[];
+}
+export interface SeedModule {
+  slug: string;
+  title: string;
+  description: string;
+  role_applicability: string[];
+  sequence_order: number;
+  lessons: SeedLesson[];
+}
+
+const ALL_PATHS = ["production_supervisor", "sales_executive", "factory_coordinator"];
+
+export const SEED_MODULES: SeedModule[] = [
+  {
+    slug: "brand-foundation",
+    title: "Maiyuri Brand Foundation",
+    description: "What Maiyuri stands for and how to represent it.",
+    role_applicability: ALL_PATHS,
+    sequence_order: 1,
+    lessons: [
+      {
+        slug: "what-maiyuri-represents",
+        title: "Why Maiyuri Bricks is not just another brick supplier",
+        objective: "Explain Maiyuri's value clearly to a customer.",
+        content:
+          "Maiyuri Bricks helps families build cooler, stronger, smarter homes using red soil-based smart interlock bricks rooted in Tamil construction wisdom. We are not only a brick seller — we provide product guidance, factory proof, project examples, and local Tamil Nadu support. Walls are a lifetime decision: paint and tiles can change later, but walls stay.",
+        examples:
+          "Customer: Why should I buy from Maiyuri?\nYou: Sir, if you are building your own house, wall material is a lifetime decision. Maiyuri helps you choose a smarter wall system with better comfort, proper guidance, and visible proof you can check at our factory.",
+        do_dont_notes:
+          "Do explain WHY (comfort, proof, local support). Don't just say 'our brick is best.' Don't attack competitors.",
+        quizzes: [
+          {
+            slug: "position-maiyuri",
+            question: "Maiyuri should be positioned mainly as:",
+            question_type: "mcq",
+            options: [
+              { key: "A", label: "Cheapest brick supplier" },
+              { key: "B", label: "Smart wall solution for stronger, cooler homes" },
+              { key: "C", label: "Normal brick alternative only" },
+              { key: "D", label: "A transport company" },
+            ],
+            correct_answer: "B",
+            explanation:
+              "Maiyuri competes on total wall value (comfort, strength, proof, local support) — not on being cheapest.",
+          },
+        ],
+      },
+      {
+        slug: "tone-of-communication",
+        title: "Speaking with confidence and humility",
+        objective: "Represent the brand well on calls and factory visits.",
+        content:
+          "Be clear, direct, encouraging and simple. Listen first, then explain. Customers trust proof more than claims — offer to show wall samples, project videos, strength-test videos and the factory process. Always close with a next action.",
+        do_dont_notes:
+          "Do acknowledge the concern before answering. Don't oversell or promise unrealistic benefits.",
+      },
+    ],
+  },
+  {
+    slug: "product-knowledge",
+    title: "Product Mastery",
+    description: "Smart interlock bricks, simply explained.",
+    role_applicability: ALL_PATHS,
+    sequence_order: 2,
+    lessons: [
+      {
+        slug: "what-is-smart-interlock",
+        title: "What is a smart interlock brick?",
+        objective: "Explain interlocking and its benefits simply.",
+        content:
+          "Normal bricks need more mortar and more wall finishing. Interlock bricks are designed to lock with each other, reduce dependency on mortar, improve alignment, and support faster construction. Maiyuri focuses on smart interlock bricks made for Tamil Nadu climate and customer needs. Lab-tested compressive strength for SmartBrick 6 is around 11 N/mm² and water absorption averages about 3% — but always state structural suitability is subject to engineer approval.",
+        examples:
+          "Customer: How is this different from normal brick?\nYou: Interlock bricks lock together, so you need less mortar and get better alignment and faster work. For your climate, that means a cooler, neater wall.",
+        do_dont_notes:
+          "Do cite verified figures and add 'subject to engineer approval' for structural claims. Don't promise an exact temperature drop or '100% waterproof'.",
+        quizzes: [
+          {
+            slug: "interlock-benefit",
+            question:
+              "Maiyuri Bricks should be explained based on total ______ value, not only brick price.",
+            question_type: "fill_blank",
+            correct_answer: "wall",
+            explanation: "We compare total wall value, not just the brick rate.",
+          },
+        ],
+      },
+      {
+        slug: "kerala-comparison",
+        title: "Maiyuri vs Kerala interlock bricks",
+        objective: "Handle the Kerala comparison fairly and with proof.",
+        content:
+          "Don't attack Kerala bricks. Reframe from brick price to total delivered cost: loading, transport, unloading, wastage, wall finish, local support and quality consistency. Maiyuri is made locally for Tamil Nadu customers, and the customer can visit the factory and check quality before deciding.",
+        examples:
+          "Customer: Kerala brick is cheaper.\nYou: I understand, sir. For your own house the right comparison is total delivered cost and long-term comfort — not only brick rate. You can visit our factory and check the quality before deciding.",
+        do_dont_notes:
+          "Do ask whether they're comparing brick rate or total delivered cost. Don't say 'Kerala brick is not good.'",
+      },
+    ],
+  },
+  {
+    slug: "customer-psychology",
+    title: "Customer Handling & Psychology",
+    description: "What customers care about and how to build trust.",
+    role_applicability: ["sales_executive", "production_supervisor"],
+    sequence_order: 3,
+    lessons: [
+      {
+        slug: "price-to-value",
+        title: "Shifting from price to value",
+        objective: "Move the conversation from brick price to total wall value.",
+        content:
+          "Customers compare price first because they fear paying more without understanding the difference. Acknowledge the concern, then explain total wall value: comfort, speed, quality, delivery reliability, finishing and long-term savings. Then move to a next step (factory visit, cost calculator, technical call).",
+        quizzes: [
+          {
+            slug: "price-objection-best",
+            question: "Best way to respond when a customer says the price is high?",
+            question_type: "mcq",
+            options: [
+              { key: "A", label: "Say our product is the best" },
+              { key: "B", label: "Immediately offer a discount" },
+              { key: "C", label: "Understand the concern and explain total value" },
+              { key: "D", label: "Ignore the concern" },
+            ],
+            correct_answer: "C",
+            explanation: "Acknowledge first, then explain total wall value — don't defend or discount reflexively.",
+          },
+        ],
+      },
+      {
+        slug: "lead-temperature",
+        title: "Hot, warm or cold? Reading the lead",
+        objective: "Classify a lead's temperature during the call.",
+        content:
+          "HOT: site finalised, starting soon, engineer aligned or open, asking for quote/visit. WARM: serious but comparing options or timeline 1–3 months out. COLD: early enquiry, no site/timeline, only price-curious. Set the next follow-up date based on temperature: hot within 24–48h, warm weekly, cold nurture.",
+        do_dont_notes:
+          "Do record temperature + next follow-up date after every call. Don't mark everyone 'hot'.",
+      },
+    ],
+  },
+  {
+    slug: "objection-handling",
+    title: "Objection Handling",
+    description: "Natural, brand-safe answers to common objections.",
+    role_applicability: ALL_PATHS,
+    sequence_order: 4,
+    lessons: [
+      {
+        slug: "engineer-doubt",
+        title: "When the engineer is hesitant",
+        objective: "Handle engineer/technical doubt and route correctly.",
+        content:
+          "Acknowledge the engineer's role — they are responsible for safety. Offer technical specs and lab reports, share proof (wall samples, project videos), and suggest a technical discussion or factory visit. For structural decisions, always defer to engineer approval and, when unsure, connect the customer to Maiyuri's technical person or the owner.",
+        examples:
+          "Customer: My engineer says normal brick is safer.\nYou: That's fair, sir — your engineer is right to be careful. Can we share our lab reports and arrange a short technical call or factory visit so your engineer can decide with full information?",
+        do_dont_notes:
+          "Do respect the engineer and offer proof + a technical next step. Don't give structural advice beyond approved knowledge.",
+        quizzes: [
+          {
+            slug: "engineer-scenario",
+            question:
+              "A customer says: 'My engineer does not recommend interlock bricks.' What should you do?",
+            question_type: "scenario",
+            explanation:
+              "Acknowledge the engineer's role, offer technical specs + proof, and suggest a factory visit or technical discussion. Defer structural calls to the engineer.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "factory-visit",
+    title: "Factory Visit Excellence",
+    description: "Turn a factory visit into a confident next step.",
+    role_applicability: ["production_supervisor", "factory_coordinator"],
+    sequence_order: 5,
+    lessons: [
+      {
+        slug: "factory-visit-script",
+        title: "A 5-minute factory visit explanation",
+        objective: "Welcome visitors and explain the process clearly.",
+        content:
+          "1) Welcome warmly and ask about their project. 2) Show the red-soil raw material and explain why it suits Tamil Nadu homes. 3) Walk through production and interlock forming. 4) Show finished bricks and how to check quality. 5) Explain quality checks. 6) Close: ask for the next step — share plan/wall quantity, get a quote, or connect with the technical person.",
+        do_dont_notes:
+          "Do end every visit with a clear next action. Don't overwhelm with jargon — keep it simple and proof-led.",
+      },
+    ],
+  },
+  {
+    slug: "sales-followup",
+    title: "Sales Follow-Up Discipline",
+    description: "Follow-up that closes the next action.",
+    role_applicability: ["sales_executive", "production_supervisor"],
+    sequence_order: 6,
+    lessons: [
+      {
+        slug: "followup-next-action",
+        title: "Always close the next action",
+        objective: "End every customer contact with a clear next step.",
+        content:
+          "Follow-up matters because most orders happen after several touches. Classify the lead (hot/warm/cold), update status + next follow-up date, and send a short WhatsApp recap. Never sound desperate — be helpful and specific. Always end with one clear next action: factory visit, cost calculator, plan/quantity share, or technical call.",
+        quizzes: [
+          {
+            slug: "followup-end",
+            question: "Every customer call should end with:",
+            question_type: "mcq",
+            options: [
+              { key: "A", label: "A general 'we'll talk later'" },
+              { key: "B", label: "One clear next action and a follow-up date" },
+              { key: "C", label: "A discount offer" },
+              { key: "D", label: "Nothing — wait for the customer" },
+            ],
+            correct_answer: "B",
+            explanation: "A specific next action + follow-up date keeps the lead moving.",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export interface SeedAssignment {
+  slug: string;
+  title: string;
+  description: string;
+  assignment_type:
+    | "product_explanation"
+    | "lead_followup"
+    | "objection_practice"
+    | "factory_explanation"
+    | "reflection"
+    | "custom";
+  due_frequency: "daily" | "weekly" | "once";
+}
+
+export const SEED_ASSIGNMENTS: SeedAssignment[] = [
+  {
+    slug: "product-explanation-60s",
+    title: "Explain Maiyuri Smart Interlock Bricks in 60 seconds",
+    description: "Type a simple, confident, customer-friendly explanation.",
+    assignment_type: "product_explanation",
+    due_frequency: "daily",
+  },
+  {
+    slug: "followup-5-leads",
+    title: "Follow up with 5 leads and update their status",
+    description:
+      "For each: customer concern, current status, next follow-up date, interest level, notes.",
+    assignment_type: "lead_followup",
+    due_frequency: "daily",
+  },
+  {
+    slug: "objection-regular-bricks",
+    title: "Answer today's objection: 'Why should I not use regular bricks?'",
+    description: "Acknowledge, explain total wall value, end with a next action.",
+    assignment_type: "objection_practice",
+    due_frequency: "daily",
+  },
+  {
+    slug: "daily-reflection",
+    title: "Daily reflection",
+    description:
+      "What customer question was difficult today? What did you learn? Where do you need help?",
+    assignment_type: "reflection",
+    due_frequency: "daily",
+  },
+];
+
+export interface SeedKnowledge {
+  slug: string;
+  category:
+    | "brand_story"
+    | "product"
+    | "pricing"
+    | "kerala_comparison"
+    | "objection"
+    | "approved_phrases"
+    | "avoid_phrases"
+    | "factory_visit"
+    | "faq";
+  title: string;
+  content: string;
+}
+
+export const SEED_KNOWLEDGE: SeedKnowledge[] = [
+  {
+    slug: "kb-brand-promise",
+    category: "brand_story",
+    title: "Brand promise",
+    content:
+      "Maiyuri helps families build cooler, stronger, smarter homes using red soil-based smart interlock bricks rooted in Tamil construction wisdom. We sell guidance + proof + local support, not just bricks.",
+  },
+  {
+    slug: "kb-approved-phrases",
+    category: "approved_phrases",
+    title: "Approved phrases",
+    content:
+      "‘total wall value’, ‘subject to engineer approval’, ‘you can visit the factory and check’, ‘lab-tested’, ‘made locally for Tamil Nadu’.",
+  },
+  {
+    slug: "kb-avoid-phrases",
+    category: "avoid_phrases",
+    title: "Phrases to avoid",
+    content:
+      "Never say: ‘guaranteed cooler’, ‘zero plastering’, ‘100% waterproof’, ‘carbon negative’, or attack competitors. No fixed temperature-drop promises.",
+  },
+  {
+    slug: "kb-price-objection",
+    category: "objection",
+    title: "Objection: costlier than Kerala brick",
+    content:
+      "Acknowledge, then reframe to total delivered cost (loading, transport, unloading, wastage, wall finish, local support, quality). Follow-up question: ‘Are you comparing only brick rate, or total delivered cost?’ Next action: send cost calculator + invite factory visit.",
+  },
+  {
+    slug: "kb-lead-temperature",
+    category: "faq",
+    title: "Lead temperature criteria",
+    content:
+      "HOT: site finalised + starting soon + asking for quote/visit. WARM: serious but comparing / 1–3 months out. COLD: early, no site/timeline, price-curious.",
+  },
+];

--- a/apps/web/src/lib/user-manual.ts
+++ b/apps/web/src/lib/user-manual.ts
@@ -435,15 +435,16 @@ export const manualContent: Record<ManualSection, ManualContent> = {
 
   coaching: {
     id: "coaching",
-    title: "Sales Coaching",
+    title: "AI Sales Coach",
     description:
-      "AI-powered coaching insights from call recordings. Improve sales performance.",
+      "Your daily training hub: learn modules, take quizzes, do assignments, hit targets, and get AI feedback on lead handling.",
     path: "/coaching",
     quickStart: [
-      "View coaching insights by staff",
-      "See missed opportunities",
-      "Learn from successful calls",
-      "Track improvement over time",
+      "Open your Today's Coaching Plan",
+      "Work through a lesson, then take its quiz",
+      "Submit the day's assignment for review",
+      "Mark your daily targets done",
+      "Check AI Feedback for lead-handling tips",
     ],
     steps: [
       {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1117,3 +1117,202 @@ export type UpdateWbsItemInput = z.infer<typeof updateWbsItemSchema>;
 export type CreateDailyProgressInput = z.infer<typeof createDailyProgressSchema>;
 export type CreateCostEntryInput = z.infer<typeof createCostEntrySchema>;
 export type SetupAssistantInput = z.infer<typeof setupAssistantSchema>;
+
+// ============================================================================
+// AI SALES COACH (Phase 1) — zod schemas
+// ============================================================================
+export const coachTrainingPathSchema = z.enum([
+  "production_supervisor",
+  "sales_executive",
+  "factory_coordinator",
+  "site_engineer",
+  "accounts_assistant",
+  "delivery_coordinator",
+]);
+export const coachDifficultySchema = z.enum(["beginner", "intermediate", "advanced"]);
+export const quizQuestionTypeSchema = z.enum(["mcq", "scenario", "fill_blank", "voice_text"]);
+export const coachAssignmentTypeSchema = z.enum([
+  "product_explanation",
+  "lead_followup",
+  "objection_practice",
+  "factory_explanation",
+  "reflection",
+  "custom",
+]);
+export const coachFrequencySchema = z.enum(["daily", "weekly", "once"]);
+export const coachEvaluationMethodSchema = z.enum(["ai", "manager", "both", "self"]);
+export const coachManagerStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "needs_improvement",
+  "rejected",
+]);
+export const coachTargetTypeSchema = z.enum([
+  "learning",
+  "quiz",
+  "roleplay",
+  "sales_followup",
+  "production_update",
+  "reflection",
+  "custom",
+]);
+export const coachTargetStatusSchema = z.enum([
+  "not_started",
+  "in_progress",
+  "completed",
+  "missed",
+  "needs_review",
+]);
+export const coachKnowledgeCategorySchema = z.enum([
+  "brand_story",
+  "product",
+  "pricing",
+  "kerala_comparison",
+  "regular_comparison",
+  "factory_process",
+  "quality",
+  "delivery",
+  "faq",
+  "objection",
+  "approved_phrases",
+  "avoid_phrases",
+  "proof_links",
+  "reviews",
+  "project_videos",
+  "cost_calculator",
+  "factory_visit",
+]);
+
+const quizOptionSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+});
+
+// --- Admin CMS: modules / lessons / quizzes / assignments / knowledge ---
+export const createCoachModuleSchema = z.object({
+  slug: z.string().min(1),
+  title: z.string().min(1, "Title is required"),
+  description: emptyStringToNull(z.string().nullable().optional()),
+  role_applicability: z.array(z.string()).default([]),
+  difficulty: coachDifficultySchema.default("beginner"),
+  estimated_minutes: optionalNumber(),
+  sequence_order: optionalNumber(),
+  is_required: z.boolean().default(true),
+  is_active: z.boolean().default(true),
+});
+export const updateCoachModuleSchema = createCoachModuleSchema.partial();
+
+export const createCoachLessonSchema = z.object({
+  module_id: z.string().uuid(),
+  slug: z.string().min(1),
+  title: z.string().min(1, "Title is required"),
+  objective: emptyStringToNull(z.string().nullable().optional()),
+  content: z.string().default(""),
+  examples: emptyStringToNull(z.string().nullable().optional()),
+  do_dont_notes: emptyStringToNull(z.string().nullable().optional()),
+  estimated_minutes: optionalNumber(),
+  sequence_order: optionalNumber(),
+  is_active: z.boolean().default(true),
+});
+export const updateCoachLessonSchema = createCoachLessonSchema.partial();
+
+export const createCoachQuizSchema = z.object({
+  slug: z.string().min(1),
+  lesson_id: emptyStringToNull(z.string().uuid().nullable().optional()),
+  module_id: emptyStringToNull(z.string().uuid().nullable().optional()),
+  question: z.string().min(1, "Question is required"),
+  question_type: quizQuestionTypeSchema.default("mcq"),
+  options_json: z.array(quizOptionSchema).default([]),
+  correct_answer: emptyStringToNull(z.string().nullable().optional()),
+  explanation: emptyStringToNull(z.string().nullable().optional()),
+  suggested_lesson_id: emptyStringToNull(z.string().uuid().nullable().optional()),
+  difficulty: coachDifficultySchema.default("beginner"),
+  sequence_order: optionalNumber(),
+  is_active: z.boolean().default(true),
+});
+export const updateCoachQuizSchema = createCoachQuizSchema.partial();
+
+export const createCoachAssignmentSchema = z.object({
+  slug: z.string().min(1),
+  title: z.string().min(1, "Title is required"),
+  description: emptyStringToNull(z.string().nullable().optional()),
+  module_id: emptyStringToNull(z.string().uuid().nullable().optional()),
+  assignment_type: coachAssignmentTypeSchema.default("custom"),
+  due_frequency: coachFrequencySchema.default("daily"),
+  evaluation_method: coachEvaluationMethodSchema.default("manager"),
+  is_active: z.boolean().default(true),
+});
+export const updateCoachAssignmentSchema = createCoachAssignmentSchema.partial();
+
+export const createCoachKnowledgeSchema = z.object({
+  slug: z.string().min(1),
+  category: coachKnowledgeCategorySchema.default("faq"),
+  title: z.string().min(1, "Title is required"),
+  content: z.string().default(""),
+  source_link: emptyStringToNull(z.string().nullable().optional()),
+  tags: z.array(z.string()).default([]),
+  is_active: z.boolean().default(true),
+});
+export const updateCoachKnowledgeSchema = createCoachKnowledgeSchema.partial();
+
+// --- Targets (admin assigns; learner updates progress) ---
+export const createCoachTargetSchema = z.object({
+  user_id: z.string().uuid(),
+  target_type: coachTargetTypeSchema.default("custom"),
+  title: z.string().min(1, "Title is required"),
+  description: emptyStringToNull(z.string().nullable().optional()),
+  due_date: emptyStringToNull(z.string().nullable().optional()),
+  frequency: coachFrequencySchema.default("daily"),
+  target_value: optionalNumber(),
+});
+export const updateCoachTargetSchema = z.object({
+  status: coachTargetStatusSchema.optional(),
+  completion_value: optionalNumber(),
+});
+
+// --- Learner actions ---
+export const completeLessonSchema = z.object({
+  lesson_id: z.string().uuid(),
+});
+export const submitQuizAttemptSchema = z.object({
+  quiz_id: z.string().uuid(),
+  selected_answer: z.string().min(1, "An answer is required"),
+});
+export const submitAssignmentSchema = z.object({
+  assignment_id: z.string().uuid(),
+  submission_text: emptyStringToNull(z.string().nullable().optional()),
+  attachment_url: emptyStringToNull(z.string().nullable().optional()),
+});
+
+// --- Manager review of a submission ---
+export const reviewSubmissionSchema = z.object({
+  manager_status: coachManagerStatusSchema,
+  manager_comment: emptyStringToNull(z.string().nullable().optional()),
+});
+
+// --- Learner profile (training path) ---
+export const upsertCoachUserSchema = z.object({
+  user_id: z.string().uuid(),
+  role: emptyStringToNull(z.string().nullable().optional()),
+  training_path: coachTrainingPathSchema.default("production_supervisor"),
+  joining_date: emptyStringToNull(z.string().nullable().optional()),
+  active_status: z.boolean().default(true),
+});
+
+export type CreateCoachModuleInput = z.infer<typeof createCoachModuleSchema>;
+export type UpdateCoachModuleInput = z.infer<typeof updateCoachModuleSchema>;
+export type CreateCoachLessonInput = z.infer<typeof createCoachLessonSchema>;
+export type UpdateCoachLessonInput = z.infer<typeof updateCoachLessonSchema>;
+export type CreateCoachQuizInput = z.infer<typeof createCoachQuizSchema>;
+export type UpdateCoachQuizInput = z.infer<typeof updateCoachQuizSchema>;
+export type CreateCoachAssignmentInput = z.infer<typeof createCoachAssignmentSchema>;
+export type UpdateCoachAssignmentInput = z.infer<typeof updateCoachAssignmentSchema>;
+export type CreateCoachKnowledgeInput = z.infer<typeof createCoachKnowledgeSchema>;
+export type UpdateCoachKnowledgeInput = z.infer<typeof updateCoachKnowledgeSchema>;
+export type CreateCoachTargetInput = z.infer<typeof createCoachTargetSchema>;
+export type UpdateCoachTargetInput = z.infer<typeof updateCoachTargetSchema>;
+export type CompleteLessonInput = z.infer<typeof completeLessonSchema>;
+export type SubmitQuizAttemptInput = z.infer<typeof submitQuizAttemptSchema>;
+export type SubmitAssignmentInput = z.infer<typeof submitAssignmentSchema>;
+export type ReviewSubmissionInput = z.infer<typeof reviewSubmissionSchema>;
+export type UpsertCoachUserInput = z.infer<typeof upsertCoachUserSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1846,3 +1846,251 @@ export interface CostEntry {
   created_by?: string | null;
   created_at: string;
 }
+
+// ============================================================================
+// AI SALES COACH (Phase 1 — Foundation)
+// Training + coaching system: modules → lessons → quizzes → assignments,
+// daily/weekly targets, progress, knowledge base. AI fields (Phase 2) nullable.
+// ============================================================================
+export type CoachTrainingPath =
+  | "production_supervisor"
+  | "sales_executive"
+  | "factory_coordinator"
+  | "site_engineer"
+  | "accounts_assistant"
+  | "delivery_coordinator";
+
+export type CoachDifficulty = "beginner" | "intermediate" | "advanced";
+
+export type QuizQuestionType = "mcq" | "scenario" | "fill_blank" | "voice_text";
+
+export type CoachAssignmentType =
+  | "product_explanation"
+  | "lead_followup"
+  | "objection_practice"
+  | "factory_explanation"
+  | "reflection"
+  | "custom";
+
+export type CoachFrequency = "daily" | "weekly" | "once";
+
+export type CoachEvaluationMethod = "ai" | "manager" | "both" | "self";
+
+export type CoachManagerStatus =
+  | "pending"
+  | "approved"
+  | "needs_improvement"
+  | "rejected";
+
+export type CoachTargetType =
+  | "learning"
+  | "quiz"
+  | "roleplay"
+  | "sales_followup"
+  | "production_update"
+  | "reflection"
+  | "custom";
+
+export type CoachTargetStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "missed"
+  | "needs_review";
+
+export type CoachLessonProgressStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed";
+
+export type CoachKnowledgeCategory =
+  | "brand_story"
+  | "product"
+  | "pricing"
+  | "kerala_comparison"
+  | "regular_comparison"
+  | "factory_process"
+  | "quality"
+  | "delivery"
+  | "faq"
+  | "objection"
+  | "approved_phrases"
+  | "avoid_phrases"
+  | "proof_links"
+  | "reviews"
+  | "project_videos"
+  | "cost_calculator"
+  | "factory_visit";
+
+export interface CoachUser {
+  id: string;
+  user_id: string;
+  role?: string | null;
+  training_path: CoachTrainingPath;
+  joining_date?: string | null;
+  current_level: number;
+  active_status: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachModule {
+  id: string;
+  slug: string;
+  title: string;
+  description?: string | null;
+  role_applicability: string[];
+  difficulty: CoachDifficulty;
+  estimated_minutes: number;
+  sequence_order: number;
+  is_required: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachLesson {
+  id: string;
+  module_id: string;
+  slug: string;
+  title: string;
+  objective?: string | null;
+  content: string;
+  examples?: string | null;
+  do_dont_notes?: string | null;
+  estimated_minutes: number;
+  sequence_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachQuizOption {
+  key: string;
+  label: string;
+}
+
+export interface CoachQuiz {
+  id: string;
+  slug: string;
+  lesson_id?: string | null;
+  module_id?: string | null;
+  question: string;
+  question_type: QuizQuestionType;
+  options_json: CoachQuizOption[];
+  correct_answer?: string | null;
+  explanation?: string | null;
+  suggested_lesson_id?: string | null;
+  difficulty: CoachDifficulty;
+  sequence_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachLessonProgress {
+  id: string;
+  user_id: string;
+  lesson_id: string;
+  status: CoachLessonProgressStatus;
+  completed_at: string;
+}
+
+export interface CoachQuizAttempt {
+  id: string;
+  user_id: string;
+  quiz_id: string;
+  selected_answer?: string | null;
+  is_correct?: boolean | null;
+  score: number;
+  ai_feedback?: string | null;
+  attempted_at: string;
+}
+
+export interface CoachAssignment {
+  id: string;
+  slug: string;
+  title: string;
+  description?: string | null;
+  module_id?: string | null;
+  assignment_type: CoachAssignmentType;
+  due_frequency: CoachFrequency;
+  evaluation_method: CoachEvaluationMethod;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachAssignmentSubmission {
+  id: string;
+  assignment_id: string;
+  user_id: string;
+  submission_text?: string | null;
+  attachment_url?: string | null;
+  ai_score?: number | null;
+  ai_feedback?: string | null;
+  manager_status: CoachManagerStatus;
+  manager_comment?: string | null;
+  submitted_at: string;
+}
+
+export interface CoachRoleplay {
+  id: string;
+  user_id: string;
+  scenario_type: string;
+  conversation_json: Array<{ role: "customer" | "employee"; content: string }>;
+  ai_score?: number | null;
+  clarity_score?: number | null;
+  empathy_score?: number | null;
+  product_score?: number | null;
+  closing_score?: number | null;
+  ai_feedback?: string | null;
+  created_at: string;
+}
+
+export interface CoachTarget {
+  id: string;
+  user_id: string;
+  target_type: CoachTargetType;
+  title: string;
+  description?: string | null;
+  due_date?: string | null;
+  frequency: CoachFrequency;
+  status: CoachTargetStatus;
+  completion_value: number;
+  target_value: number;
+  created_by?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoachKnowledgeArticle {
+  id: string;
+  slug: string;
+  category: CoachKnowledgeCategory;
+  title: string;
+  content: string;
+  source_link?: string | null;
+  tags: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// Learner dashboard bundle (GET /api/coaching/me)
+export interface CoachProgressScore {
+  trainingCompletionPct: number;
+  quizAveragePct: number;
+  lessonsCompleted: number;
+  lessonsTotal: number;
+  todayTargetsCompleted: number;
+  todayTargetsTotal: number;
+  weekTargetCompletionPct: number;
+}
+
+export interface CoachTodayPlanItem {
+  kind: "lesson" | "quiz" | "assignment" | "target";
+  refId: string;
+  title: string;
+  done: boolean;
+}

--- a/supabase/migrations/20260606000001_ai_sales_coach.sql
+++ b/supabase/migrations/20260606000001_ai_sales_coach.sql
@@ -1,0 +1,235 @@
+-- AI Sales Coach — Phase 1 (Foundation, no AI yet)
+-- Training + coaching system: modules → lessons → quizzes → assignments,
+-- daily/weekly targets, progress tracking, knowledge base, admin CMS.
+-- Phase-2 AI columns (ai_score, ai_feedback, *_score, conversation_json) are
+-- created now but left nullable. Conventions mirror projects_core / smart_quotes:
+-- UUID PK, FKs, JSONB, CHECK enums, created_at/updated_at (app sets updated_at),
+-- indexes, RLS enabled with an authenticated-staff policy (service role bypasses).
+-- Stable `slug`/`(user_id,...)` uniques enable idempotent content seeding.
+
+-- ============================================================================
+-- LEARNER PROFILE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE,
+  role TEXT,
+  training_path TEXT NOT NULL DEFAULT 'production_supervisor'
+    CHECK (training_path IN (
+      'production_supervisor','sales_executive','factory_coordinator',
+      'site_engineer','accounts_assistant','delivery_coordinator')),
+  joining_date DATE,
+  current_level INTEGER NOT NULL DEFAULT 1,
+  active_status BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ============================================================================
+-- CONTENT LIBRARY — modules → lessons → quizzes
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_modules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  role_applicability TEXT[] NOT NULL DEFAULT '{}',
+  difficulty TEXT NOT NULL DEFAULT 'beginner'
+    CHECK (difficulty IN ('beginner','intermediate','advanced')),
+  estimated_minutes INTEGER NOT NULL DEFAULT 10,
+  sequence_order INTEGER NOT NULL DEFAULT 0,
+  is_required BOOLEAN NOT NULL DEFAULT true,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.coach_lessons (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  module_id UUID NOT NULL REFERENCES public.coach_modules(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  objective TEXT,
+  content TEXT NOT NULL DEFAULT '',
+  examples TEXT,
+  do_dont_notes TEXT,
+  estimated_minutes INTEGER NOT NULL DEFAULT 5,
+  sequence_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_lessons_module ON public.coach_lessons(module_id);
+
+CREATE TABLE IF NOT EXISTS public.coach_quizzes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  lesson_id UUID REFERENCES public.coach_lessons(id) ON DELETE CASCADE,
+  module_id UUID REFERENCES public.coach_modules(id) ON DELETE CASCADE,
+  question TEXT NOT NULL,
+  question_type TEXT NOT NULL DEFAULT 'mcq'
+    CHECK (question_type IN ('mcq','scenario','fill_blank','voice_text')),
+  options_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  correct_answer TEXT,
+  explanation TEXT,
+  suggested_lesson_id UUID REFERENCES public.coach_lessons(id) ON DELETE SET NULL,
+  difficulty TEXT NOT NULL DEFAULT 'beginner'
+    CHECK (difficulty IN ('beginner','intermediate','advanced')),
+  sequence_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_quizzes_lesson ON public.coach_quizzes(lesson_id);
+CREATE INDEX IF NOT EXISTS idx_coach_quizzes_module ON public.coach_quizzes(module_id);
+
+-- ============================================================================
+-- LEARNER ACTIVITY — lesson progress, quiz attempts
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_lesson_progress (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  lesson_id UUID NOT NULL REFERENCES public.coach_lessons(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'completed'
+    CHECK (status IN ('not_started','in_progress','completed')),
+  completed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, lesson_id)
+);
+CREATE INDEX IF NOT EXISTS idx_coach_lesson_progress_user ON public.coach_lesson_progress(user_id);
+
+CREATE TABLE IF NOT EXISTS public.coach_quiz_attempts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  quiz_id UUID NOT NULL REFERENCES public.coach_quizzes(id) ON DELETE CASCADE,
+  selected_answer TEXT,
+  is_correct BOOLEAN,            -- null = pending review (scenario/voice_text)
+  score NUMERIC NOT NULL DEFAULT 0,
+  ai_feedback TEXT,              -- Phase 2
+  attempted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_quiz_attempts_user ON public.coach_quiz_attempts(user_id);
+CREATE INDEX IF NOT EXISTS idx_coach_quiz_attempts_quiz ON public.coach_quiz_attempts(quiz_id);
+
+-- ============================================================================
+-- ASSIGNMENTS + submissions
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  module_id UUID REFERENCES public.coach_modules(id) ON DELETE SET NULL,
+  assignment_type TEXT NOT NULL DEFAULT 'custom'
+    CHECK (assignment_type IN (
+      'product_explanation','lead_followup','objection_practice',
+      'factory_explanation','reflection','custom')),
+  due_frequency TEXT NOT NULL DEFAULT 'daily'
+    CHECK (due_frequency IN ('daily','weekly','once')),
+  evaluation_method TEXT NOT NULL DEFAULT 'manager'
+    CHECK (evaluation_method IN ('ai','manager','both','self')),
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.coach_assignment_submissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id UUID NOT NULL REFERENCES public.coach_assignments(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  submission_text TEXT,
+  attachment_url TEXT,
+  ai_score NUMERIC,             -- Phase 2
+  ai_feedback TEXT,             -- Phase 2
+  manager_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (manager_status IN ('pending','approved','needs_improvement','rejected')),
+  manager_comment TEXT,
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_subs_assignment ON public.coach_assignment_submissions(assignment_id);
+CREATE INDEX IF NOT EXISTS idx_coach_subs_user ON public.coach_assignment_submissions(user_id);
+
+-- ============================================================================
+-- ROLEPLAYS (Phase 2 populated; table created now)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_roleplays (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  scenario_type TEXT NOT NULL,
+  conversation_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ai_score NUMERIC,
+  clarity_score NUMERIC,
+  empathy_score NUMERIC,
+  product_score NUMERIC,
+  closing_score NUMERIC,
+  ai_feedback TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_roleplays_user ON public.coach_roleplays(user_id);
+
+-- ============================================================================
+-- TARGETS (daily / weekly)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_targets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  target_type TEXT NOT NULL DEFAULT 'custom'
+    CHECK (target_type IN (
+      'learning','quiz','roleplay','sales_followup',
+      'production_update','reflection','custom')),
+  title TEXT NOT NULL,
+  description TEXT,
+  due_date DATE,
+  frequency TEXT NOT NULL DEFAULT 'daily'
+    CHECK (frequency IN ('daily','weekly','once')),
+  status TEXT NOT NULL DEFAULT 'not_started'
+    CHECK (status IN ('not_started','in_progress','completed','missed','needs_review')),
+  completion_value NUMERIC NOT NULL DEFAULT 0,
+  target_value NUMERIC NOT NULL DEFAULT 1,
+  created_by UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_targets_user ON public.coach_targets(user_id);
+CREATE INDEX IF NOT EXISTS idx_coach_targets_due ON public.coach_targets(due_date);
+
+-- ============================================================================
+-- KNOWLEDGE BASE (grounds Phase-2 AI; admin-managed)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.coach_knowledge_base (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  category TEXT NOT NULL DEFAULT 'faq'
+    CHECK (category IN (
+      'brand_story','product','pricing','kerala_comparison','regular_comparison',
+      'factory_process','quality','delivery','faq','objection','approved_phrases',
+      'avoid_phrases','proof_links','reviews','project_videos','cost_calculator',
+      'factory_visit')),
+  title TEXT NOT NULL,
+  content TEXT NOT NULL DEFAULT '',
+  source_link TEXT,
+  tags TEXT[] NOT NULL DEFAULT '{}',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_coach_kb_category ON public.coach_knowledge_base(category);
+
+-- ============================================================================
+-- RLS — enable + authenticated-staff full access (service role bypasses)
+-- ============================================================================
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'coach_users','coach_modules','coach_lessons','coach_quizzes',
+    'coach_lesson_progress','coach_quiz_attempts','coach_assignments',
+    'coach_assignment_submissions','coach_roleplays','coach_targets',
+    'coach_knowledge_base'
+  ] LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY;', t);
+    EXECUTE format('DROP POLICY IF EXISTS %I_auth_all ON public.%I;', t, t);
+    EXECUTE format(
+      'CREATE POLICY %I_auth_all ON public.%I FOR ALL USING (auth.role() = ''authenticated'') WITH CHECK (auth.role() = ''authenticated'');',
+      t, t);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
Adds the **AI Sales Coach** — an in-app training + coaching hub for the new Production Supervisor and future hires (PRD Phase 1, foundation, **no new AI yet**).

Extends the existing `/coaching` route: the current AI performance-analysis page moves to `/coaching/performance` (untouched) and is surfaced as the "AI Feedback" section feeding the training plan.

## What's included
- **Migration** `20260606000001_ai_sales_coach.sql` — 11 `coach_*` tables (Projects-style: UUID PK, CHECK enums, JSONB, indexes, RLS authenticated-all). Phase-2 AI columns created but nullable.
- **Shared types + zod schemas** (reuse `emptyStringToNull`/`optionalNumber`).
- **API** under `app/api/coaching/*`: dashboard bundle (`me`), modules/lessons (+complete), quizzes (+**deterministic-graded** attempt), assignments (+submit), submissions (manager review), targets, knowledge, admin/progress. Learner vs founder/owner gating; quiz answers never leaked before answering.
- **Pure, unit-tested helpers**: `grading.ts` + `progress.ts` (10 tests).
- **UI**: hub dashboard, learning library + lesson detail + quiz runner, assignments, targets, weekly review, tabbed **admin CMS**.
- **Nav/roles**: `production_supervisor` + `sales` gain coaching; manual updated.
- **Seed**: brand-safe content (from PRD + Knowledge Wiki + gap topics) applied idempotently via `scripts/seed-coaching.ts`.

## Deferred (designed for, not built)
Phase 2 AI (roleplay chat, AI scoring/feedback, quiz generation, KB-grounded answers) → reuses `nudge-ai.ts` Claude pattern + `ai/models.ts`. Phase 3 cron coaching messages via push/Telegram.

## Verification
- typecheck 4/4 · lint 0 errors · apps/web tests **305/305**.
- After merge + migration: run `cd apps/web && bun run scripts/seed-coaching.ts`.

> Base is `ci/coderabbit-hardening` (stacked) because the CI/lint fixes it carries aren't in `main` yet. Rebase to `main` once that PR merges.
> ⚠️ Prod Supabase migration apply is a separate gated step (needs explicit go-ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launches AI Sales Coach: coaching hub, learning library, lesson pages, quiz runner, weekly review, targets, assignments, and admin console for content management.
  * Learner flows: mark-complete, submit assignments, take graded quizzes, view progress and personalized “Today” plan.
  * Leads: AI Summary viewer and updated WhatsApp Business share label.

* **Documentation**
  * Updated Coaching section in the user manual to “AI Sales Coach”.

* **Tests**
  * Added unit tests for quiz grading and progress scoring.

* **Chores**
  * Database schema and seed content for AI Sales Coach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->