### PR TITLE
feat(coaching): show correct answer on wrong MCQ attempts

### DIFF
--- a/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
+++ b/apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx
@@ -117,6 +117,11 @@ export default function QuizRunnerPage() {
                   : "❌ Not quite"}
             </div>
             {result.explanation && <p className="mt-1">{result.explanation}</p>}
+            {result.correct_answer && (
+              <p className="mt-1">
+                <span className="font-medium">Correct answer:</span> {result.correct_answer}
+              </p>
+            )}
             {result.suggested_lesson_id && (
               <Link
                 href={`/coaching/learn/${result.suggested_lesson_id}`}


### PR DESCRIPTION
Small, self-contained fix. The coaching quiz result panel (`apps/web/app/(dashboard)/coaching/quiz/[quizId]/page.tsx`) already received `correct_answer` from the attempt API but never rendered it — so a learner who answered an MCQ/fill_blank wrong didn't see the right option. Adds a guarded render after the explanation.

Already null-guarded by the API (null for AI-graded scenario answers and for correct answers), so it only appears for wrong deterministic attempts.

Typecheck 4/4, lint 0 errors. No migration.

> Note: PR #44 (AI auto-grading) also touches this result panel; whichever merges second will have a trivial conflict (both add lines to the same block) — keep both additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quiz results now display the correct answer for reference after submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->