### PR TITLE
feat: push notifications expansion + default-assignee + Superfone call audit

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, Button, Spinner } from "@maiyuri/ui";
 import { SmartQuoteImagesTab } from "@/components/settings/SmartQuoteImagesTab";
 import { WallCostSettingsTab } from "@/components/settings/WallCostSettingsTab";
+import { CallAuditTab } from "@/components/settings/CallAuditTab";
 import { HelpButton } from "@/components/help";
 import { getSupabase } from "@/lib/supabase";
 import { interpretPushTest } from "@/lib/push/test-result";
@@ -79,7 +80,8 @@ type TabId =
   | "team"
   | "smart-quotes"
   | "wall-costs"
-  | "nudges";
+  | "nudges"
+  | "call-audit";
 
 interface Tab {
   id: TabId;
@@ -94,6 +96,7 @@ const TABS: Tab[] = [
   { id: "smart-quotes", label: "Smart Quotes", roles: ["founder"] },
   { id: "wall-costs", label: "Wall Costs", roles: ["founder", "owner"] },
   { id: "nudges", label: "Nudges", roles: ["founder", "owner", "admin"] },
+  { id: "call-audit", label: "Call Audit", roles: ["founder", "owner"] },
 ];
 
 export default function SettingsPage() {
@@ -153,6 +156,7 @@ export default function SettingsPage() {
       {activeTab === "smart-quotes" && <SmartQuoteImagesTab />}
       {activeTab === "wall-costs" && <WallCostSettingsTab />}
       {activeTab === "nudges" && <NudgesSettings />}
+      {activeTab === "call-audit" && <CallAuditTab />}
     </div>
   );
 }

--- a/apps/web/app/api/leads/[id]/analyze/route.ts
+++ b/apps/web/app/api/leads/[id]/analyze/route.ts
@@ -4,6 +4,7 @@ import { success, error, notFound } from "@/lib/api-utils";
 import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { getUserFromRequest } from "@/lib/supabase-server";
 import { notifyAIAnalysis } from "@/lib/telegram";
+import { notifyLeadPush, resolveLeadRecipients } from "@/lib/push/fcm";
 import type { Lead, NudgeEventType } from "@maiyuri/shared";
 
 const APP_URL =
@@ -274,6 +275,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const isHot = newScore >= HOT_LEAD_THRESHOLD;
 
       if (!wasHot && isHot) {
+        // Native push to the owner (or leadership) — a hot lead needs action now.
+        try {
+          const recipients = await resolveLeadRecipients(
+            updatedLead.assigned_staff ?? null,
+          );
+          await notifyLeadPush(recipients, {
+            title: "🔥 Lead just turned hot",
+            body: `${updatedLead.name ?? "A lead"} crossed ${Math.round(
+              HOT_LEAD_THRESHOLD * 100,
+            )}% — follow up now`,
+            leadId: id,
+          });
+        } catch (err) {
+          console.error("[Hot Lead Push] failed:", err);
+        }
+
         // Lead just became hot - trigger hot lead alert
         triggerEventNudge("hot_lead_alert", id, {
           previous_score: previousScore,

--- a/apps/web/app/api/leads/route.ts
+++ b/apps/web/app/api/leads/route.ts
@@ -11,28 +11,13 @@ import {
   sanitizeSearchTerm,
 } from "@/lib/api-utils";
 import { notifyNewLeadDetailed } from "@/lib/telegram";
-import { notifyLeadPush } from "@/lib/push/fcm";
+import { notifyLeadPush, resolveLeadRecipients } from "@/lib/push/fcm";
 import {
   createLeadSchema,
   paginationSchema,
   leadFiltersSchema,
   type Lead,
 } from "@maiyuri/shared";
-
-/**
- * Resolve which users should receive a "new lead" push:
- * the assigned rep if set, otherwise leadership (founder/owner).
- */
-async function resolveNewLeadRecipients(
-  assignedStaff: string | null,
-): Promise<string[]> {
-  if (assignedStaff) return [assignedStaff];
-  const { data } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .in("role", ["founder", "owner"]);
-  return (data ?? []).map((u) => u.id);
-}
 
 // GET /api/leads - List all leads with filtering and pagination
 export async function GET(request: NextRequest) {
@@ -135,9 +120,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Native push for the new lead (awaited before response so Vercel doesn't kill it).
-    const recipients = await resolveNewLeadRecipients(
-      lead.assigned_staff ?? null,
-    );
+    const recipients = await resolveLeadRecipients(lead.assigned_staff ?? null);
     const requirement = lead.requirement_type
       ? String(lead.requirement_type).replace(/_/g, " ")
       : null;

--- a/apps/web/app/api/reconciliation/superfone/route.ts
+++ b/apps/web/app/api/reconciliation/superfone/route.ts
@@ -1,0 +1,99 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { getUserFromRequest } from "@/lib/supabase-server";
+import { success, error } from "@/lib/api-utils";
+import {
+  parseCsv,
+  detectColumn,
+  normalizePhone,
+  reconcile,
+} from "@/lib/reconciliation/superfone";
+
+// POST /api/reconciliation/superfone — diff a Superfone call-log CSV against
+// CRM leads and return the callers that never became a lead. Founder/owner only.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return error("Unauthorized", 401);
+
+    const { data: me } = await supabaseAdmin
+      .from("users")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+    if (!me || !["founder", "owner"].includes(me.role)) {
+      return error("Forbidden", 403);
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const csv = typeof body.csv === "string" ? body.csv : "";
+    if (!csv.trim()) return error("Missing CSV content", 400);
+    const sinceDays =
+      typeof body.sinceDays === "number" && body.sinceDays > 0
+        ? Math.floor(body.sinceDays)
+        : null;
+
+    const { headers, rows } = parseCsv(csv);
+    if (!headers.length || !rows.length) {
+      return error("CSV has no data rows", 400);
+    }
+
+    // Locate the phone column: caller-supplied override, else auto-detect.
+    const phoneIdx =
+      typeof body.phoneColumn === "string" && headers.includes(body.phoneColumn)
+        ? headers.indexOf(body.phoneColumn)
+        : detectColumn(headers, [
+            /phone/i,
+            /mobile/i,
+            /\bnumber\b/i,
+            /caller/i,
+            /from/i,
+            /contact/i,
+          ]);
+
+    // Couldn't guess — let the UI present a column picker.
+    if (phoneIdx < 0) {
+      return success({ needsColumn: true, headers });
+    }
+
+    const nameIdx = detectColumn(headers, [/name/i, /caller/i]);
+    const dateIdx = detectColumn(headers, [/date|time|timestamp/i]);
+
+    const calls = rows.map((r) => ({
+      phone: r[phoneIdx] ?? "",
+      name: nameIdx >= 0 ? (r[nameIdx] ?? null) : null,
+      at: dateIdx >= 0 ? (r[dateIdx] ?? null) : null,
+    }));
+
+    // Build the set of known lead phone numbers (optionally windowed).
+    let query = supabaseAdmin.from("leads").select("contact, created_at");
+    if (sinceDays) {
+      const since = new Date(Date.now() - sinceDays * 86_400_000).toISOString();
+      query = query.gte("created_at", since);
+    }
+    const { data: leads, error: dbErr } = await query;
+    if (dbErr) {
+      console.error("reconcile leads query error:", dbErr);
+      return error("Failed to load leads", 500);
+    }
+
+    const leadPhones = new Set(
+      (leads ?? [])
+        .map((l) => normalizePhone(l.contact as string | null))
+        .filter(Boolean),
+    );
+
+    const result = reconcile(calls, leadPhones);
+    return success({
+      ...result,
+      leadsConsidered: leadPhones.size,
+      phoneColumn: headers[phoneIdx],
+      sinceDays,
+    });
+  } catch (err) {
+    console.error("reconcile error:", err);
+    return error("Internal server error", 500);
+  }
+}

--- a/apps/web/app/api/sq/[slug]/submit/route.ts
+++ b/apps/web/app/api/sq/[slug]/submit/route.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from "@/lib/supabase-admin";
 import { success, notFound, error, parseBody } from "@/lib/api-utils";
 import { smartQuoteCtaSubmitSchema } from "@maiyuri/shared";
 import { sendTelegramMessage } from "@/lib/telegram";
+import { notifyLeadPush, resolveLeadRecipients } from "@/lib/push/fcm";
 
 interface RouteParams {
   params: Promise<{ slug: string }>;
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Get lead details
     const { data: lead } = await supabaseAdmin
       .from("leads")
-      .select("id, name, contact, lead_status")
+      .select("id, name, contact, lead_status, assigned_staff")
       .eq("id", quote.lead_id)
       .single();
 
@@ -128,6 +129,23 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       primaryAngle: quote.primary_angle,
       quoteSlug: slug,
     }).catch(console.error);
+
+    // Native push: a customer just responded to the quote — strong buying
+    // signal, so notify the rep (or leadership) to follow up fast.
+    if (lead) {
+      try {
+        const recipients = await resolveLeadRecipients(
+          lead.assigned_staff ?? null,
+        );
+        await notifyLeadPush(recipients, {
+          title: "📨 Customer responded to your quote",
+          body: `${name} · ${formatRoute(quote.route_decision)}`,
+          leadId: lead.id,
+        });
+      } catch (err) {
+        console.error("[SmartQuoteSubmit] push failed:", err);
+      }
+    }
 
     return success({ submitted: true });
   } catch (err) {

--- a/apps/web/src/components/settings/CallAuditTab.tsx
+++ b/apps/web/src/components/settings/CallAuditTab.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import { Card, Button, Spinner } from "@maiyuri/ui";
+import { getSupabase } from "@/lib/supabase";
+
+interface CallGap {
+  phone: string;
+  name: string | null;
+  calls: number;
+  lastCallAt: string | null;
+}
+
+interface ReconcileResponse {
+  needsColumn?: boolean;
+  headers?: string[];
+  totalCalls?: number;
+  uniqueCallers?: number;
+  matched?: number;
+  leadsConsidered?: number;
+  callsWithoutLead?: CallGap[];
+  phoneColumn?: string;
+}
+
+async function authFetch(input: string, init: RequestInit = {}) {
+  let token: string | undefined;
+  try {
+    const {
+      data: { session },
+    } = await getSupabase().auth.getSession();
+    token = session?.access_token;
+  } catch {
+    /* fall through — request will 401 */
+  }
+  return fetch(input, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+}
+
+export function CallAuditTab() {
+  const [csv, setCsv] = useState("");
+  const [fileName, setFileName] = useState("");
+  const [sinceDays, setSinceDays] = useState<string>("0");
+  const [phoneColumn, setPhoneColumn] = useState<string>("");
+  const [columns, setColumns] = useState<string[]>([]);
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">(
+    "idle",
+  );
+  const [message, setMessage] = useState("");
+  const [result, setResult] = useState<ReconcileResponse | null>(null);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    setCsv(await file.text());
+    setColumns([]);
+    setPhoneColumn("");
+    setResult(null);
+    setStatus("idle");
+    setMessage("");
+  };
+
+  const run = async () => {
+    if (!csv.trim()) {
+      setStatus("error");
+      setMessage("Choose a Superfone CSV export first.");
+      return;
+    }
+    setStatus("loading");
+    setMessage("");
+    try {
+      const res = await authFetch("/api/reconciliation/superfone", {
+        method: "POST",
+        body: JSON.stringify({
+          csv,
+          sinceDays: Number(sinceDays) || undefined,
+          phoneColumn: phoneColumn || undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Failed to analyse CSV");
+      const data: ReconcileResponse = json.data ?? {};
+      if (data.needsColumn) {
+        setColumns(data.headers ?? []);
+        setStatus("idle");
+        setMessage("Couldn't detect the phone column — pick it and run again.");
+        return;
+      }
+      setResult(data);
+      setStatus("done");
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : "Something went wrong.");
+    }
+  };
+
+  const downloadGaps = () => {
+    const gaps = result?.callsWithoutLead ?? [];
+    const lines = [
+      "phone,name,calls,last_call",
+      ...gaps.map(
+        (g) =>
+          `${g.phone},"${(g.name ?? "").replace(/"/g, '""')}",${g.calls},${g.lastCallAt ?? ""}`,
+      ),
+    ];
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "calls-without-leads.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const gaps = result?.callsWithoutLead ?? [];
+
+  return (
+    <Card className="p-6">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-1">
+        Call Audit — Superfone vs Leads
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">
+        Export your Superfone call log as CSV and upload it here. We match
+        numbers (last 10 digits) against your leads and list callers that never
+        became a lead.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <label className="px-3 py-2 text-sm font-medium rounded-md bg-slate-100 dark:bg-slate-800 cursor-pointer hover:bg-slate-200 dark:hover:bg-slate-700">
+          {fileName || "Choose CSV…"}
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={onFile}
+            className="hidden"
+          />
+        </label>
+
+        <select
+          value={sinceDays}
+          onChange={(e) => setSinceDays(e.target.value)}
+          className="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm"
+        >
+          <option value="0">Compare all leads</option>
+          <option value="30">Leads from last 30 days</option>
+          <option value="90">Leads from last 90 days</option>
+        </select>
+
+        {columns.length > 0 && (
+          <select
+            value={phoneColumn}
+            onChange={(e) => setPhoneColumn(e.target.value)}
+            className="rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm"
+          >
+            <option value="">Select phone column…</option>
+            {columns.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <Button onClick={run} disabled={status === "loading" || !csv}>
+          {status === "loading" ? "Analysing…" : "Analyse"}
+        </Button>
+      </div>
+
+      {message && (
+        <p
+          className={`text-sm mb-4 ${
+            status === "error"
+              ? "text-red-600 dark:text-red-400"
+              : "text-amber-600 dark:text-amber-400"
+          }`}
+        >
+          {message}
+        </p>
+      )}
+
+      {status === "loading" && (
+        <div className="flex justify-center py-8">
+          <Spinner size="md" />
+        </div>
+      )}
+
+      {status === "done" && result && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <Stat label="Total calls" value={result.totalCalls ?? 0} />
+            <Stat label="Unique callers" value={result.uniqueCallers ?? 0} />
+            <Stat label="Matched to leads" value={result.matched ?? 0} />
+            <Stat
+              label="No lead created"
+              value={gaps.length}
+              highlight={gaps.length > 0}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-slate-900 dark:text-white">
+              Callers with no lead ({gaps.length})
+            </h3>
+            {gaps.length > 0 && (
+              <button
+                onClick={downloadGaps}
+                className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Download CSV
+              </button>
+            )}
+          </div>
+
+          {gaps.length === 0 ? (
+            <p className="text-sm text-green-600 dark:text-green-400">
+              🎉 Every caller in this export has a matching lead.
+            </p>
+          ) : (
+            <div className="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 dark:bg-slate-800 text-left text-slate-500">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Phone</th>
+                    <th className="px-3 py-2 font-medium">Name</th>
+                    <th className="px-3 py-2 font-medium">Calls</th>
+                    <th className="px-3 py-2 font-medium">Last call</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {gaps.map((g) => (
+                    <tr key={g.phone}>
+                      <td className="px-3 py-2 font-mono">{g.phone}</td>
+                      <td className="px-3 py-2">{g.name || "—"}</td>
+                      <td className="px-3 py-2">{g.calls}</td>
+                      <td className="px-3 py-2">{g.lastCallAt || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">
+      <div
+        className={`text-2xl font-bold ${
+          highlight
+            ? "text-red-600 dark:text-red-400"
+            : "text-slate-900 dark:text-white"
+        }`}
+      >
+        {value}
+      </div>
+      <div className="text-xs text-slate-500 dark:text-slate-400">{label}</div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/call-recording/processor.ts
+++ b/apps/web/src/lib/call-recording/processor.ts
@@ -13,15 +13,22 @@ import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { uploadToGoogleDrive } from "./gdrive-storage";
 import { transcribeAudio } from "./transcription";
 import { analyzeTranscript, extractLeadDetails } from "./analysis";
-import { sendCallRecordingNotification, sendErrorNotification } from "./notifications";
-import { notifyLeadPush } from "@/lib/push/fcm";
+import {
+  sendCallRecordingNotification,
+  sendErrorNotification,
+} from "./notifications";
+import { notifyLeadPush, resolveLeadRecipients } from "@/lib/push/fcm";
 import { logError, logProgress } from "./logger";
 import {
   triggerLeadAnalysis,
   triggerCallRecordingNudge,
   triggerObjectionNudge,
 } from "./triggers";
-import type { CallRecording, ExtractedLeadDetails, ProcessingStatus } from "./types";
+import type {
+  CallRecording,
+  ExtractedLeadDetails,
+  ProcessingStatus,
+} from "./types";
 
 /**
  * Update recording status in database
@@ -165,7 +172,11 @@ export async function processRecording(
     // Stage 2: Upload to Google Drive (raw audio)
     // ========================================
     const lead = await getLeadDetails(lead_id);
-    let driveResult: { fileId: string; webViewLink: string; webContentLink?: string } | null = null;
+    let driveResult: {
+      fileId: string;
+      webViewLink: string;
+      webContentLink?: string;
+    } | null = null;
 
     const hasGDriveCredentials =
       process.env.GOOGLE_CLIENT_ID &&
@@ -190,7 +201,10 @@ export async function processRecording(
         mp3_gdrive_url: driveResult.webViewLink,
       });
     } else {
-      logProgress(id, "Skipping Google Drive upload (credentials not configured)");
+      logProgress(
+        id,
+        "Skipping Google Drive upload (credentials not configured)",
+      );
     }
 
     // ========================================
@@ -280,7 +294,10 @@ export async function processRecording(
         ) {
           updates.classification = extractedDetails.classification;
         }
-        if (!currentLead.requirement_type && extractedDetails.requirement_type) {
+        if (
+          !currentLead.requirement_type &&
+          extractedDetails.requirement_type
+        ) {
           updates.requirement_type = extractedDetails.requirement_type;
         }
         if (
@@ -299,7 +316,10 @@ export async function processRecording(
         if (!currentLead.next_action && extractedDetails.next_action) {
           updates.next_action = extractedDetails.next_action;
         }
-        if (!currentLead.estimated_quantity && extractedDetails.estimated_quantity) {
+        if (
+          !currentLead.estimated_quantity &&
+          extractedDetails.estimated_quantity
+        ) {
           updates.estimated_quantity = extractedDetails.estimated_quantity;
         }
         if (!currentLead.notes && extractedDetails.notes) {
@@ -348,12 +368,19 @@ export async function processRecording(
       isNewlyAutoPopulated,
     });
 
-    // Native push to the rep who owns this lead (best-effort, non-blocking).
-    if (lead?.assigned_staff && lead?.id) {
-      await notifyLeadPush([lead.assigned_staff], {
-        title: lead.name ? `📞 Call logged: ${lead.name}` : "📞 New call logged",
-        body:
-          (analysis.summary || "A new call recording was processed.").slice(0, 160),
+    // Native push to the rep who owns this lead — or leadership when the lead
+    // is unassigned (Telegram voice notes auto-create leads with no owner).
+    // Best-effort, non-blocking.
+    if (lead?.id) {
+      const recipients = await resolveLeadRecipients(lead.assigned_staff);
+      await notifyLeadPush(recipients, {
+        title: lead.name
+          ? `📞 Call logged: ${lead.name}`
+          : "📞 New call logged",
+        body: (analysis.summary || "A new call recording was processed.").slice(
+          0,
+          160,
+        ),
         leadId: lead.id,
       });
     }

--- a/apps/web/src/lib/push/fcm.test.ts
+++ b/apps/web/src/lib/push/fcm.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for resolveLeadRecipients — ensures lead pushes target the assigned
+ * rep, and fall back to leadership for unassigned leads (e.g. Telegram voice
+ * notes) so notifications are never silently dropped.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockIn = vi.fn();
+vi.mock("@/lib/supabase-admin", () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => ({ select: vi.fn(() => ({ in: mockIn })) })),
+  },
+}));
+// googleapis is imported by fcm.ts but unused in these tests — stub it out.
+vi.mock("googleapis", () => ({ google: { auth: { JWT: class {} } } }));
+
+import { resolveLeadRecipients } from "./fcm";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("resolveLeadRecipients", () => {
+  it("returns the assigned rep without a DB lookup", async () => {
+    expect(await resolveLeadRecipients("rep-1")).toEqual(["rep-1"]);
+    expect(mockIn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to founders/owners when unassigned", async () => {
+    mockIn.mockResolvedValue({ data: [{ id: "f1" }, { id: "o1" }] });
+    expect(await resolveLeadRecipients(null)).toEqual(["f1", "o1"]);
+    expect(mockIn).toHaveBeenCalledWith("role", ["founder", "owner"]);
+  });
+
+  it("returns an empty array when no leadership exists", async () => {
+    mockIn.mockResolvedValue({ data: [] });
+    expect(await resolveLeadRecipients(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/push/fcm.test.ts
+++ b/apps/web/src/lib/push/fcm.test.ts
@@ -14,9 +14,22 @@ vi.mock("@/lib/supabase-admin", () => ({
 // googleapis is imported by fcm.ts but unused in these tests — stub it out.
 vi.mock("googleapis", () => ({ google: { auth: { JWT: class {} } } }));
 
-import { resolveLeadRecipients } from "./fcm";
+import { resolveLeadRecipients, getUserIdsByRoles } from "./fcm";
 
 beforeEach(() => vi.clearAllMocks());
+
+describe("getUserIdsByRoles", () => {
+  it("returns [] for an empty role list without a DB query", async () => {
+    expect(await getUserIdsByRoles([])).toEqual([]);
+    expect(mockIn).not.toHaveBeenCalled();
+  });
+
+  it("maps matched users to their ids", async () => {
+    mockIn.mockResolvedValue({ data: [{ id: "a" }, { id: "b" }] });
+    expect(await getUserIdsByRoles(["founder", "owner"])).toEqual(["a", "b"]);
+    expect(mockIn).toHaveBeenCalledWith("role", ["founder", "owner"]);
+  });
+});
 
 describe("resolveLeadRecipients", () => {
   it("returns the assigned rep without a DB lookup", async () => {

--- a/apps/web/src/lib/push/fcm.ts
+++ b/apps/web/src/lib/push/fcm.ts
@@ -140,6 +140,16 @@ export async function sendPushToUser(
   return sendPushToUsers([userId], payload);
 }
 
+/** Return the user IDs of everyone holding any of the given roles. */
+export async function getUserIdsByRoles(roles: string[]): Promise<string[]> {
+  if (!roles.length) return [];
+  const { data } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .in("role", roles);
+  return (data ?? []).map((u) => u.id as string);
+}
+
 /**
  * Resolve who should receive a lead-related push: the assigned rep if set,
  * otherwise leadership (founder/owner) as a fallback. This matters for leads
@@ -150,11 +160,7 @@ export async function resolveLeadRecipients(
   assignedStaff: string | null | undefined,
 ): Promise<string[]> {
   if (assignedStaff) return [assignedStaff];
-  const { data } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .in("role", ["founder", "owner"]);
-  return (data ?? []).map((u) => u.id as string);
+  return getUserIdsByRoles(["founder", "owner"]);
 }
 
 /**

--- a/apps/web/src/lib/push/fcm.ts
+++ b/apps/web/src/lib/push/fcm.ts
@@ -141,6 +141,23 @@ export async function sendPushToUser(
 }
 
 /**
+ * Resolve who should receive a lead-related push: the assigned rep if set,
+ * otherwise leadership (founder/owner) as a fallback. This matters for leads
+ * with no owner — e.g. auto-created from a Telegram voice note — so they still
+ * notify someone instead of being silently dropped.
+ */
+export async function resolveLeadRecipients(
+  assignedStaff: string | null | undefined,
+): Promise<string[]> {
+  if (assignedStaff) return [assignedStaff];
+  const { data } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .in("role", ["founder", "owner"]);
+  return (data ?? []).map((u) => u.id as string);
+}
+
+/**
  * Convenience wrapper for lead-related pushes: centralizes the `/leads/[id]`
  * deep-link convention and the best-effort (swallow + log) discipline every
  * lead trigger needs, so call sites only decide recipients + copy. Never

--- a/apps/web/src/lib/reconciliation/superfone.test.ts
+++ b/apps/web/src/lib/reconciliation/superfone.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { normalizePhone, parseCsv, detectColumn, reconcile } from "./superfone";
+
+describe("normalizePhone", () => {
+  it("matches numbers regardless of +91 / 0 / spacing", () => {
+    expect(normalizePhone("+91 98765 43210")).toBe("9876543210");
+    expect(normalizePhone("098765-43210")).toBe("9876543210");
+    expect(normalizePhone("919876543210")).toBe("9876543210");
+  });
+  it("returns '' for empty/garbage input", () => {
+    expect(normalizePhone(null)).toBe("");
+    expect(normalizePhone("n/a")).toBe("");
+  });
+});
+
+describe("parseCsv", () => {
+  it("parses headers, quoted fields, and skips blank rows", () => {
+    const csv =
+      'Caller,Phone,Time\n"Ravi, K",+91 98765 43210,2026-06-01\n\nAnu,9000000000,2026-06-02\n';
+    const { headers, rows } = parseCsv(csv);
+    expect(headers).toEqual(["Caller", "Phone", "Time"]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual(["Ravi, K", "+91 98765 43210", "2026-06-01"]);
+  });
+});
+
+describe("detectColumn", () => {
+  it("finds the phone column by header pattern", () => {
+    const headers = ["Caller Name", "Mobile Number", "Duration"];
+    expect(detectColumn(headers, [/phone/i, /mobile/i, /number/i])).toBe(1);
+  });
+});
+
+describe("reconcile", () => {
+  const leadPhones = new Set(["9876543210"]);
+
+  it("flags callers with no matching lead, busiest first", () => {
+    const calls = [
+      { phone: "+91 98765 43210", name: "Ravi" }, // has a lead
+      { phone: "9000000001", name: "Anu" }, // no lead
+      { phone: "0900-000-0001", name: "Anu" }, // same caller again
+      { phone: "9000000002" }, // no lead, single
+    ];
+    const r = reconcile(calls, leadPhones);
+    expect(r.totalCalls).toBe(4);
+    expect(r.uniqueCallers).toBe(3);
+    expect(r.matched).toBe(1);
+    expect(r.callsWithoutLead.map((g) => g.phone)).toEqual([
+      "9000000001",
+      "9000000002",
+    ]);
+    expect(r.callsWithoutLead[0].calls).toBe(2);
+  });
+
+  it("keeps the most recent call timestamp per caller", () => {
+    const r = reconcile(
+      [
+        { phone: "9000000001", at: "2026-06-01" },
+        { phone: "9000000001", at: "2026-06-05" },
+      ],
+      new Set(),
+    );
+    expect(r.callsWithoutLead[0].lastCallAt).toBe("2026-06-05");
+  });
+});

--- a/apps/web/src/lib/reconciliation/superfone.ts
+++ b/apps/web/src/lib/reconciliation/superfone.ts
@@ -1,0 +1,130 @@
+/**
+ * Superfone call-log ↔ CRM lead reconciliation.
+ *
+ * Pure helpers (no I/O) so the matching logic is unit-testable. Phone numbers
+ * are matched on their last 10 digits to ignore +91 / 0 prefixes and spacing.
+ */
+
+/** Reduce a raw phone string to a comparable key (last 10 digits). */
+export function normalizePhone(raw: string | null | undefined): string {
+  const digits = (raw ?? "").replace(/\D/g, "");
+  return digits.length > 10 ? digits.slice(-10) : digits;
+}
+
+/** Minimal CSV parser: handles quoted fields, escaped quotes ("") and CRLF. */
+export function parseCsv(text: string): {
+  headers: string[];
+  rows: string[][];
+} {
+  const all: string[][] = [];
+  let field = "";
+  let row: string[] = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\n") {
+      row.push(field);
+      all.push(row);
+      row = [];
+      field = "";
+    } else if (c !== "\r") {
+      field += c;
+    }
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    all.push(row);
+  }
+
+  const headers = (all.shift() ?? []).map((h) => h.trim());
+  const rows = all.filter((r) => r.some((v) => v.trim() !== ""));
+  return { headers, rows };
+}
+
+/** Index of the first header matching any pattern, or -1. */
+export function detectColumn(headers: string[], patterns: RegExp[]): number {
+  for (const p of patterns) {
+    const idx = headers.findIndex((h) => p.test(h));
+    if (idx >= 0) return idx;
+  }
+  return -1;
+}
+
+export interface CallGap {
+  phone: string;
+  name: string | null;
+  calls: number;
+  lastCallAt: string | null;
+}
+
+export interface ReconcileResult {
+  totalCalls: number;
+  uniqueCallers: number;
+  matched: number;
+  callsWithoutLead: CallGap[];
+}
+
+/**
+ * Compare call records against the set of normalized lead phone numbers.
+ * Returns unique callers that have no matching lead, busiest first.
+ */
+export function reconcile(
+  calls: { phone: string; name?: string | null; at?: string | null }[],
+  leadPhones: Set<string>,
+): ReconcileResult {
+  const byPhone = new Map<string, CallGap>();
+  let totalCalls = 0;
+
+  for (const call of calls) {
+    const phone = normalizePhone(call.phone);
+    if (!phone) continue;
+    totalCalls++;
+    const existing = byPhone.get(phone);
+    if (existing) {
+      existing.calls++;
+      if (call.at && (!existing.lastCallAt || call.at > existing.lastCallAt)) {
+        existing.lastCallAt = call.at;
+      }
+      if (!existing.name && call.name) existing.name = call.name;
+    } else {
+      byPhone.set(phone, {
+        phone,
+        name: call.name ?? null,
+        calls: 1,
+        lastCallAt: call.at ?? null,
+      });
+    }
+  }
+
+  let matched = 0;
+  const callsWithoutLead: CallGap[] = [];
+  for (const gap of byPhone.values()) {
+    if (leadPhones.has(gap.phone)) matched++;
+    else callsWithoutLead.push(gap);
+  }
+  callsWithoutLead.sort((a, b) => b.calls - a.calls);
+
+  return {
+    totalCalls,
+    uniqueCallers: byPhone.size,
+    matched,
+    callsWithoutLead,
+  };
+}

--- a/apps/web/src/lib/ticket-service.ts
+++ b/apps/web/src/lib/ticket-service.ts
@@ -23,10 +23,30 @@ import {
   updateProductionOrderStatus,
 } from "./production-service";
 import { supabaseAdmin } from "./supabase-admin";
+import { sendPushToUser, sendPushToUsers, getUserIdsByRoles } from "./push/fcm";
 
 // Use centralized supabase admin client
 function getSupabase() {
   return supabaseAdmin;
+}
+
+/** Push the requester (best-effort) when their approval ticket is decided. */
+async function pushTicketDecision(
+  createdBy: string | null | undefined,
+  title: string,
+  body: string,
+  ticketId: string,
+): Promise<void> {
+  if (!createdBy) return;
+  try {
+    await sendPushToUser(createdBy, {
+      title,
+      body: body.slice(0, 160),
+      data: { url: `/tickets/${ticketId}` },
+    });
+  } catch (err) {
+    console.error("ticket decision push failed:", err);
+  }
 }
 
 interface ServiceResult<T = void> {
@@ -301,6 +321,13 @@ export async function approveTicket(
       }
     }
 
+    await pushTicketDecision(
+      ticket.created_by,
+      "✅ Approval granted",
+      `${ticket.title} was approved`,
+      ticketId,
+    );
+
     return { success: true, message: "Ticket approved successfully" };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error";
@@ -364,6 +391,13 @@ export async function rejectTicket(
       await updateProductionOrderStatus(ticket.production_order_id, "draft");
     }
 
+    await pushTicketDecision(
+      ticket.created_by,
+      "❌ Approval rejected",
+      `${ticket.title}: ${input.reason}`,
+      ticketId,
+    );
+
     return { success: true, message: "Ticket rejected" };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error";
@@ -424,6 +458,13 @@ export async function requestChanges(
     if (ticket.type === "production_order" && ticket.production_order_id) {
       await updateProductionOrderStatus(ticket.production_order_id, "draft");
     }
+
+    await pushTicketDecision(
+      ticket.created_by,
+      "✏️ Changes requested",
+      `${ticket.title}: ${input.reason}`,
+      ticketId,
+    );
 
     return { success: true, message: "Changes requested" };
   } catch (err) {
@@ -610,6 +651,18 @@ export async function submitProductionOrderForApproval(
         submitted_for_approval_at: new Date().toISOString(),
       })
       .eq("id", orderId);
+
+    // Notify approvers (leadership) that an order is waiting — best-effort.
+    try {
+      const approvers = await getUserIdsByRoles(["founder", "owner"]);
+      await sendPushToUsers(approvers, {
+        title: "📝 Approval needed",
+        body: ticketResult.data.title,
+        data: { url: `/tickets/${ticketResult.data.id}` },
+      });
+    } catch (err) {
+      console.error("approval-request push failed:", err);
+    }
 
     return {
       success: true,

--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -44,6 +44,21 @@ stayed empty, and every send found zero devices — so nothing was ever delivere
 - Server + client agree on a high-importance `"default"` channel.
 - Settings → Notifications has a **"Send Test"** button + live device count.
 
+## What triggers a push
+
+| Event | Recipients | Source |
+|-------|-----------|--------|
+| New lead created | assigned rep, else founders/owners | `app/api/leads/route.ts` |
+| Lead reassigned / status changed | new/current assignee | `app/api/leads/[id]/route.ts` |
+| Call recording processed (incl. Telegram voice notes) | assigned rep, else founders/owners | `src/lib/call-recording/processor.ts` |
+| Lead turns hot (score ≥ 80%) | assigned rep, else founders/owners | `app/api/leads/[id]/analyze/route.ts` |
+| Customer responds to a Smart Quote (CTA submit) | assigned rep, else founders/owners | `app/api/sq/[slug]/submit/route.ts` |
+| Production order submitted for approval | founders/owners (approvers) | `src/lib/ticket-service.ts` |
+| Approval decided (approved / rejected / changes) | the requester (`created_by`) | `src/lib/ticket-service.ts` |
+| Nudge digest / SalesPulse | assigned staff / configured roles | `app/api/nudges/digest`, `app/api/salespulse/send` |
+
+Recipient resolution helpers live in `src/lib/push/fcm.ts`: `resolveLeadRecipients(assignedStaff)` (assignee → leadership fallback) and `getUserIdsByRoles(roles)`. All triggers are best-effort (swallow + log) so a push failure never breaks the request.
+
 ## Required configuration
 
 | Where | Variable / file | Purpose |

--- a/supabase/migrations/20260607000001_default_lead_assignee.sql
+++ b/supabase/migrations/20260607000001_default_lead_assignee.sql
@@ -1,0 +1,31 @@
+-- Default new leads to Nithya when no assignee is provided.
+--
+-- All lead-creation paths (manual API, Telegram voice/text auto-create, future
+-- sources) insert into public.leads, so a BEFORE INSERT trigger guarantees a
+-- consistent default without touching each call site. Resolves Nithya by name
+-- at insert time, so it keeps working if her user id changes. If no matching
+-- user exists, assigned_staff stays NULL (lead pushes then fall back to
+-- leadership) — safe degradation.
+
+CREATE OR REPLACE FUNCTION public.set_default_lead_assignee()
+RETURNS TRIGGER AS $$
+DECLARE
+  default_assignee uuid;
+BEGIN
+  IF NEW.assigned_staff IS NULL THEN
+    SELECT id INTO default_assignee
+    FROM public.users
+    WHERE name ILIKE 'nithya%'
+    ORDER BY created_at
+    LIMIT 1;
+    NEW.assigned_staff := default_assignee;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_default_lead_assignee ON public.leads;
+CREATE TRIGGER trg_default_lead_assignee
+  BEFORE INSERT ON public.leads
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_default_lead_assignee();


### PR DESCRIPTION
Builds on the merged push fix (#46). Three areas:

## 1. Push notifications
- **Fix:** Telegram voice notes never pushed — they create *unassigned* leads and the call-recording push was guarded by `if (lead.assigned_staff)`. Now falls back to founders/owners via shared `resolveLeadRecipients()`.
- **New events** (best-effort, swallow + log):
  - 🔥 Lead turns hot (score ≥ 80%) — `leads/[id]/analyze`
  - 📨 Customer responds to a Smart Quote CTA — `sq/[slug]/submit`
  - 📝 Production order submitted for approval → approvers — `ticket-service`
  - ✅/❌/✏️ Approval decided → requester — `ticket-service`
- Helpers `resolveLeadRecipients` / `getUserIdsByRoles` in `fcm.ts`; all triggers documented in `docs/PUSH_NOTIFICATIONS.md`.

## 2. Default lead assignee → Nithya
- `BEFORE INSERT` trigger on `public.leads` (migration `20260607000001_default_lead_assignee.sql`) sets `assigned_staff` to Nithya (resolved by name) whenever it's null — covers all lead sources. Falls back to NULL if no match.
- **Action:** apply the migration on prod (paste the SQL from the migration into the Supabase SQL editor).

## 3. Superfone Call Audit (CSV reconciliation)
- New founder/owner **Settings → Call Audit** tab: upload a Superfone call-log CSV → lists callers that never became a lead (phones matched on last 10 digits), with a downloadable CSV of the gaps.
- Pure `src/lib/reconciliation/superfone.ts` (parse/normalize/reconcile) + tests; `POST /api/reconciliation/superfone` with role gate and phone-column auto-detect/override.

## Tests
24 unit tests pass (push routes/helpers/test-result, reconciliation). Typecheck + lint clean.

## Security follow-ups (still recommended)
- Rotate the FCM service-account key and the `RESEND_API_KEY` committed in `apps/web/.env.vercel`.

https://claude.ai/code/session_01J1er7YijujZNu6XYzrTQR1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native push notifications for hot leads, quote submissions, and ticket decisions.
  * New "Call Audit" settings tab with CSV upload, analysis, and downloadable unmatched-call reports.
  * New reconciliation API to match call logs against leads.

* **Refactor**
  * Centralized recipient resolution and standardized best-effort push patterns across flows.

* **Tests**
  * Added tests for push recipient logic and reconciliation utilities.

* **Chores**
  * DB migration to set a default lead assignee on new leads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->