### PR TITLE
feat(coaching): Phase 2 M1 — AI auto-grading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,6 @@ LANGFUSE_BASE_URL=https://cloud.langfuse.com
 # AI Cost Alerting (optional)
 AI_DAILY_COST_ALERT_USD=50
 AI_ERROR_RATE_ALERT_PERCENT=5
+
+# AI Coaching auto-grading kill-switch (optional)
+COACH_AI_ENABLED=true # set to "false" to disable AI auto-grading (coaching)

--- a/apps/web/app/(dashboard)/coaching/assignments/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/assignments/page.tsx
@@ -56,7 +56,20 @@ function AssignmentCard({ a, onDone }: { a: AssignmentRow; onDone: () => void })
             </span>
             <span className="text-xs text-slate-400">Last submission</span>
           </div>
-          <p className="whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-300">
+          {a.mySubmission.ai_score != null && (
+            <div className="mt-2 space-y-1">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                  AI score: {a.mySubmission.ai_score}/100
+                </span>
+                <span className="text-xs text-slate-400 italic">AI-graded · manager can adjust</span>
+              </div>
+              {a.mySubmission.ai_feedback && (
+                <p className="text-xs text-slate-500 dark:text-slate-400">{a.mySubmission.ai_feedback}</p>
+              )}
+            </div>
+          )}
+          <p className="mt-2 whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-300">
             {a.mySubmission.submission_text}
           </p>
           {a.mySubmission.manager_comment && (

--- a/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
@@ -14,6 +14,8 @@ interface AttemptResult {
   correct_answer: string | null;
   explanation: string | null;
   suggested_lesson_id: string | null;
+  feedback: string | null;
+  gaps: string[] | null;
 }
 
 export default function QuizRunnerPage() {
@@ -117,6 +119,17 @@ export default function QuizRunnerPage() {
                   : "❌ Not quite"}
             </div>
             {result.explanation && <p className="mt-1">{result.explanation}</p>}
+            {result.feedback && <p className="mt-2">{result.feedback}</p>}
+            {result.gaps && result.gaps.length > 0 && (
+              <div className="mt-2">
+                <p className="font-medium">To improve:</p>
+                <ul className="mt-1 list-disc pl-4 space-y-0.5">
+                  {result.gaps.map((gap, i) => (
+                    <li key={i}>{gap}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             {result.suggested_lesson_id && (
               <Link
                 href={`/coaching/learn/${result.suggested_lesson_id}`}

--- a/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
@@ -125,7 +125,7 @@ export default function QuizRunnerPage() {
                 <p className="font-medium">To improve:</p>
                 <ul className="mt-1 list-disc pl-4 space-y-0.5">
                   {result.gaps.map((gap, i) => (
-                    <li key={i}>{gap}</li>
+                    <li key={`${i}-${gap}`}>{gap}</li>
                   ))}
                 </ul>
               </div>

--- a/apps/web/app/api/coaching/assignments/[id]/submit/route.ts
+++ b/apps/web/app/api/coaching/assignments/[id]/submit/route.ts
@@ -1,10 +1,12 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest } from "next/server";
-import { success, error, unauthorized, parseBody } from "@/lib/api-utils";
+import { success, error, notFound, unauthorized, parseBody } from "@/lib/api-utils";
 import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { getCoachContext } from "@/lib/coaching/context";
-import type { CoachAssignmentSubmission } from "@maiyuri/shared";
+import { scoreAssignment } from "@/lib/coaching/ai/grade";
+import { isCoachAiEnabled } from "@/lib/coaching/ai/flags";
+import type { CoachAssignment, CoachAssignmentSubmission } from "@maiyuri/shared";
 import { z } from "zod";
 
 const bodySchema = z.object({
@@ -14,7 +16,7 @@ const bodySchema = z.object({
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-// POST /api/coaching/assignments/[id]/submit — learner submits (manager review pending; AI score Phase 2)
+// POST /api/coaching/assignments/[id]/submit — learner submits; AI pre-scores when enabled
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const ctx = await getCoachContext(request);
@@ -27,14 +29,35 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return error("Provide a written answer or an attachment", 400);
     }
 
-    const { data, error: dbErr } = await getSupabaseAdmin()
+    const admin = getSupabaseAdmin();
+    const { data: assignment, error: aErr } = await admin
+      .from("coach_assignments")
+      .select("*")
+      .eq("id", id)
+      .single();
+    if (aErr || !assignment) return notFound("Assignment not found");
+
+    const a = assignment as CoachAssignment;
+
+    // AI pre-score when enabled and a text submission is present.
+    let aiScore: { ai_score: number; ai_feedback: string; suggestedStatus: "approved" | "needs_improvement" } | null = null;
+    if (isCoachAiEnabled() && parsed.data.submission_text) {
+      aiScore = await scoreAssignment(
+        { title: a.title, description: a.description },
+        parsed.data.submission_text,
+      );
+    }
+
+    const { data, error: dbErr } = await admin
       .from("coach_assignment_submissions")
       .insert({
         assignment_id: id,
         user_id: ctx.userId,
         submission_text: parsed.data.submission_text ?? null,
         attachment_url: parsed.data.attachment_url ?? null,
-        manager_status: "pending",
+        manager_status: aiScore ? aiScore.suggestedStatus : "pending",
+        ai_score: aiScore ? aiScore.ai_score : null,
+        ai_feedback: aiScore ? aiScore.ai_feedback : null,
       })
       .select()
       .single();

--- a/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
+++ b/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
@@ -13,7 +13,7 @@ import { getCoachContext } from "@/lib/coaching/context";
 import { gradeQuizAnswer } from "@/lib/coaching/grading";
 import { gradeScenarioAnswer } from "@/lib/coaching/ai/grade";
 import { isCoachAiEnabled } from "@/lib/coaching/ai/flags";
-import type { CoachQuiz } from "@maiyuri/shared";
+import type { CoachQuiz, ScenarioGrade } from "@maiyuri/shared";
 import { z } from "zod";
 
 const attemptSchema = z.object({ selected_answer: z.string().min(1, "An answer is required") });
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const grade = gradeQuizAnswer(q, parsed.data.selected_answer);
 
     // For open-ended types, replace the pending result with an AI grade when enabled.
-    let aiGrade: { score: number; isCorrect: boolean; feedback: string; gaps: string[] } | null = null;
+    let aiGrade: ScenarioGrade | null = null;
     if (grade.pending && isCoachAiEnabled()) {
       aiGrade = await gradeScenarioAnswer(
         { question: q.question, explanation: q.explanation },
@@ -64,13 +64,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // Surface the explanation + suggested revision lesson only AFTER answering.
+    const answeredWrong = aiGrade ? !aiGrade.isCorrect : !grade.isCorrect;
     return success({
       is_correct: aiGrade ? aiGrade.isCorrect : grade.isCorrect,
       score: aiGrade ? aiGrade.score : grade.score,
       pending: aiGrade ? false : grade.pending,
       correct_answer: (aiGrade || grade.pending) ? null : q.correct_answer,
       explanation: q.explanation ?? null,
-      suggested_lesson_id: (aiGrade ? !aiGrade.isCorrect : !grade.isCorrect) ? q.suggested_lesson_id ?? null : null,
+      suggested_lesson_id: answeredWrong ? q.suggested_lesson_id ?? null : null,
       feedback: aiGrade ? aiGrade.feedback : null,
       gaps: aiGrade ? aiGrade.gaps : null,
     });

--- a/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
+++ b/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       is_correct: aiGrade ? aiGrade.isCorrect : grade.isCorrect,
       score: aiGrade ? aiGrade.score : grade.score,
       pending: aiGrade ? false : grade.pending,
-      correct_answer: (aiGrade || !grade.pending) ? null : q.correct_answer,
+      correct_answer: (aiGrade || grade.pending) ? null : q.correct_answer,
       explanation: q.explanation ?? null,
       suggested_lesson_id: (aiGrade ? !aiGrade.isCorrect : !grade.isCorrect) ? q.suggested_lesson_id ?? null : null,
       feedback: aiGrade ? aiGrade.feedback : null,

--- a/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
+++ b/apps/web/app/api/coaching/quizzes/[id]/attempt/route.ts
@@ -11,6 +11,8 @@ import {
 import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { getCoachContext } from "@/lib/coaching/context";
 import { gradeQuizAnswer } from "@/lib/coaching/grading";
+import { gradeScenarioAnswer } from "@/lib/coaching/ai/grade";
+import { isCoachAiEnabled } from "@/lib/coaching/ai/flags";
 import type { CoachQuiz } from "@maiyuri/shared";
 import { z } from "zod";
 
@@ -39,12 +41,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const q = quiz as CoachQuiz;
     const grade = gradeQuizAnswer(q, parsed.data.selected_answer);
 
+    // For open-ended types, replace the pending result with an AI grade when enabled.
+    let aiGrade: { score: number; isCorrect: boolean; feedback: string; gaps: string[] } | null = null;
+    if (grade.pending && isCoachAiEnabled()) {
+      aiGrade = await gradeScenarioAnswer(
+        { question: q.question, explanation: q.explanation },
+        parsed.data.selected_answer,
+      );
+    }
+
     const { error: insErr } = await admin.from("coach_quiz_attempts").insert({
       user_id: ctx.userId,
       quiz_id: id,
       selected_answer: parsed.data.selected_answer,
-      is_correct: grade.isCorrect,
-      score: grade.score,
+      is_correct: aiGrade ? aiGrade.isCorrect : grade.isCorrect,
+      score: aiGrade ? aiGrade.score : grade.score,
+      ai_feedback: aiGrade ? aiGrade.feedback : null,
     });
     if (insErr) {
       console.error("coaching quiz attempt insert error:", insErr);
@@ -53,12 +65,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     // Surface the explanation + suggested revision lesson only AFTER answering.
     return success({
-      is_correct: grade.isCorrect,
-      score: grade.score,
-      pending: grade.pending,
-      correct_answer: grade.pending ? null : q.correct_answer,
+      is_correct: aiGrade ? aiGrade.isCorrect : grade.isCorrect,
+      score: aiGrade ? aiGrade.score : grade.score,
+      pending: aiGrade ? false : grade.pending,
+      correct_answer: (aiGrade || !grade.pending) ? null : q.correct_answer,
       explanation: q.explanation ?? null,
-      suggested_lesson_id: grade.isCorrect ? null : q.suggested_lesson_id ?? null,
+      suggested_lesson_id: (aiGrade ? !aiGrade.isCorrect : !grade.isCorrect) ? q.suggested_lesson_id ?? null : null,
+      feedback: aiGrade ? aiGrade.feedback : null,
+      gaps: aiGrade ? aiGrade.gaps : null,
     });
   } catch (err) {
     console.error("coaching/quizzes/[id]/attempt POST error:", err);

--- a/apps/web/src/lib/coaching/ai/client.test.ts
+++ b/apps/web/src/lib/coaching/ai/client.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { extractJson } from "./client";
+
+describe("extractJson", () => {
+  it("parses a bare JSON object", () => {
+    expect(extractJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+  it("strips ```json code fences", () => {
+    expect(extractJson<{ a: number }>('```json\n{"a":2}\n```')).toEqual({ a: 2 });
+  });
+  it("returns null on malformed JSON instead of throwing", () => {
+    expect(extractJson("not json")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/coaching/ai/client.test.ts
+++ b/apps/web/src/lib/coaching/ai/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractJson } from "./client";
+import { extractJson, completeJson } from "./client";
 
 describe("extractJson", () => {
   it("parses a bare JSON object", () => {
@@ -10,5 +10,25 @@ describe("extractJson", () => {
   });
   it("returns null on malformed JSON instead of throwing", () => {
     expect(extractJson("not json")).toBeNull();
+  });
+});
+
+describe("completeJson fail-open", () => {
+  it("returns null when the coaching AI flag is disabled", async () => {
+    const prev = process.env.COACH_AI_ENABLED;
+    process.env.COACH_AI_ENABLED = "false";
+    const out = await completeJson("sys", "user");
+    expect(out).toBeNull();
+    process.env.COACH_AI_ENABLED = prev;
+  });
+  it("returns null when GOOGLE_AI_API_KEY is missing", async () => {
+    const prevFlag = process.env.COACH_AI_ENABLED;
+    const prevKey = process.env.GOOGLE_AI_API_KEY;
+    process.env.COACH_AI_ENABLED = "true";
+    delete process.env.GOOGLE_AI_API_KEY;
+    const out = await completeJson("sys", "user");
+    expect(out).toBeNull();
+    process.env.COACH_AI_ENABLED = prevFlag;
+    if (prevKey !== undefined) process.env.GOOGLE_AI_API_KEY = prevKey;
   });
 });

--- a/apps/web/src/lib/coaching/ai/client.ts
+++ b/apps/web/src/lib/coaching/ai/client.ts
@@ -1,0 +1,33 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+
+/** Strip ```json fences and parse; return null on any failure (never throws). */
+export function extractJson<T>(raw: string): T | null {
+  try {
+    const s = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+    return JSON.parse(s) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** One Gemini Flash-Lite call returning strict JSON, or null on failure. */
+export async function completeJson<T>(
+  systemPrompt: string,
+  userPrompt: string,
+  opts: { maxOutputTokens?: number } = {},
+): Promise<T | null> {
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({
+      model: GEMINI_DEFAULT_MODEL,
+      generationConfig: { maxOutputTokens: opts.maxOutputTokens ?? 700, responseMimeType: "application/json" },
+    });
+    const result = await model.generateContent(`${systemPrompt}\n\n${userPrompt}`);
+    return extractJson<T>(result.response.text());
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/coaching/ai/client.ts
+++ b/apps/web/src/lib/coaching/ai/client.ts
@@ -1,5 +1,13 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+import { isCoachAiEnabled } from "./flags";
+
+/** Module-level singleton — created once per process, reused across calls. */
+let _client: GoogleGenerativeAI | null = null;
+function getClient(apiKey: string): GoogleGenerativeAI {
+  if (!_client) _client = new GoogleGenerativeAI(apiKey);
+  return _client;
+}
 
 /** Strip ```json fences and parse; return null on any failure (never throws). */
 export function extractJson<T>(raw: string): T | null {
@@ -17,10 +25,11 @@ export async function completeJson<T>(
   userPrompt: string,
   opts: { maxOutputTokens?: number } = {},
 ): Promise<T | null> {
+  if (!isCoachAiEnabled()) return null;
   const apiKey = process.env.GOOGLE_AI_API_KEY;
   if (!apiKey) return null;
   try {
-    const genAI = new GoogleGenerativeAI(apiKey);
+    const genAI = getClient(apiKey);
     const model = genAI.getGenerativeModel({
       model: GEMINI_DEFAULT_MODEL,
       generationConfig: { maxOutputTokens: opts.maxOutputTokens ?? 700, responseMimeType: "application/json" },

--- a/apps/web/src/lib/coaching/ai/flags.ts
+++ b/apps/web/src/lib/coaching/ai/flags.ts
@@ -1,0 +1,4 @@
+/** Master switch for the coaching AI layer. Default ON; set COACH_AI_ENABLED=false to disable. */
+export function isCoachAiEnabled(): boolean {
+  return process.env.COACH_AI_ENABLED !== "false";
+}

--- a/apps/web/src/lib/coaching/ai/grade.test.ts
+++ b/apps/web/src/lib/coaching/ai/grade.test.ts
@@ -13,12 +13,10 @@ describe("gradeScenarioAnswer", () => {
     expect(g.score).toBe(80);
     expect(g.isCorrect).toBe(true);
   });
-  it("falls back to pending (score 0, isCorrect false) when the model fails", async () => {
+  it("returns null when the model fails", async () => {
     (completeJson as any).mockResolvedValue(null);
     const g = await gradeScenarioAnswer(quiz, "answer");
-    expect(g.score).toBe(0);
-    expect(g.isCorrect).toBe(false);
-    expect(g.feedback).toMatch(/review/i);
+    expect(g).toBeNull();
   });
 });
 
@@ -29,10 +27,9 @@ describe("scoreAssignment", () => {
     const g = await scoreAssignment({ title: "Explain bricks", description: "60s explanation" }, "Sir, interlock bricks...");
     expect(g.suggestedStatus).toBe("approved");
   });
-  it("falls back to needs_improvement/pending on model failure", async () => {
+  it("returns null on model failure", async () => {
     (completeJson as any).mockResolvedValue(null);
     const g = await scoreAssignment({ title: "x", description: "y" }, "z");
-    expect(g.suggestedStatus).toBe("needs_improvement");
-    expect(g.ai_score).toBe(0);
+    expect(g).toBeNull();
   });
 });

--- a/apps/web/src/lib/coaching/ai/grade.test.ts
+++ b/apps/web/src/lib/coaching/ai/grade.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("./client", () => ({ completeJson: vi.fn() }));
 import { completeJson } from "./client";
-import { gradeScenarioAnswer } from "./grade";
+import { gradeScenarioAnswer, scoreAssignment } from "./grade";
 
 const quiz = { question: "Engineer doubts interlock. Respond.", explanation: "Acknowledge engineer; offer proof; suggest factory visit." };
 
@@ -19,5 +19,20 @@ describe("gradeScenarioAnswer", () => {
     expect(g.score).toBe(0);
     expect(g.isCorrect).toBe(false);
     expect(g.feedback).toMatch(/review/i);
+  });
+});
+
+describe("scoreAssignment", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it("maps model output to an AssignmentGrade", async () => {
+    (completeJson as any).mockResolvedValue({ ai_score: 90, ai_feedback: "Strong.", suggestedStatus: "approved" });
+    const g = await scoreAssignment({ title: "Explain bricks", description: "60s explanation" }, "Sir, interlock bricks...");
+    expect(g.suggestedStatus).toBe("approved");
+  });
+  it("falls back to needs_improvement/pending on model failure", async () => {
+    (completeJson as any).mockResolvedValue(null);
+    const g = await scoreAssignment({ title: "x", description: "y" }, "z");
+    expect(g.suggestedStatus).toBe("needs_improvement");
+    expect(g.ai_score).toBe(0);
   });
 });

--- a/apps/web/src/lib/coaching/ai/grade.test.ts
+++ b/apps/web/src/lib/coaching/ai/grade.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("./client", () => ({ completeJson: vi.fn() }));
+import { completeJson } from "./client";
+import { gradeScenarioAnswer } from "./grade";
+
+const quiz = { question: "Engineer doubts interlock. Respond.", explanation: "Acknowledge engineer; offer proof; suggest factory visit." };
+
+describe("gradeScenarioAnswer", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it("returns the model grade when JSON is valid", async () => {
+    (completeJson as any).mockResolvedValue({ score: 80, isCorrect: true, feedback: "Good.", gaps: [] });
+    const g = await gradeScenarioAnswer(quiz, "I'd acknowledge the engineer and offer lab reports + a factory visit.");
+    expect(g.score).toBe(80);
+    expect(g.isCorrect).toBe(true);
+  });
+  it("falls back to pending (score 0, isCorrect false) when the model fails", async () => {
+    (completeJson as any).mockResolvedValue(null);
+    const g = await gradeScenarioAnswer(quiz, "answer");
+    expect(g.score).toBe(0);
+    expect(g.isCorrect).toBe(false);
+    expect(g.feedback).toMatch(/review/i);
+  });
+});

--- a/apps/web/src/lib/coaching/ai/grade.ts
+++ b/apps/web/src/lib/coaching/ai/grade.ts
@@ -5,11 +5,11 @@ import type { ScenarioGrade, AssignmentGrade } from "@maiyuri/shared";
 export async function gradeScenarioAnswer(
   quiz: { question: string; explanation?: string | null },
   answer: string,
-): Promise<ScenarioGrade> {
+): Promise<ScenarioGrade | null> {
   const user = `SCENARIO: ${quiz.question}\nMODEL GUIDANCE: ${quiz.explanation ?? "(none)"}\nTRAINEE ANSWER: ${answer}`;
   const out = await completeJson<ScenarioGrade>(SCENARIO_GRADE_SYSTEM, user, { maxOutputTokens: 500 });
   if (!out || typeof out.score !== "number") {
-    return { score: 0, isCorrect: false, feedback: "Saved — pending manager review.", gaps: [] };
+    return null;
   }
   const score = Math.max(0, Math.min(100, Math.round(out.score)));
   return {
@@ -23,11 +23,11 @@ export async function gradeScenarioAnswer(
 export async function scoreAssignment(
   assignment: { title: string; description?: string | null },
   submissionText: string,
-): Promise<AssignmentGrade> {
+): Promise<AssignmentGrade | null> {
   const user = `ASSIGNMENT: ${assignment.title}\nINSTRUCTIONS: ${assignment.description ?? "(none)"}\nSUBMISSION: ${submissionText}`;
   const out = await completeJson<AssignmentGrade>(ASSIGNMENT_GRADE_SYSTEM, user, { maxOutputTokens: 500 });
   if (!out || typeof out.ai_score !== "number") {
-    return { ai_score: 0, ai_feedback: "Saved — pending manager review.", suggestedStatus: "needs_improvement" };
+    return null;
   }
   const score = Math.max(0, Math.min(100, Math.round(out.ai_score)));
   return {

--- a/apps/web/src/lib/coaching/ai/grade.ts
+++ b/apps/web/src/lib/coaching/ai/grade.ts
@@ -1,0 +1,38 @@
+import { completeJson } from "./client";
+import { SCENARIO_GRADE_SYSTEM, ASSIGNMENT_GRADE_SYSTEM, PASS_THRESHOLD } from "./prompts";
+import type { ScenarioGrade, AssignmentGrade } from "@maiyuri/shared";
+
+export async function gradeScenarioAnswer(
+  quiz: { question: string; explanation?: string | null },
+  answer: string,
+): Promise<ScenarioGrade> {
+  const user = `SCENARIO: ${quiz.question}\nMODEL GUIDANCE: ${quiz.explanation ?? "(none)"}\nTRAINEE ANSWER: ${answer}`;
+  const out = await completeJson<ScenarioGrade>(SCENARIO_GRADE_SYSTEM, user, { maxOutputTokens: 500 });
+  if (!out || typeof out.score !== "number") {
+    return { score: 0, isCorrect: false, feedback: "Saved — pending manager review.", gaps: [] };
+  }
+  const score = Math.max(0, Math.min(100, Math.round(out.score)));
+  return {
+    score,
+    isCorrect: score >= PASS_THRESHOLD,
+    feedback: out.feedback ?? "",
+    gaps: Array.isArray(out.gaps) ? out.gaps : [],
+  };
+}
+
+export async function scoreAssignment(
+  assignment: { title: string; description?: string | null },
+  submissionText: string,
+): Promise<AssignmentGrade> {
+  const user = `ASSIGNMENT: ${assignment.title}\nINSTRUCTIONS: ${assignment.description ?? ""}\nSUBMISSION: ${submissionText}`;
+  const out = await completeJson<AssignmentGrade>(ASSIGNMENT_GRADE_SYSTEM, user, { maxOutputTokens: 500 });
+  if (!out || typeof out.ai_score !== "number") {
+    return { ai_score: 0, ai_feedback: "Saved — pending manager review.", suggestedStatus: "needs_improvement" };
+  }
+  const score = Math.max(0, Math.min(100, Math.round(out.ai_score)));
+  return {
+    ai_score: score,
+    ai_feedback: out.ai_feedback ?? "",
+    suggestedStatus: score >= PASS_THRESHOLD ? "approved" : "needs_improvement",
+  };
+}

--- a/apps/web/src/lib/coaching/ai/grade.ts
+++ b/apps/web/src/lib/coaching/ai/grade.ts
@@ -24,7 +24,7 @@ export async function scoreAssignment(
   assignment: { title: string; description?: string | null },
   submissionText: string,
 ): Promise<AssignmentGrade> {
-  const user = `ASSIGNMENT: ${assignment.title}\nINSTRUCTIONS: ${assignment.description ?? ""}\nSUBMISSION: ${submissionText}`;
+  const user = `ASSIGNMENT: ${assignment.title}\nINSTRUCTIONS: ${assignment.description ?? "(none)"}\nSUBMISSION: ${submissionText}`;
   const out = await completeJson<AssignmentGrade>(ASSIGNMENT_GRADE_SYSTEM, user, { maxOutputTokens: 500 });
   if (!out || typeof out.ai_score !== "number") {
     return { ai_score: 0, ai_feedback: "Saved — pending manager review.", suggestedStatus: "needs_improvement" };

--- a/apps/web/src/lib/coaching/ai/prompts.ts
+++ b/apps/web/src/lib/coaching/ai/prompts.ts
@@ -1,0 +1,15 @@
+export const BRAND_GUARDRAILS = `You are the Maiyuri Bricks sales coach. Enforce these brand rules in all output:
+- Make only proof-backed claims. NEVER say "guaranteed cooler", "zero plastering", "100% waterproof", or "carbon negative".
+- Any structural/strength claim must be "subject to engineer approval".
+- Never attack competitors (incl. Kerala bricks). Reframe to total wall value.
+- Always be encouraging, specific, and end on a concrete next step.
+Respond ONLY with valid JSON matching the requested shape. No prose outside JSON.`;
+
+export const SCENARIO_GRADE_SYSTEM = `${BRAND_GUARDRAILS}
+Grade a trainee's open-ended answer to a sales scenario. Output JSON:
+{"score": <0-100 int>, "isCorrect": <bool, true if score>=70>, "feedback": "<2-3 sentences, encouraging + specific>", "gaps": ["<missed point>", ...]}`;
+
+export const ASSIGNMENT_GRADE_SYSTEM = `${BRAND_GUARDRAILS}
+Grade a trainee's assignment submission against its description. Output JSON:
+{"ai_score": <0-100 int>, "ai_feedback": "<3-4 sentences>", "suggestedStatus": "approved" | "needs_improvement"}
+Use "approved" only when ai_score >= 70.`;

--- a/apps/web/src/lib/coaching/ai/prompts.ts
+++ b/apps/web/src/lib/coaching/ai/prompts.ts
@@ -1,3 +1,6 @@
+/** Score (0-100) at/above which a scenario answer or assignment is considered a pass. */
+export const PASS_THRESHOLD = 70;
+
 export const BRAND_GUARDRAILS = `You are the Maiyuri Bricks sales coach. Enforce these brand rules in all output:
 - Make only proof-backed claims. NEVER say "guaranteed cooler", "zero plastering", "100% waterproof", or "carbon negative".
 - Any structural/strength claim must be "subject to engineer approval".
@@ -7,9 +10,9 @@ Respond ONLY with valid JSON matching the requested shape. No prose outside JSON
 
 export const SCENARIO_GRADE_SYSTEM = `${BRAND_GUARDRAILS}
 Grade a trainee's open-ended answer to a sales scenario. Output JSON:
-{"score": <0-100 int>, "isCorrect": <bool, true if score>=70>, "feedback": "<2-3 sentences, encouraging + specific>", "gaps": ["<missed point>", ...]}`;
+{"score": <0-100 int>, "isCorrect": <bool, true if score>=${PASS_THRESHOLD}>, "feedback": "<2-3 sentences, encouraging + specific>", "gaps": ["<missed point>", ...]}`;
 
 export const ASSIGNMENT_GRADE_SYSTEM = `${BRAND_GUARDRAILS}
 Grade a trainee's assignment submission against its description. Output JSON:
 {"ai_score": <0-100 int>, "ai_feedback": "<3-4 sentences>", "suggestedStatus": "approved" | "needs_improvement"}
-Use "approved" only when ai_score >= 70.`;
+Use "approved" only when ai_score >= ${PASS_THRESHOLD}.`;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2094,3 +2094,17 @@ export interface CoachTodayPlanItem {
   title: string;
   done: boolean;
 }
+
+// AI autograding result shapes (Phase 2, Milestone 1)
+export interface ScenarioGrade {
+  score: number;
+  isCorrect: boolean;
+  feedback: string;
+  gaps: string[];
+}
+
+export interface AssignmentGrade {
+  ai_score: number;
+  ai_feedback: string;
+  suggestedStatus: "approved" | "needs_improvement";
+}


### PR DESCRIPTION
**AI Sales Coach Phase 2, Milestone 1** — the shared `coaching/ai` module (Gemini 2.5 Flash-Lite) + AI auto-grading of open-ended scenario quizzes and assignment submissions. Auto-finalized with manager override; gated by `COACH_AI_ENABLED` (default on); deterministic fail-open (AI failure → attempt stays *pending*, never a false wrong-answer).

### What's included
- `coaching/ai/`: `client.ts` (strict-JSON Gemini wrapper, flag-gated, never throws), `prompts.ts` (brand guardrails + `PASS_THRESHOLD`), `flags.ts`, `grade.ts` (`gradeScenarioAnswer`/`scoreAssignment`, return `null` on failure).
- Shared types: `ScenarioGrade`, `AssignmentGrade`.
- Wired into `quizzes/[id]/attempt` (scenario/voice_text auto-grade; MCQ path untouched) and `assignments/[id]/submit` (AI pre-score → `manager_status`).
- UI: quiz feedback + "to improve" gaps; assignment AI score + "AI-graded · manager can adjust" badge.
- `.env.example`: documents the `COACH_AI_ENABLED` kill-switch.

### Quality
- TDD throughout; **314 tests pass** (+9), typecheck 4/4, lint 0 errors.
- Reviewed per-unit (spec + code-quality) and a final whole-implementation pass; all findings fixed (correct_answer reveal logic, AI-failure pending semantics, type drift, list keys).
- No migration (reuses Phase 1 `ai_*` columns + `coach_roleplays`).

Spec: `docs/superpowers/specs/2026-06-06-ai-sales-coach-phase-2-design.md` · Plan: `docs/superpowers/plans/2026-06-06-ai-coach-phase-2-m1-autograding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AI-powered grading for assignments with scores and feedback displayed in submission panels
  * Added AI-generated quiz attempt grading with actionable improvement suggestions and identified learning gaps
  * Managers can now review and adjust AI-suggested grades for assignments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->