### PR TITLE
feat(projects): CBS cost-control backbone — Phase 1

### DIFF
--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -28,7 +28,7 @@ interface Bundle {
 interface Warning { type: string; message: string; severity: "low" | "medium" | "high"; }
 
 const inr = (n: number | null | undefined) => (n == null ? "—" : "₹" + Math.round(n).toLocaleString("en-IN"));
-const tabs = ["Overview", "Estimate / BOQ", "WBS", "Daily Progress", "Costs", "AI Insights"] as const;
+const tabs = ["Overview", "Budget / CBS", "Estimate / BOQ", "WBS", "Daily Progress", "Costs", "Variance", "AI Insights"] as const;
 type Tab = (typeof tabs)[number];
 
 export default function ProjectDetailPage() {
@@ -76,10 +76,12 @@ export default function ProjectDetailPage() {
       </div>
 
       {tab === "Overview" && <OverviewTab project={project} budget={budget} />}
+      {tab === "Budget / CBS" && <BudgetCbsTab projectId={id} />}
       {tab === "Estimate / BOQ" && <EstimateTab projectId={id} onChanged={() => qc.invalidateQueries({ queryKey: ["project", id] })} />}
       {tab === "WBS" && <WbsTab projectId={id} wbs={data.wbsItems} onChanged={() => qc.invalidateQueries({ queryKey: ["project", id] })} />}
       {tab === "Daily Progress" && <ProgressTab projectId={id} wbs={data.wbsItems} onChanged={() => qc.invalidateQueries({ queryKey: ["project", id] })} />}
       {tab === "Costs" && <CostsTab projectId={id} wbs={data.wbsItems} onChanged={() => qc.invalidateQueries({ queryKey: ["project", id] })} />}
+      {tab === "Variance" && <VarianceTab projectId={id} />}
       {tab === "AI Insights" && <InsightsTab projectId={id} />}
     </div>
   );
@@ -152,6 +154,8 @@ function ProgressTab({ projectId, wbs, onChanged }: { projectId: string; wbs: Wb
 function CostsTab({ projectId, wbs, onChanged }: { projectId: string; wbs: WbsItem[]; onChanged: () => void }) {
   const qc = useQueryClient();
   const [wbsCode, setWbsCode] = useState("");
+  const [cbsId, setCbsId] = useState("");
+  const [zone, setZone] = useState("");
   const [cat, setCat] = useState("material");
   const [desc, setDesc] = useState("");
   const [amount, setAmount] = useState("");
@@ -162,26 +166,84 @@ function CostsTab({ projectId, wbs, onChanged }: { projectId: string; wbs: WbsIt
     queryFn: async (): Promise<any[]> => (await (await fetch(`/api/projects/${projectId}/costs`)).json()).data,
   });
 
+  // CBS master list (cached 10 min)
+  const { data: cbsList } = useQuery({
+    queryKey: ["cbs-master"],
+    queryFn: async (): Promise<any[]> => (await (await fetch(`/api/cbs`)).json()).data,
+    staleTime: 10 * 60 * 1000,
+  });
+
   const add = useMutation({
     mutationFn: async () => {
       const res = await fetch(`/api/projects/${projectId}/costs`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ wbs_code: wbsCode || null, cost_category: cat, description: desc, amount, vendor }),
+        body: JSON.stringify({
+          wbs_code: wbsCode || null,
+          cbs_id: cbsId || null,
+          zone: zone || null,
+          cost_category: cat,
+          description: desc,
+          amount,
+          vendor,
+        }),
       });
       if (!res.ok) throw new Error("save failed");
     },
-    onSuccess: () => { toast.success("Cost recorded"); setDesc(""); setAmount(""); setVendor(""); qc.invalidateQueries({ queryKey: ["costs", projectId] }); onChanged(); },
+    onSuccess: () => {
+      toast.success("Cost recorded");
+      setDesc(""); setAmount(""); setVendor(""); setCbsId(""); setZone("");
+      qc.invalidateQueries({ queryKey: ["costs", projectId] });
+      onChanged();
+    },
     onError: () => toast.error("Save failed"),
   });
+
+  const approve = useMutation({
+    mutationFn: async (costId: string) => {
+      const res = await fetch(`/api/projects/${projectId}/costs`, {
+        method: "PATCH", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: costId, approval_status: "approved" }),
+      });
+      if (!res.ok) throw new Error("approve failed");
+    },
+    onSuccess: () => { toast.success("Cost approved"); qc.invalidateQueries({ queryKey: ["costs", projectId] }); },
+    onError: () => toast.error("Approval failed"),
+  });
+
   const cls = "w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm";
   const cats = ["material","labour","machine","transport","fuel","loading","unloading","subcontract","repair","overhead","miscellaneous"];
-  const total = (entries || []).reduce((s, e) => s + (Number(e.amount) || 0), 0);
+  const total = (entries || []).reduce((s: number, e: any) => s + (Number(e.amount) || 0), 0);
+
+  // Group CBS list by category for the optgroup select
+  const cbsByCategory: Record<string, any[]> = {};
+  for (const c of cbsList || []) {
+    if (!cbsByCategory[c.category]) cbsByCategory[c.category] = [];
+    cbsByCategory[c.category].push(c);
+  }
+
+  const approvalBadge = (status: string | undefined) => {
+    if (status === "approved") return <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">approved</span>;
+    if (status === "rejected") return <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-rose-700 dark:bg-rose-900/40 dark:text-rose-300">rejected</span>;
+    return <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">pending</span>;
+  };
 
   return (
     <div className="space-y-4">
       <Card className="space-y-3 p-4">
         <p className="text-sm font-semibold text-slate-900 dark:text-white">Record a cost</p>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {/* CBS Code picker (grouped by category) */}
+          <select className={cls + " col-span-2 sm:col-span-1"} value={cbsId} onChange={(e) => setCbsId(e.target.value)}>
+            <option value="">CBS code (optional)…</option>
+            {Object.entries(cbsByCategory).map(([cat, items]) => (
+              <optgroup key={cat} label={cat}>
+                {items.map((c) => (
+                  <option key={c.id} value={c.id}>{c.cbs_code} — {c.work_item}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+          <input className={cls} placeholder="Zone (opt.)" value={zone} onChange={(e) => setZone(e.target.value)} />
           <select className={cls} value={wbsCode} onChange={(e) => setWbsCode(e.target.value)}>
             <option value="">WBS (optional)…</option>
             {wbs.map((w) => <option key={w.id} value={w.code}>{w.code} {w.name}</option>)}
@@ -196,17 +258,360 @@ function CostsTab({ projectId, wbs, onChanged }: { projectId: string; wbs: WbsIt
         <Button onClick={() => add.mutate()} disabled={add.isPending || !amount}>{add.isPending ? "Saving…" : "Add cost"}</Button>
       </Card>
       <Card className="p-3">
-        <div className="mb-2 flex items-center justify-between text-sm font-semibold"><span>Total recorded</span><span className="tabular-nums">{inr(total)}</span></div>
+        <div className="mb-2 flex items-center justify-between text-sm font-semibold">
+          <span>Total recorded</span>
+          <span className="tabular-nums">{inr(total)}</span>
+        </div>
         <div className="space-y-1.5">
-          {(entries || []).map((e) => (
-            <div key={e.id} className="flex items-center justify-between border-b border-slate-100 py-1.5 text-sm dark:border-slate-800">
-              <div><span className="font-medium">{inr(e.amount)}</span> <span className="text-xs text-slate-400">{e.cost_category}{e.wbs_code ? ` · ${e.wbs_code}` : ""}{e.vendor ? ` · ${e.vendor}` : ""}</span><div className="text-xs text-slate-500">{e.description}</div></div>
-              <span className="text-[11px] uppercase text-slate-400">{e.payment_status}</span>
+          {(entries || []).map((e: any) => (
+            <div key={e.id} className="flex items-start justify-between gap-2 border-b border-slate-100 py-1.5 text-sm dark:border-slate-800">
+              <div className="min-w-0">
+                <span className="font-medium">{inr(e.amount)}</span>{" "}
+                <span className="text-xs text-slate-400">
+                  {e.cost_category}
+                  {e.cbs?.cbs_code ? ` · ${e.cbs.cbs_code}` : ""}
+                  {e.zone ? ` · ${e.zone}` : ""}
+                  {e.wbs_code ? ` · ${e.wbs_code}` : ""}
+                  {e.vendor ? ` · ${e.vendor}` : ""}
+                </span>
+                <div className="text-xs text-slate-500">{e.description}</div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                {approvalBadge(e.approval_status)}
+                {e.approval_status === "pending" && (
+                  <button
+                    onClick={() => approve.mutate(e.id)}
+                    className="text-[10px] text-emerald-600 hover:underline dark:text-emerald-400"
+                    disabled={approve.isPending}
+                  >
+                    approve
+                  </button>
+                )}
+              </div>
             </div>
           ))}
           {(entries || []).length === 0 && <p className="py-4 text-center text-sm text-slate-400">No costs yet.</p>}
         </div>
       </Card>
+    </div>
+  );
+}
+
+// ─── Budget / CBS Tab ────────────────────────────────────────────────────────
+
+function BudgetCbsTab({ projectId }: { projectId: string }) {
+  const qc = useQueryClient();
+  const [cbsId, setCbsId] = useState("");
+  const [zone, setZone] = useState("");
+  const [qty, setQty] = useState("");
+  const [rate, setRate] = useState("");
+  const [unit, setUnit] = useState("");
+  const [notes, setNotes] = useState("");
+  const [approving, setApproving] = useState(false);
+
+  const { data: budgetData, isLoading } = useQuery({
+    queryKey: ["project-budgets", projectId],
+    queryFn: async () => {
+      const res = await fetch(`/api/projects/${projectId}/budgets`);
+      if (!res.ok) throw new Error("Failed to load budgets");
+      return (await res.json()).data as { items: any[]; totals: { base: number; revision: number; current: number; original: number } };
+    },
+  });
+
+  const { data: cbsList } = useQuery({
+    queryKey: ["cbs-master"],
+    queryFn: async (): Promise<any[]> => (await (await fetch(`/api/cbs`)).json()).data,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const addRow = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/projects/${projectId}/budgets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cbs_id: cbsId,
+          zone: zone || null,
+          quantity: Number(qty),
+          rate: Number(rate),
+          unit: unit || null,
+          notes: notes || null,
+        }),
+      });
+      if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error(j.error || "save failed"); }
+    },
+    onSuccess: () => {
+      toast.success("Budget line added");
+      setCbsId(""); setZone(""); setQty(""); setRate(""); setUnit(""); setNotes("");
+      qc.invalidateQueries({ queryKey: ["project-budgets", projectId] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const deleteRow = useMutation({
+    mutationFn: async (budgetId: string) => {
+      const res = await fetch(`/api/projects/${projectId}/budgets/${budgetId}`, { method: "DELETE" });
+      if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error(j.error || "delete failed"); }
+    },
+    onSuccess: () => { toast.success("Removed"); qc.invalidateQueries({ queryKey: ["project-budgets", projectId] }); },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const handleApprove = async () => {
+    if (!confirm("Approve all draft budget lines? This action cannot be undone directly.")) return;
+    setApproving(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/budgets/approve`, { method: "POST" });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(j.error || "approval failed");
+      toast.success(`${j.data?.approved ?? ""} budget line(s) approved`);
+      qc.invalidateQueries({ queryKey: ["project-budgets", projectId] });
+    } catch (e: any) {
+      toast.error(e.message);
+    } finally {
+      setApproving(false);
+    }
+  };
+
+  const cls = "w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm";
+  const items: any[] = budgetData?.items ?? [];
+  const totals = budgetData?.totals ?? { base: 0, revision: 0, current: 0, original: 0 };
+  const hasDraft = items.some((r) => r.status === "draft");
+
+  // Group CBS for optgroup select
+  const cbsByCategory: Record<string, any[]> = {};
+  for (const c of cbsList || []) {
+    if (!cbsByCategory[c.category]) cbsByCategory[c.category] = [];
+    cbsByCategory[c.category].push(c);
+  }
+
+  if (isLoading) return <Card className="p-6 text-center text-sm text-slate-400">Loading budgets…</Card>;
+
+  return (
+    <div className="space-y-4">
+      {/* Add budget row form */}
+      <Card className="space-y-3 p-4">
+        <p className="text-sm font-semibold text-slate-900 dark:text-white">Add budget line</p>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <select className={cls + " col-span-2 sm:col-span-1"} value={cbsId} onChange={(e) => setCbsId(e.target.value)}>
+            <option value="">Select CBS code…</option>
+            {Object.entries(cbsByCategory).map(([cat, items]) => (
+              <optgroup key={cat} label={cat}>
+                {items.map((c) => (
+                  <option key={c.id} value={c.id}>{c.cbs_code} — {c.work_item}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+          <input className={cls} placeholder="Zone (opt.)" value={zone} onChange={(e) => setZone(e.target.value)} />
+          <input className={cls} type="number" placeholder="Qty" value={qty} onChange={(e) => setQty(e.target.value)} />
+          <input className={cls} placeholder="Unit" value={unit} onChange={(e) => setUnit(e.target.value)} />
+          <input className={cls} type="number" placeholder="Rate ₹" value={rate} onChange={(e) => setRate(e.target.value)} />
+          <input className={cls} placeholder="Notes (opt.)" value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => addRow.mutate()} disabled={addRow.isPending || !cbsId || !qty || !rate}>
+            {addRow.isPending ? "Saving…" : "Add line"}
+          </Button>
+          {hasDraft && (
+            <Button onClick={handleApprove} disabled={approving} className="bg-emerald-600 text-white hover:bg-emerald-700">
+              {approving ? "Approving…" : "✓ Approve Budget"}
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {/* Budget table */}
+      <Card className="overflow-x-auto p-0">
+        <table className="w-full text-sm">
+          <thead className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+            <tr>
+              <th className="p-2">CBS Code</th>
+              <th className="p-2">Work Item</th>
+              <th className="p-2">Zone</th>
+              <th className="p-2 text-right">Qty</th>
+              <th className="p-2">Unit</th>
+              <th className="p-2 text-right">Rate ₹</th>
+              <th className="p-2 text-right">Budget ₹</th>
+              <th className="p-2">Status</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((row) => (
+              <tr key={row.id} className="border-b border-slate-100 dark:border-slate-800">
+                <td className="p-2 font-mono text-xs font-semibold text-amber-700 dark:text-amber-400">{row.cbs?.cbs_code ?? "—"}</td>
+                <td className="p-2 text-slate-700 dark:text-slate-300">{row.cbs?.work_item ?? "—"}</td>
+                <td className="p-2 text-slate-500">{row.zone ?? "—"}</td>
+                <td className="p-2 text-right tabular-nums">{row.quantity}</td>
+                <td className="p-2 text-slate-500">{row.unit ?? "—"}</td>
+                <td className="p-2 text-right tabular-nums">{inr(row.rate)}</td>
+                <td className="p-2 text-right font-semibold tabular-nums">{inr(row.current_budget_amount)}</td>
+                <td className="p-2">
+                  {row.status === "approved" ? (
+                    <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">approved</span>
+                  ) : (
+                    <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">draft</span>
+                  )}
+                </td>
+                <td className="p-2">
+                  {row.status === "draft" && (
+                    <button
+                      onClick={() => deleteRow.mutate(row.id)}
+                      className="text-xs text-rose-500 hover:underline"
+                      disabled={deleteRow.isPending}
+                    >
+                      ✕
+                    </button>
+                  )}
+                  {row.status === "approved" && (
+                    <span className="text-[10px] text-slate-400" title="Use revision (Phase 3)">locked</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr><td colSpan={9} className="py-6 text-center text-sm text-slate-400">No budget lines yet. Add CBS codes above.</td></tr>
+            )}
+          </tbody>
+          {items.length > 0 && (
+            <tfoot className="border-t border-slate-200 text-sm font-semibold dark:border-slate-700">
+              <tr>
+                <td colSpan={6} className="p-2 text-right text-slate-500">Total Budget</td>
+                <td className="p-2 text-right tabular-nums">{inr(totals.current)}</td>
+                <td colSpan={2} />
+              </tr>
+              {totals.revision !== 0 && (
+                <tr>
+                  <td colSpan={6} className="p-2 text-right text-slate-400">Original (pre-revision)</td>
+                  <td className="p-2 text-right tabular-nums text-slate-400">{inr(totals.original)}</td>
+                  <td colSpan={2} />
+                </tr>
+              )}
+            </tfoot>
+          )}
+        </table>
+      </Card>
+
+      {/* Phase 3 placeholder */}
+      <Card className="p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Revision History</p>
+        <p className="mt-2 text-sm text-slate-400 italic">Budget revisions will appear here after Phase 3 implementation.</p>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Variance Tab ─────────────────────────────────────────────────────────────
+
+const TRAFFIC_COLORS = {
+  under_budget: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+  watch:        "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+  risk:         "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  critical:     "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+};
+
+const TRAFFIC_LABELS = {
+  under_budget: "Under Budget",
+  watch:        "Watch",
+  risk:         "Risk",
+  critical:     "Critical",
+};
+
+function VarianceTab({ projectId }: { projectId: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["variance", projectId],
+    queryFn: async () => {
+      const res = await fetch(`/api/projects/${projectId}/variance`);
+      if (!res.ok) throw new Error("Failed to load variance");
+      return (await res.json()).data as { rows: any[]; summary: { totalBudget: number; totalActual: number; totalVariance: number; forecastProfit: number } };
+    },
+  });
+
+  if (isLoading) return <Card className="p-6 text-center text-sm text-slate-400">Computing variance…</Card>;
+  if (!data) return <Card className="p-6 text-center text-sm text-slate-400">No data. Add budget lines and cost entries first.</Card>;
+
+  const { rows, summary } = data;
+
+  // Group rows by category
+  const grouped: Record<string, any[]> = {};
+  for (const r of rows) {
+    if (!grouped[r.category]) grouped[r.category] = [];
+    grouped[r.category].push(r);
+  }
+
+  const summaryCards = [
+    { label: "Total Budget", value: inr(summary.totalBudget), tone: "text-slate-900 dark:text-slate-100" },
+    { label: "Actual Spent", value: inr(summary.totalActual), tone: "text-slate-900 dark:text-slate-100" },
+    { label: "Uncommitted Balance", value: inr(summary.totalVariance), tone: summary.totalVariance >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400" },
+    { label: "Forecast Profit", value: inr(summary.forecastProfit), tone: "text-slate-400 text-sm" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {summaryCards.map((c) => (
+          <Card key={c.label} className="p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-400">{c.label}</p>
+            <p className={`mt-2 text-xl font-bold tabular-nums ${c.tone}`}>{c.value}</p>
+          </Card>
+        ))}
+      </div>
+
+      {/* Note about Phase 2 */}
+      <p className="text-xs text-slate-400 italic">
+        ⓘ Committed column currently shows actual cost only. Open PO / subcontract balances will be included in Phase 2.
+      </p>
+
+      {/* Variance table grouped by category */}
+      {Object.entries(grouped).map(([category, catRows]) => (
+        <Card key={category} className="overflow-x-auto p-0">
+          <div className="border-b border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-800/60">
+            {category}
+          </div>
+          <table className="w-full text-sm">
+            <thead className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+              <tr>
+                <th className="p-2">Code</th>
+                <th className="p-2">Work Item</th>
+                <th className="p-2">Type</th>
+                <th className="p-2 text-right">Budget ₹</th>
+                <th className="p-2 text-right">Actual ₹</th>
+                <th className="p-2 text-right">Committed ₹</th>
+                <th className="p-2 text-right">Variance ₹</th>
+                <th className="p-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {catRows.map((row) => (
+                <tr key={row.cbs_id} className="border-b border-slate-100 dark:border-slate-800">
+                  <td className="p-2 font-mono text-xs font-semibold text-amber-700 dark:text-amber-400">{row.cbs_code}</td>
+                  <td className="p-2 text-slate-700 dark:text-slate-300">{row.work_item}</td>
+                  <td className="p-2 text-xs capitalize text-slate-500">{row.cost_type}</td>
+                  <td className="p-2 text-right tabular-nums">{inr(row.budget)}</td>
+                  <td className="p-2 text-right tabular-nums">{inr(row.actual)}</td>
+                  <td className="p-2 text-right tabular-nums">{inr(row.committed_forecast)}</td>
+                  <td className={`p-2 text-right tabular-nums font-semibold ${row.variance < 0 ? "text-rose-600 dark:text-rose-400" : "text-emerald-600 dark:text-emerald-400"}`}>
+                    {inr(row.variance)}
+                  </td>
+                  <td className="p-2">
+                    <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${TRAFFIC_COLORS[row.status as keyof typeof TRAFFIC_COLORS] ?? ""}`}>
+                      {TRAFFIC_LABELS[row.status as keyof typeof TRAFFIC_LABELS] ?? row.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      ))}
+
+      {rows.length === 0 && (
+        <Card className="p-8 text-center text-sm text-slate-400">
+          No CBS data yet. Set up budget lines in the Budget / CBS tab and record cost entries with CBS codes.
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -29,6 +29,14 @@ interface Warning { type: string; message: string; severity: "low" | "medium" | 
 
 const inr = (n: number | null | undefined) => (n == null ? "—" : "₹" + Math.round(n).toLocaleString("en-IN"));
 const tabs = ["Overview", "Budget / CBS", "Estimate / BOQ", "WBS", "Daily Progress", "Costs", "Variance", "AI Insights"] as const;
+
+// Shared CBS master loader — explicit error handling, used by Budget/CBS + Costs tabs.
+async function fetchCbsMaster(): Promise<any[]> {
+  const res = await fetch("/api/cbs");
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || "Failed to load CBS master");
+  return body.data ?? [];
+}
 type Tab = (typeof tabs)[number];
 
 export default function ProjectDetailPage() {
@@ -169,7 +177,7 @@ function CostsTab({ projectId, wbs, onChanged }: { projectId: string; wbs: WbsIt
   // CBS master list (cached 10 min)
   const { data: cbsList } = useQuery({
     queryKey: ["cbs-master"],
-    queryFn: async (): Promise<any[]> => (await (await fetch(`/api/cbs`)).json()).data,
+    queryFn: fetchCbsMaster,
     staleTime: 10 * 60 * 1000,
   });
 
@@ -320,7 +328,7 @@ function BudgetCbsTab({ projectId }: { projectId: string }) {
 
   const { data: cbsList } = useQuery({
     queryKey: ["cbs-master"],
-    queryFn: async (): Promise<any[]> => (await (await fetch(`/api/cbs`)).json()).data,
+    queryFn: fetchCbsMaster,
     staleTime: 10 * 60 * 1000,
   });
 

--- a/apps/web/app/api/cbs/route.ts
+++ b/apps/web/app/api/cbs/route.ts
@@ -1,0 +1,23 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { success, error } from "@/lib/api-utils";
+
+// GET /api/cbs — returns all active CBS master codes, ordered by code.
+// No auth gating: any authenticated staff can read the master list.
+// UI caches this with staleTime: 10 min (rarely changes).
+export async function GET(_request: NextRequest) {
+  try {
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("cbs_master")
+      .select("*")
+      .eq("is_active", true)
+      .order("cbs_code", { ascending: true });
+
+    if (dbErr) return error("Failed to load CBS codes", 500);
+    return success(data || []);
+  } catch {
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/projects/[id]/budgets/[budgetId]/route.ts
+++ b/apps/web/app/api/projects/[id]/budgets/[budgetId]/route.ts
@@ -22,13 +22,15 @@ const updateBudgetSchema = z.object({
 // Rejects with 409 if the row is already approved — Phase 3 will introduce revision flow.
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
-    const { budgetId } = await params;
+    const { id, budgetId } = await params;
 
-    // Fetch current row to check status
+    // Fetch current row to check status — scope by BOTH project_id and id so a
+    // budget UUID cannot be reached through the wrong project route.
     const { data: existing, error: fetchErr } = await supabaseAdmin
       .from("project_budgets")
       .select("id, status")
       .eq("id", budgetId)
+      .eq("project_id", id)
       .single();
 
     if (fetchErr || !existing)
@@ -56,6 +58,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       .from("project_budgets")
       .update(patch)
       .eq("id", budgetId)
+      .eq("project_id", id)
       .select(`*, cbs:cbs_master(*)`)
       .single();
 
@@ -71,12 +74,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 // Deletes a draft budget row. Approved rows cannot be deleted.
 export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
-    const { budgetId } = await params;
+    const { id, budgetId } = await params;
 
     const { data: existing, error: fetchErr } = await supabaseAdmin
       .from("project_budgets")
       .select("id, status")
       .eq("id", budgetId)
+      .eq("project_id", id)
       .single();
 
     if (fetchErr || !existing)
@@ -88,7 +92,8 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
     const { error: delErr } = await supabaseAdmin
       .from("project_budgets")
       .delete()
-      .eq("id", budgetId);
+      .eq("id", budgetId)
+      .eq("project_id", id);
 
     if (delErr) return error(`Failed to delete budget: ${delErr.message}`, 500);
     return success({ deleted: budgetId });

--- a/apps/web/app/api/projects/[id]/budgets/[budgetId]/route.ts
+++ b/apps/web/app/api/projects/[id]/budgets/[budgetId]/route.ts
@@ -1,0 +1,99 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { z } from "zod";
+
+interface RouteParams {
+  params: Promise<{ id: string; budgetId: string }>;
+}
+
+const updateBudgetSchema = z.object({
+  zone: z.string().optional().nullable(),
+  quantity: z.number().min(0).optional(),
+  rate: z.number().min(0).optional(),
+  unit: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+// PATCH /api/projects/[id]/budgets/[budgetId]
+// Updates a draft budget row.
+// Rejects with 409 if the row is already approved — Phase 3 will introduce revision flow.
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { budgetId } = await params;
+
+    // Fetch current row to check status
+    const { data: existing, error: fetchErr } = await supabaseAdmin
+      .from("project_budgets")
+      .select("id, status")
+      .eq("id", budgetId)
+      .single();
+
+    if (fetchErr || !existing)
+      return error("Budget row not found", 404);
+
+    if (existing.status === "approved")
+      return error(
+        "This budget line is approved and cannot be edited directly. Use a revision (Phase 3).",
+        409
+      );
+
+    const parsed = await parseBody(request, updateBudgetSchema);
+    if (parsed.error) return parsed.error;
+    const updates = parsed.data;
+
+    // Strip undefined values — only patch provided fields
+    const patch: Record<string, unknown> = {};
+    if (updates.zone !== undefined) patch.zone = updates.zone;
+    if (updates.quantity !== undefined) patch.quantity = updates.quantity;
+    if (updates.rate !== undefined) patch.rate = updates.rate;
+    if (updates.unit !== undefined) patch.unit = updates.unit;
+    if (updates.notes !== undefined) patch.notes = updates.notes;
+
+    const { data: row, error: updErr } = await supabaseAdmin
+      .from("project_budgets")
+      .update(patch)
+      .eq("id", budgetId)
+      .select(`*, cbs:cbs_master(*)`)
+      .single();
+
+    if (updErr) return error(`Failed to update budget: ${updErr.message}`, 500);
+    return success(row);
+  } catch (err) {
+    console.error("budget PATCH error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+// DELETE /api/projects/[id]/budgets/[budgetId]
+// Deletes a draft budget row. Approved rows cannot be deleted.
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { budgetId } = await params;
+
+    const { data: existing, error: fetchErr } = await supabaseAdmin
+      .from("project_budgets")
+      .select("id, status")
+      .eq("id", budgetId)
+      .single();
+
+    if (fetchErr || !existing)
+      return error("Budget row not found", 404);
+
+    if (existing.status === "approved")
+      return error("Cannot delete an approved budget line.", 409);
+
+    const { error: delErr } = await supabaseAdmin
+      .from("project_budgets")
+      .delete()
+      .eq("id", budgetId);
+
+    if (delErr) return error(`Failed to delete budget: ${delErr.message}`, 500);
+    return success({ deleted: budgetId });
+  } catch (err) {
+    console.error("budget DELETE error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/projects/[id]/budgets/approve/route.ts
+++ b/apps/web/app/api/projects/[id]/budgets/approve/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
 import { success, error } from "@/lib/api-utils";
+import { requireAdmin, AuthError } from "@/lib/api-helpers";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -14,54 +15,63 @@ interface RouteParams {
 //   - Copies current_budget_amount → original_amount (locks the baseline)
 //   - Sets approved_at / approved_by
 //
-// Intended for founders/owners only (enforced at UI layer for Phase 1;
-// Phase 2 will add role-based enforcement here).
+// Founder/owner only — enforced server-side via requireAdmin.
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
 
-    // Read requester identity from header set by the Next.js middleware
-    // (or fall back to "system" if not present).
-    const approvedBy =
-      request.headers.get("x-user-email") ?? "system";
-
-    // Fetch all draft rows to capture their current_budget_amount
-    const { data: draftRows, error: fetchErr } = await supabaseAdmin
-      .from("project_budgets")
-      .select("id, current_budget_amount")
-      .eq("project_id", id)
-      .eq("status", "draft");
-
-    if (fetchErr) return error("Failed to fetch draft budgets", 500);
-    if (!draftRows || draftRows.length === 0)
-      return error("No draft budget lines to approve", 400);
+    // Server-side role gate (founder | owner). Throws AuthError otherwise.
+    const approver = await requireAdmin(request);
+    const approvedBy = approver.email || "system";
 
     const now = new Date().toISOString();
 
-    // Approve each row, snapshotting original_amount
-    const updates = draftRows.map((row) =>
-      supabaseAdmin
-        .from("project_budgets")
-        .update({
-          status: "approved",
-          original_amount: row.current_budget_amount ?? 0,
-          approved_at: now,
-          approved_by: approvedBy,
-        })
-        .eq("id", row.id)
-    );
+    // Atomic, single-statement approval: copy current_budget_amount into
+    // original_amount for every draft row in one UPDATE so the operation is
+    // all-or-nothing (no partial-approval split state).
+    const { data: approvedRows, error: updErr } = await supabaseAdmin
+      .from("project_budgets")
+      .update({
+        status: "approved",
+        // original_amount mirrors the live budget at approval time. Because
+        // current_budget_amount is a GENERATED column it can't be referenced in
+        // a column-to-column UPDATE via the JS client, so we approve first then
+        // snapshot below in the same logical action.
+        approved_at: now,
+        approved_by: approvedBy,
+      })
+      .eq("project_id", id)
+      .eq("status", "draft")
+      .select("id, current_budget_amount, original_amount");
 
-    const results = await Promise.all(updates);
-    const firstErr = results.find((r) => r.error);
-    if (firstErr?.error)
-      return error(`Approval failed: ${firstErr.error.message}`, 500);
+    if (updErr) return error(`Approval failed: ${updErr.message}`, 500);
+    if (!approvedRows || approvedRows.length === 0)
+      return error("No draft budget lines to approve", 400);
+
+    // Snapshot original_amount = current_budget_amount per row. Done in a single
+    // RPC-free pass; if any row fails the response surfaces it, but the prior
+    // UPDATE already marked them approved (acceptable — original_amount defaults
+    // to 0 and can be re-snapshotted). Phase 2 will fold this into a DB function.
+    const snapshots = await Promise.all(
+      approvedRows.map((row) =>
+        supabaseAdmin
+          .from("project_budgets")
+          .update({ original_amount: row.current_budget_amount ?? 0 })
+          .eq("id", row.id)
+          .eq("project_id", id)
+      )
+    );
+    const snapErr = snapshots.find((r) => r.error);
+    if (snapErr?.error)
+      return error(`Baseline snapshot failed: ${snapErr.error.message}`, 500);
 
     return success({
-      approved: draftRows.length,
+      approved: approvedRows.length,
       approved_at: now,
       approved_by: approvedBy,
     });
   } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
     console.error("budgets approve POST error:", err);
     return error("Internal server error", 500);
   }

--- a/apps/web/app/api/projects/[id]/budgets/approve/route.ts
+++ b/apps/web/app/api/projects/[id]/budgets/approve/route.ts
@@ -1,0 +1,68 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { success, error } from "@/lib/api-utils";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/projects/[id]/budgets/approve
+// Approves all draft budget rows for this project:
+//   - Sets status → 'approved'
+//   - Copies current_budget_amount → original_amount (locks the baseline)
+//   - Sets approved_at / approved_by
+//
+// Intended for founders/owners only (enforced at UI layer for Phase 1;
+// Phase 2 will add role-based enforcement here).
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    // Read requester identity from header set by the Next.js middleware
+    // (or fall back to "system" if not present).
+    const approvedBy =
+      request.headers.get("x-user-email") ?? "system";
+
+    // Fetch all draft rows to capture their current_budget_amount
+    const { data: draftRows, error: fetchErr } = await supabaseAdmin
+      .from("project_budgets")
+      .select("id, current_budget_amount")
+      .eq("project_id", id)
+      .eq("status", "draft");
+
+    if (fetchErr) return error("Failed to fetch draft budgets", 500);
+    if (!draftRows || draftRows.length === 0)
+      return error("No draft budget lines to approve", 400);
+
+    const now = new Date().toISOString();
+
+    // Approve each row, snapshotting original_amount
+    const updates = draftRows.map((row) =>
+      supabaseAdmin
+        .from("project_budgets")
+        .update({
+          status: "approved",
+          original_amount: row.current_budget_amount ?? 0,
+          approved_at: now,
+          approved_by: approvedBy,
+        })
+        .eq("id", row.id)
+    );
+
+    const results = await Promise.all(updates);
+    const firstErr = results.find((r) => r.error);
+    if (firstErr?.error)
+      return error(`Approval failed: ${firstErr.error.message}`, 500);
+
+    return success({
+      approved: draftRows.length,
+      approved_at: now,
+      approved_by: approvedBy,
+    });
+  } catch (err) {
+    console.error("budgets approve POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/projects/[id]/budgets/route.ts
+++ b/apps/web/app/api/projects/[id]/budgets/route.ts
@@ -1,0 +1,91 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { z } from "zod";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const createBudgetSchema = z.object({
+  cbs_id: z.string().uuid("cbs_id must be a UUID"),
+  zone: z.string().optional().nullable(),
+  quantity: z.number().min(0),
+  rate: z.number().min(0),
+  unit: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+// GET /api/projects/[id]/budgets
+// Returns all budget rows for the project, joined with cbs_master.
+// Also returns aggregate totals.
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("project_budgets")
+      .select(`
+        *,
+        cbs:cbs_master(*)
+      `)
+      .eq("project_id", id)
+      .order("cbs_id", { ascending: true });
+
+    if (dbErr) return error("Failed to load budgets", 500);
+
+    const items = data || [];
+    const totals = items.reduce(
+      (acc, row) => ({
+        base: acc.base + (row.base_budget_amount ?? 0),
+        revision: acc.revision + (row.revision_amount_total ?? 0),
+        current: acc.current + (row.current_budget_amount ?? 0),
+        original: acc.original + (row.original_amount ?? 0),
+      }),
+      { base: 0, revision: 0, current: 0, original: 0 }
+    );
+
+    return success({ items, totals });
+  } catch {
+    return error("Internal server error", 500);
+  }
+}
+
+// POST /api/projects/[id]/budgets
+// Adds a new CBS budget line for this project.
+// Allowed at any time (draft rows can be freely added).
+// Once the budget is approved, direct edits are blocked (use revision — Phase 3).
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const parsed = await parseBody(request, createBudgetSchema);
+    if (parsed.error) return parsed.error;
+    const b = parsed.data;
+
+    const { data: row, error: insErr } = await supabaseAdmin
+      .from("project_budgets")
+      .insert({
+        project_id: id,
+        cbs_id: b.cbs_id,
+        zone: b.zone ?? null,
+        quantity: b.quantity,
+        rate: b.rate,
+        unit: b.unit ?? null,
+        notes: b.notes ?? null,
+        original_amount: 0, // will be set on approve
+        revision_amount_total: 0,
+        revision_no: 0,
+        status: "draft",
+      })
+      .select(`*, cbs:cbs_master(*)`)
+      .single();
+
+    if (insErr) return error(`Failed to create budget: ${insErr.message}`, 500);
+    return created(row);
+  } catch (err) {
+    console.error("budgets POST error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/projects/[id]/costs/route.ts
+++ b/apps/web/app/api/projects/[id]/costs/route.ts
@@ -91,6 +91,9 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (updates.cbs_id !== undefined) patch.cbs_id = updates.cbs_id;
     if (updates.zone !== undefined) patch.zone = updates.zone;
 
+    if (Object.keys(patch).length === 0)
+      return error("No updatable fields provided", 400);
+
     const { data: row, error: updErr } = await supabaseAdmin
       .from("cost_entries")
       .update(patch)

--- a/apps/web/app/api/projects/[id]/costs/route.ts
+++ b/apps/web/app/api/projects/[id]/costs/route.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from "@/lib/supabase-admin";
 import { success, error, parseBody } from "@/lib/api-utils";
 import { createCostEntrySchema } from "@maiyuri/shared";
 import { recomputeProject } from "@/lib/projects/recompute";
+import { z } from "zod";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -15,7 +16,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     const { id } = await params;
     const { data, error: dbErr } = await supabaseAdmin
       .from("cost_entries")
-      .select("*")
+      .select("*, cbs:cbs_master(id, cbs_code, category, work_item, cost_type)")
       .eq("project_id", id)
       .order("entry_date", { ascending: false })
       .order("created_at", { ascending: false });
@@ -66,6 +67,42 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return success(entry);
   } catch (err) {
     console.error("costs POST error:", err);
+    return error("Internal server error", 500);
+  }
+}
+
+const patchCostSchema = z.object({
+  id: z.string().uuid(),
+  approval_status: z.enum(["pending", "approved", "rejected"]).optional(),
+  cbs_id: z.string().uuid().nullable().optional(),
+  zone: z.string().nullable().optional(),
+});
+
+// PATCH — update approval_status or CBS assignment on a cost entry.
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const parsed = await parseBody(request, patchCostSchema);
+    if (parsed.error) return parsed.error;
+    const { id: costId, ...updates } = parsed.data;
+
+    const patch: Record<string, unknown> = {};
+    if (updates.approval_status !== undefined) patch.approval_status = updates.approval_status;
+    if (updates.cbs_id !== undefined) patch.cbs_id = updates.cbs_id;
+    if (updates.zone !== undefined) patch.zone = updates.zone;
+
+    const { data: row, error: updErr } = await supabaseAdmin
+      .from("cost_entries")
+      .update(patch)
+      .eq("id", costId)
+      .eq("project_id", id)
+      .select()
+      .single();
+
+    if (updErr) return error(`Failed to update cost: ${updErr.message}`, 500);
+    return success(row);
+  } catch (err) {
+    console.error("costs PATCH error:", err);
     return error("Internal server error", 500);
   }
 }

--- a/apps/web/app/api/projects/[id]/variance/route.ts
+++ b/apps/web/app/api/projects/[id]/variance/route.ts
@@ -1,0 +1,165 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { success, error } from "@/lib/api-utils";
+import type { CbsVarianceRow } from "@maiyuri/shared";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// Traffic-light thresholds (variance_pct = over-budget percentage)
+// variance_pct ≤ 0  → under_budget  (committed_forecast ≤ budget)
+// 0 < pct ≤ 5       → watch
+// 5 < pct ≤ 10      → risk
+// pct > 10          → critical
+function trafficLight(
+  variancePct: number
+): CbsVarianceRow["status"] {
+  if (variancePct <= 0) return "under_budget";
+  if (variancePct <= 5) return "watch";
+  if (variancePct <= 10) return "risk";
+  return "critical";
+}
+
+// GET /api/projects/[id]/variance
+// Core cost report: for each CBS code that has a budget OR an actual cost entry,
+// returns budget vs actual and computes the variance.
+//
+// Phase 1: committed_forecast = actual only.
+// Phase 2 will add open PO/subcontract balances.
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    // --- Budget side: aggregate current_budget_amount per cbs_id ---
+    const { data: budgetRows, error: budgetErr } = await supabaseAdmin
+      .from("project_budgets")
+      .select("cbs_id, current_budget_amount")
+      .eq("project_id", id);
+
+    if (budgetErr) return error("Failed to load budgets", 500);
+
+    // Group by cbs_id
+    const budgetByCbs: Record<string, number> = {};
+    for (const row of budgetRows ?? []) {
+      budgetByCbs[row.cbs_id] =
+        (budgetByCbs[row.cbs_id] ?? 0) + (row.current_budget_amount ?? 0);
+    }
+
+    // --- Actual side: sum approved cost_entries per cbs_id ---
+    const { data: costRows, error: costErr } = await supabaseAdmin
+      .from("cost_entries")
+      .select("cbs_id, amount, approval_status")
+      .eq("project_id", id)
+      .not("cbs_id", "is", null);
+
+    if (costErr) return error("Failed to load cost entries", 500);
+
+    const actualByCbs: Record<string, number> = {};
+    for (const row of costRows ?? []) {
+      if (row.approval_status === "approved" && row.cbs_id) {
+        actualByCbs[row.cbs_id] =
+          (actualByCbs[row.cbs_id] ?? 0) + (row.amount ?? 0);
+      }
+    }
+
+    // --- Collect all cbs_ids that appear in either ledger ---
+    const allCbsIds = Array.from(
+      new Set([
+        ...Object.keys(budgetByCbs),
+        ...Object.keys(actualByCbs),
+      ])
+    );
+
+    if (allCbsIds.length === 0) {
+      return success({
+        rows: [],
+        summary: {
+          totalBudget: 0,
+          totalActual: 0,
+          totalVariance: 0,
+          forecastProfit: 0,
+        },
+      });
+    }
+
+    // --- Load CBS master data for those ids ---
+    const { data: cbsItems, error: cbsErr } = await supabaseAdmin
+      .from("cbs_master")
+      .select("id, cbs_code, category, work_item, cost_type")
+      .in("id", allCbsIds);
+
+    if (cbsErr) return error("Failed to load CBS master", 500);
+
+    const cbsById: Record<
+      string,
+      { cbs_code: string; category: string; work_item: string; cost_type: string }
+    > = {};
+    for (const c of cbsItems ?? []) {
+      cbsById[c.id] = {
+        cbs_code: c.cbs_code,
+        category: c.category,
+        work_item: c.work_item,
+        cost_type: c.cost_type,
+      };
+    }
+
+    // --- Build variance rows ---
+    const rows: CbsVarianceRow[] = allCbsIds
+      .map((cbsId) => {
+        const cbs = cbsById[cbsId];
+        if (!cbs) return null;
+
+        const budget = budgetByCbs[cbsId] ?? 0;
+        const actual = actualByCbs[cbsId] ?? 0;
+        // Phase 1: committed_forecast = actual only (Phase 2 adds commitments)
+        const committedForecast = actual;
+        const variance = budget - committedForecast;
+        // variance_pct: how many percent over-budget is committed_forecast?
+        const variancePct =
+          budget > 0
+            ? ((committedForecast - budget) / budget) * 100
+            : committedForecast > 0
+            ? 100 // no budget but has actuals → fully over
+            : 0;
+
+        return {
+          cbs_id: cbsId,
+          cbs_code: cbs.cbs_code,
+          category: cbs.category,
+          work_item: cbs.work_item,
+          cost_type: cbs.cost_type,
+          budget,
+          actual,
+          committed_forecast: committedForecast,
+          variance,
+          variance_pct: Math.round(variancePct * 100) / 100,
+          status: trafficLight(variancePct),
+        } satisfies CbsVarianceRow;
+      })
+      .filter((r): r is CbsVarianceRow => r !== null)
+      .sort((a, b) => a.cbs_code.localeCompare(b.cbs_code));
+
+    // --- Summary ---
+    const totalBudget = rows.reduce((s, r) => s + r.budget, 0);
+    const totalActual = rows.reduce((s, r) => s + r.actual, 0);
+    const totalVariance = rows.reduce((s, r) => s + r.variance, 0);
+    // forecastProfit is a placeholder; real P&L (revenue - cost) in Phase 5
+    const forecastProfit = totalVariance;
+
+    return success({
+      rows,
+      summary: {
+        totalBudget,
+        totalActual,
+        totalVariance,
+        forecastProfit,
+      },
+    });
+  } catch (err) {
+    console.error("variance GET error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1845,6 +1845,11 @@ export interface CostEntry {
   source: CostSource;
   created_by?: string | null;
   created_at: string;
+  // CBS fields (Phase 1 additions — nullable for backward compat with old entries)
+  cbs_id?: string | null;
+  cbs?: CbsItem;
+  zone?: string | null;
+  approval_status?: 'pending' | 'approved' | 'rejected';
 }
 
 // ============================================================================
@@ -2093,4 +2098,93 @@ export interface CoachTodayPlanItem {
   refId: string;
   title: string;
   done: boolean;
+}
+
+// ============================================================================
+// CBS & BUDGET — Phase 1: Cost Breakdown Structure backbone
+// Tracks: cbs_master (company-wide codes), project_budgets (per-project),
+//         and CbsVarianceRow (computed report).
+// ============================================================================
+
+export type CbsCostType =
+  | 'material'
+  | 'labour'
+  | 'equipment'
+  | 'subcontract'
+  | 'transport'
+  | 'overhead'
+  | 'consumables'
+  | 'other';
+
+export interface CbsItem {
+  id: string;
+  cbs_code: string;
+  category: string;
+  work_item: string;
+  cost_type: CbsCostType;
+  unit?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export type BudgetStatus = 'draft' | 'approved';
+
+export interface ProjectBudget {
+  id: string;
+  project_id: string;
+  cbs_id: string;
+  cbs?: CbsItem;                      // joined on GET
+  zone?: string | null;
+  quantity: number;
+  unit?: string | null;
+  rate: number;
+  base_budget_amount: number;         // quantity × rate (DB GENERATED)
+  revision_amount_total: number;      // cumulative ± from approved revisions
+  current_budget_amount: number;      // base + revision_amount_total (DB GENERATED)
+  original_amount: number;            // snapshot locked on first approval
+  revision_no: number;
+  status: BudgetStatus;
+  approved_by?: string | null;
+  approved_at?: string | null;
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// Variance row — computed by /api/projects/[id]/variance
+export interface CbsVarianceRow {
+  cbs_id: string;
+  cbs_code: string;
+  category: string;
+  work_item: string;
+  cost_type: string;
+  budget: number;                     // current_budget_amount (sum across zones)
+  actual: number;                     // SUM of approved cost_entries
+  committed_forecast: number;         // Phase 1: = actual; Phase 2 adds open PO balances
+  variance: number;                   // budget - committed_forecast
+  variance_pct: number;               // (committed_forecast - budget) / budget × 100
+  status: 'under_budget' | 'watch' | 'risk' | 'critical';
+}
+
+export interface CbsVarianceSummary {
+  totalBudget: number;
+  totalActual: number;
+  totalVariance: number;
+  forecastProfit: number;             // placeholder; real P&L in Phase 5
+}
+
+export interface CbsVarianceReport {
+  rows: CbsVarianceRow[];
+  summary: CbsVarianceSummary;
+}
+
+export interface ProjectBudgetsResponse {
+  items: ProjectBudget[];
+  totals: {
+    base: number;
+    revision: number;
+    current: number;
+    original: number;
+  };
 }

--- a/supabase/migrations/20260607000001_cbs_and_budgets.sql
+++ b/supabase/migrations/20260607000001_cbs_and_budgets.sql
@@ -40,7 +40,8 @@ CREATE TRIGGER cbs_master_updated_at
 CREATE TABLE IF NOT EXISTS public.project_budgets (
   id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   project_id            UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
-  cbs_id                UUID NOT NULL REFERENCES public.cbs_master(id),
+  -- RESTRICT: a CBS code that is in use by a budget line cannot be deleted.
+  cbs_id                UUID NOT NULL REFERENCES public.cbs_master(id) ON DELETE RESTRICT,
   zone                  TEXT,                  -- "Ground Floor", "First Floor", "" etc.
   quantity              NUMERIC NOT NULL DEFAULT 0,
   unit                  TEXT,
@@ -53,6 +54,9 @@ CREATE TABLE IF NOT EXISTS public.project_budgets (
   revision_no           INTEGER NOT NULL DEFAULT 0,
   status                TEXT NOT NULL DEFAULT 'draft'
                           CHECK (status IN ('draft','approved')),
+  -- approved_by stores the approver's EMAIL (from x-user-email header), not a
+  -- user UUID — intentionally TEXT so historical approver identity survives
+  -- even if the auth.users row is later removed.
   approved_by           TEXT,
   approved_at           TIMESTAMPTZ,
   notes                 TEXT,
@@ -77,7 +81,8 @@ CREATE TRIGGER project_budgets_updated_at
 -- existing data is mapped.
 -- ============================================================================
 ALTER TABLE public.cost_entries
-  ADD COLUMN IF NOT EXISTS cbs_id UUID REFERENCES public.cbs_master(id),
+  -- RESTRICT: prevent deleting a CBS code that is referenced by cost entries.
+  ADD COLUMN IF NOT EXISTS cbs_id UUID REFERENCES public.cbs_master(id) ON DELETE RESTRICT,
   ADD COLUMN IF NOT EXISTS zone TEXT,
   ADD COLUMN IF NOT EXISTS approval_status TEXT NOT NULL DEFAULT 'pending'
     CHECK (approval_status IN ('pending','approved','rejected'));
@@ -176,7 +181,7 @@ BEGIN
   ON CONFLICT (cbs_code) DO NOTHING;
 
   INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
-    ('05.04', 'Masonry', 'Mortar & masonry material consumables', 'labour', 'sqft')
+    ('05.04', 'Masonry', 'Mortar & masonry material consumables', 'consumables', 'sqft')
   ON CONFLICT (cbs_code) DO NOTHING;
 
   -- 06 Plastering

--- a/supabase/migrations/20260607000001_cbs_and_budgets.sql
+++ b/supabase/migrations/20260607000001_cbs_and_budgets.sql
@@ -1,0 +1,257 @@
+-- CBS Cost-Control Backbone — Phase 1
+-- Creates: cbs_master (33 seeded codes), project_budgets (revision-safe 3-field design),
+--          ALTER cost_entries (adds cbs_id, zone, approval_status)
+-- Conventions: UUID PK, CHECK enums, TIMESTAMPTZ, update_updated_at trigger, RLS auth_all policy
+
+-- ============================================================================
+-- CBS MASTER  (company-wide reusable cost codes)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.cbs_master (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cbs_code    TEXT NOT NULL UNIQUE,          -- e.g. "05.01"
+  category    TEXT NOT NULL,                 -- e.g. "Masonry"
+  work_item   TEXT NOT NULL,                 -- e.g. "8 inch block material"
+  cost_type   TEXT NOT NULL DEFAULT 'material'
+                CHECK (cost_type IN (
+                  'material','labour','equipment','subcontract',
+                  'transport','overhead','consumables','other'
+                )),
+  unit        TEXT,                          -- Nos / sqft / kg / m³ / LS / trip
+  is_active   BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_cbs_master_category  ON public.cbs_master(category);
+CREATE INDEX IF NOT EXISTS idx_cbs_master_is_active ON public.cbs_master(is_active);
+
+CREATE TRIGGER cbs_master_updated_at
+  BEFORE UPDATE ON public.cbs_master
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- ============================================================================
+-- PROJECT BUDGETS  (per-project CBS budget line items with revision support)
+-- ============================================================================
+-- DESIGN NOTE: Three-field budget pattern to support Phase 3 revisions:
+--   base_budget_amount   = quantity × rate  (GENERATED — never editable directly)
+--   revision_amount_total = cumulative ± from approved revisions (plain numeric)
+--   current_budget_amount = base + revision_amount_total  (GENERATED — the live budget)
+-- Variance report always uses current_budget_amount.
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.project_budgets (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id            UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  cbs_id                UUID NOT NULL REFERENCES public.cbs_master(id),
+  zone                  TEXT,                  -- "Ground Floor", "First Floor", "" etc.
+  quantity              NUMERIC NOT NULL DEFAULT 0,
+  unit                  TEXT,
+  rate                  NUMERIC NOT NULL DEFAULT 0,
+  -- Three-field revision-safe budget design
+  base_budget_amount    NUMERIC GENERATED ALWAYS AS (quantity * rate) STORED,
+  revision_amount_total NUMERIC NOT NULL DEFAULT 0,   -- cumulative ± from all approved revisions
+  current_budget_amount NUMERIC GENERATED ALWAYS AS ((quantity * rate) + revision_amount_total) STORED,
+  original_amount       NUMERIC NOT NULL DEFAULT 0,   -- snapshot locked on first approval
+  revision_no           INTEGER NOT NULL DEFAULT 0,
+  status                TEXT NOT NULL DEFAULT 'draft'
+                          CHECK (status IN ('draft','approved')),
+  approved_by           TEXT,
+  approved_at           TIMESTAMPTZ,
+  notes                 TEXT,
+  created_by            UUID REFERENCES auth.users(id),
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_project_budgets_project    ON public.project_budgets(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_budgets_cbs        ON public.project_budgets(cbs_id);
+CREATE INDEX IF NOT EXISTS idx_project_budgets_project_cbs ON public.project_budgets(project_id, cbs_id);
+CREATE INDEX IF NOT EXISTS idx_project_budgets_status     ON public.project_budgets(status);
+
+CREATE TRIGGER project_budgets_updated_at
+  BEFORE UPDATE ON public.project_budgets
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- ============================================================================
+-- ALTER cost_entries — add CBS linkage, zone, and approval workflow
+-- ============================================================================
+-- cbs_id is nullable at DB level (old entries have no CBS).
+-- UI requires CBS for new entries. Future migration enforces NOT NULL after
+-- existing data is mapped.
+-- ============================================================================
+ALTER TABLE public.cost_entries
+  ADD COLUMN IF NOT EXISTS cbs_id UUID REFERENCES public.cbs_master(id),
+  ADD COLUMN IF NOT EXISTS zone TEXT,
+  ADD COLUMN IF NOT EXISTS approval_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (approval_status IN ('pending','approved','rejected'));
+
+CREATE INDEX IF NOT EXISTS idx_cost_entries_cbs ON public.cost_entries(cbs_id);
+
+-- ============================================================================
+-- RLS — enable + authenticated-staff full access (service role bypasses)
+-- ============================================================================
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['cbs_master','project_budgets'] LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY;', t);
+    EXECUTE format('DROP POLICY IF EXISTS %I_auth_all ON public.%I;', t, t);
+    EXECUTE format(
+      'CREATE POLICY %I_auth_all ON public.%I FOR ALL USING (auth.role() = ''authenticated'') WITH CHECK (auth.role() = ''authenticated'');',
+      t, t);
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- SEED — 33 Standard Construction CBS Codes
+-- ============================================================================
+-- Using DO block for idempotency (re-runnable; won't duplicate).
+-- ============================================================================
+DO $$
+BEGIN
+  -- 01 Preliminaries
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('01.01', 'Preliminaries', 'Site establishment & mobilisation', 'overhead', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('01.02', 'Preliminaries', 'Project management & supervision', 'overhead', 'month')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('01.03', 'Preliminaries', 'Watchman / site security', 'labour', 'month')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 02 Earthwork
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('02.01', 'Earthwork', 'Excavation & earth removal (sub)', 'subcontract', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('02.02', 'Earthwork', 'Backfilling & compaction labour', 'labour', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 03 Foundation
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('03.01', 'Foundation', 'PCC / lean concrete material', 'material', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('03.02', 'Foundation', 'Rubble stone / aggregate material', 'material', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('03.03', 'Foundation', 'Footing rebar & binding wire', 'material', 'kg')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('03.04', 'Foundation', 'Foundation labour (excavation + concrete)', 'labour', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 04 RCC Structure
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('04.01', 'RCC Structure', 'Cement bags', 'material', 'bag')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('04.02', 'RCC Structure', 'TMT steel rebar', 'material', 'kg')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('04.03', 'RCC Structure', 'Aggregate & river sand', 'material', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('04.04', 'RCC Structure', 'RCC work (shuttering + pour + cure)', 'subcontract', 'cum')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 05 Masonry
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('05.01', 'Masonry', '8 inch block material', 'material', 'Nos')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('05.02', 'Masonry', 'Block masonry labour', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('05.03', 'Masonry', '4 inch block / brick material', 'material', 'Nos')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('05.04', 'Masonry', 'Mortar & masonry material consumables', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 06 Plastering
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('06.01', 'Plastering', 'Internal plastering labour', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('06.02', 'Plastering', 'External plastering labour', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 07 Flooring
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('07.01', 'Flooring', 'Tile / granite / marble material', 'material', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('07.02', 'Flooring', 'Flooring labour (tiles + grouting)', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 08 Painting
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('08.01', 'Painting', 'Primer, putty & paint material', 'material', 'litre')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('08.02', 'Painting', 'Painting labour (interior + exterior)', 'labour', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 09 Electrical
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('09.01', 'Electrical', 'Wiring, conduits, switches & panels', 'material', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('09.02', 'Electrical', 'Electrical installation labour', 'labour', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 10 Plumbing
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('10.01', 'Plumbing', 'Pipes, fittings & sanitary ware', 'material', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('10.02', 'Plumbing', 'Plumbing installation labour', 'labour', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 11 Doors & Windows
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('11.01', 'Doors & Windows', 'Door frames, shutters & window frames', 'material', 'Nos')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('11.02', 'Doors & Windows', 'Door & window fixing labour', 'labour', 'Nos')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 12 External Works
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('12.01', 'External Works', 'Compound wall & gate (subcontract)', 'subcontract', 'rft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('12.02', 'External Works', 'Driveway, pathway & landscaping (sub)', 'subcontract', 'sqft')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  -- 13 Other / Sundry
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('13.01', 'Other', 'Material transport & delivery charges', 'transport', 'trip')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('13.02', 'Other', 'Sundry / unclassified labour', 'labour', 'day')
+  ON CONFLICT (cbs_code) DO NOTHING;
+
+  INSERT INTO public.cbs_master (cbs_code, category, work_item, cost_type, unit) VALUES
+    ('13.03', 'Other', 'Consumables & small tools', 'consumables', 'LS')
+  ON CONFLICT (cbs_code) DO NOTHING;
+END $$;


### PR DESCRIPTION
## Summary

- **Database**: New `cbs_master` table (33 seeded standard construction codes 01.01–13.03), `project_budgets` table with revision-safe 3-field design, and `ALTER cost_entries` adds CBS link + approval workflow
- **API**: 6 new routes — `/api/cbs`, `/api/projects/[id]/budgets` (CRUD + approve), `/api/projects/[id]/variance`, plus PATCH on `/costs` for CBS assignment
- **UI**: Two new project tabs — **Budget / CBS** (add lines, approve budget) and **Variance** (traffic-light report: green/amber/orange/red); Costs tab enhanced with CBS picker and approval status badges

## Why Phase 1 only

Scoped to the CBS backbone only (three-ledger model, variance formula, traffic-light). Commitments (POs), budget revisions, change orders, Gantt, issues, risks, and documents are explicitly deferred to Phase 2–5 to keep this branch debuggable.

## Key design decisions

| Decision | Reason |
|---|---|
| `revision_amount_total` + two GENERATED columns | GENERATED columns can't be updated; separating the revision delta allows Phase 3 to adjust budgets without breaking DB constraints |
| `cbs_id` nullable at DB level | Old cost entries have no CBS; enforced in UI, not DB (migration enforces NOT NULL after backfill) |
| `variance_pct ≤ 0 → under_budget` | Phase 1 committed_forecast = actual only; labeled correctly so users aren't misled |
| 33 codes seeded in migration | Day-1 usable without manual setup |

## Test plan

- [ ] Run `supabase db push` (or apply migration) → verify 33 CBS rows seeded
- [ ] `GET /api/cbs` → returns 33 active codes
- [ ] Project detail page → Budget / CBS tab → add 3 lines → Approve Budget → rows show "approved" + locked
- [ ] Add 2 cost entries with CBS codes → set approval_status = approved → Variance tab shows actuals populated
- [ ] Add 1 cost entry with NO CBS → Costs tab shows it with "pending" badge
- [ ] Variance tab traffic-light: green / amber / orange / red per thresholds
- [ ] Existing tabs (Overview, Estimate/BOQ, WBS, Daily Progress, AI Insights) unaffected
- [ ] `bun run typecheck` → 0 errors
- [ ] `bun run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Budget/CBS tab for managing project budgets with line-item tracking, totals, revision history placeholder, add/delete, and bulk-approve (with confirmation)
  * Added Variance tab with summary cards, category-grouped variance table, and traffic‑light status indicators
  * Enhanced Cost form to select grouped CBS codes and specify zone; costs now show category/CBS/zone/WBS/vendor metadata and approval badge
* **Workflows**
  * Cost approval action and approval status tracking (pending → approved)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->