### PR TITLE
feat(ai): DeepSeek text fallback for Gemini outages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ ANTHROPIC_API_KEY=sk-ant-your-key
 # Google AI (Gemini) for STT/Embeddings
 GOOGLE_AI_API_KEY=your-google-ai-key
 
+# DeepSeek — TEXT-ONLY fallback for Gemini text generation (analysis, smart-quote).
+# When Gemini fails (e.g. depleted credits / 429), text features fall back to DeepSeek.
+# Does NOT cover audio transcription, image generation, or vision.
+DEEPSEEK_API_KEY=your-deepseek-key
+# DEEPSEEK_BASE_URL=https://api.deepseek.com   # optional override
+# DEEPSEEK_MODEL=deepseek-chat                 # optional; deepseek-chat (V3) | deepseek-reasoner (R1)
+
 # Telegram Bot (for notifications)
 TELEGRAM_BOT_TOKEN=your-bot-token
 TELEGRAM_CHAT_ID=your-chat-id

--- a/apps/web/src/lib/ai/deepseek.test.ts
+++ b/apps/web/src/lib/ai/deepseek.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isFallbackWorthy, deepseekComplete } from "./deepseek";
+
+describe("isFallbackWorthy", () => {
+  it("is true for quota / credit-depletion / 429 errors", () => {
+    expect(isFallbackWorthy(new Error("[429 Too Many Requests] Your prepayment credits are depleted"))).toBe(true);
+    expect(isFallbackWorthy("RESOURCE_EXHAUSTED")).toBe(true);
+    expect(isFallbackWorthy(new Error("503 model overloaded"))).toBe(true);
+    expect(isFallbackWorthy(new Error("fetch failed"))).toBe(true);
+  });
+  it("is false for ordinary non-transient errors", () => {
+    expect(isFallbackWorthy(new Error("invalid argument: bad prompt"))).toBe(false);
+    expect(isFallbackWorthy("")).toBe(false);
+  });
+});
+
+describe("deepseekComplete", () => {
+  const realFetch = globalThis.fetch;
+  const realKey = process.env.DEEPSEEK_API_KEY;
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (realKey === undefined) delete process.env.DEEPSEEK_API_KEY;
+    else process.env.DEEPSEEK_API_KEY = realKey;
+  });
+
+  it("returns null when DEEPSEEK_API_KEY is missing (no-op, never throws)", async () => {
+    delete process.env.DEEPSEEK_API_KEY;
+    expect(await deepseekComplete("hi")).toBeNull();
+  });
+
+  it("returns the assistant content on a successful response", async () => {
+    process.env.DEEPSEEK_API_KEY = "sk-test";
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "hello from deepseek" } }] }),
+    }) as unknown as typeof fetch;
+    expect(await deepseekComplete("hi")).toBe("hello from deepseek");
+  });
+
+  it("returns null (never throws) on a non-OK response or fetch error", async () => {
+    process.env.DEEPSEEK_API_KEY = "sk-test";
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }) as unknown as typeof fetch;
+    expect(await deepseekComplete("hi")).toBeNull();
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+    expect(await deepseekComplete("hi")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/deepseek.ts
+++ b/apps/web/src/lib/ai/deepseek.ts
@@ -1,0 +1,73 @@
+/**
+ * DeepSeek fallback provider — TEXT ONLY.
+ *
+ * DeepSeek exposes an OpenAI-compatible Chat Completions API, so we call it with
+ * a plain `fetch` (no extra dependency). It is used as a FALLBACK for Gemini text
+ * generation when the primary provider is unavailable (e.g. depleted prepaid
+ * credits → HTTP 429, overload, or network errors).
+ *
+ * LIMITS — DeepSeek is text-only. It does NOT do audio transcription, image
+ * generation, or vision. So audio (call-recording transcription, voice feedback)
+ * and image/vision pipelines CANNOT fall back here and still require Gemini.
+ *
+ * Config (env):
+ *   DEEPSEEK_API_KEY        required to enable the fallback (absent → no-op, returns null)
+ *   DEEPSEEK_BASE_URL       optional, defaults to https://api.deepseek.com
+ *   DEEPSEEK_MODEL          optional, defaults to deepseek-chat
+ */
+
+export const DEEPSEEK_MODEL = {
+  /** DeepSeek-V3 — fast, cheap; the right default for the JSON/analysis tasks Gemini Flash-Lite handles. */
+  CHAT: "deepseek-chat",
+  /** DeepSeek-R1 — deeper reasoning, slower/costlier. */
+  REASONER: "deepseek-reasoner",
+} as const;
+
+const DEEPSEEK_BASE_URL = process.env.DEEPSEEK_BASE_URL || "https://api.deepseek.com";
+
+/**
+ * True for errors where switching to a second provider is the right move:
+ * quota/billing exhaustion, rate limits, provider overload, 5xx, and transient
+ * network failures. NOT for genuine bad-request/auth errors (those would fail on
+ * the fallback too, so there's no point — but we stay permissive and still try).
+ */
+export function isFallbackWorthy(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err ?? "")).toLowerCase();
+  return /\b429\b|resource_exhausted|prepayment credits|depleted|quota|rate.?limit|\b5\d\d\b|overload|unavailable|timeout|timed out|fetch failed|econnreset|enotfound|network/.test(
+    msg,
+  );
+}
+
+/**
+ * One DeepSeek chat completion from a single prompt string. Returns the assistant
+ * text, or null on any failure / missing key. NEVER throws.
+ */
+export async function deepseekComplete(
+  prompt: string,
+  opts: { maxTokens?: number; model?: string } = {},
+): Promise<string | null> {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch(`${DEEPSEEK_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: opts.model || process.env.DEEPSEEK_MODEL || DEEPSEEK_MODEL.CHAT,
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: opts.maxTokens ?? 2048,
+        stream: false,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      choices?: { message?: { content?: string } }[];
+    };
+    return data.choices?.[0]?.message?.content ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/ai/text-fallback.ts
+++ b/apps/web/src/lib/ai/text-fallback.ts
@@ -1,0 +1,61 @@
+/**
+ * Provider-fallback text generation for the Maiyuri Bricks app.
+ *
+ * Tries Gemini (primary) first; if it fails for ANY reason — depleted prepaid
+ * credits (429), overload, network, or empty output — it falls back to DeepSeek
+ * (text-only, OpenAI-compatible). Returns the text plus which provider produced
+ * it, or null if BOTH are unavailable. NEVER throws.
+ *
+ * Use this for single-prompt TEXT generation (analysis, JSON extraction,
+ * summaries). It is NOT for audio transcription, image generation, or vision —
+ * DeepSeek cannot serve those, so those pipelines must keep calling Gemini
+ * directly.
+ *
+ * Callers keep their existing JSON-extraction + error handling; they just swap
+ *   const result = await model.generateContent(prompt);
+ *   const response = result.response.text();
+ * for
+ *   const out = await generateTextWithFallback(prompt);
+ *   const response = out?.text ?? "";   // (then their existing null/parse handling)
+ */
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+import { deepseekComplete } from "@/lib/ai/deepseek";
+
+export type AiProvider = "gemini" | "deepseek";
+
+export interface FallbackResult {
+  text: string;
+  provider: AiProvider;
+}
+
+let _gemini: GoogleGenerativeAI | null = null;
+function geminiClient(apiKey: string): GoogleGenerativeAI {
+  if (!_gemini) _gemini = new GoogleGenerativeAI(apiKey);
+  return _gemini;
+}
+
+export async function generateTextWithFallback(
+  prompt: string,
+  opts: { maxTokens?: number } = {},
+): Promise<FallbackResult | null> {
+  // Primary: Gemini.
+  const geminiKey = process.env.GOOGLE_AI_API_KEY;
+  if (geminiKey) {
+    try {
+      const model = geminiClient(geminiKey).getGenerativeModel({
+        model: GEMINI_DEFAULT_MODEL,
+      });
+      const result = await model.generateContent(prompt);
+      const text = result.response.text();
+      if (text) return { text, provider: "gemini" };
+      // Empty output → fall through to DeepSeek.
+    } catch {
+      // Any Gemini failure (incl. 429/credit depletion) → fall through to DeepSeek.
+    }
+  }
+
+  // Fallback: DeepSeek (text-only).
+  const ds = await deepseekComplete(prompt, { maxTokens: opts.maxTokens });
+  return ds ? { text: ds, provider: "deepseek" } : null;
+}

--- a/apps/web/src/lib/call-recording/analysis.ts
+++ b/apps/web/src/lib/call-recording/analysis.ts
@@ -5,8 +5,7 @@
  * Also extracts lead details for auto-populating lead records.
  */
 
-import { GoogleGenerativeAI } from "@google/generative-ai";
-import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+import { generateTextWithFallback } from "@/lib/ai/text-fallback";
 import { log, logError } from "./logger";
 import type {
   AnalysisResult,
@@ -14,14 +13,6 @@ import type {
   ExtractedLeadDetails,
   ProductInterest,
 } from "./types";
-
-function getGeminiClient() {
-  const apiKey = process.env.GOOGLE_AI_API_KEY;
-  if (!apiKey) {
-    throw new Error("Missing GOOGLE_AI_API_KEY");
-  }
-  return new GoogleGenerativeAI(apiKey);
-}
 
 /**
  * Analyze call transcript for sales insights
@@ -31,8 +22,6 @@ export async function analyzeTranscript(
   phoneNumber: string,
   leadName?: string,
 ): Promise<AnalysisResult> {
-  const genAI = getGeminiClient();
-  const model = genAI.getGenerativeModel({ model: GEMINI_DEFAULT_MODEL });
 
   const prompt = `You are a sales intelligence analyst for Maiyuri Bricks, a company that manufactures eco-friendly compressed earth blocks (CSEB/interlocking bricks).
 
@@ -66,8 +55,9 @@ Transcript:
 ${transcript}`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = result.response.text();
+    const out = await generateTextWithFallback(prompt);
+    if (!out) throw new Error("AI providers unavailable (Gemini + DeepSeek)");
+    const response = out.text;
 
     const analysis = parseAnalysisResponse(response);
 
@@ -138,8 +128,6 @@ export async function extractLeadDetails(
   phoneNumber: string,
   leadName?: string,
 ): Promise<ExtractedLeadDetails> {
-  const genAI = getGeminiClient();
-  const model = genAI.getGenerativeModel({ model: GEMINI_DEFAULT_MODEL });
 
   const prompt = `You are analyzing a sales call transcript for Maiyuri Bricks (CSEB/interlocking brick manufacturer in Tamil Nadu, India).
 
@@ -189,8 +177,9 @@ Transcript:
 ${transcript}`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = result.response.text();
+    const out = await generateTextWithFallback(prompt);
+    if (!out) throw new Error("AI providers unavailable (Gemini + DeepSeek)");
+    const response = out.text;
 
     const details = parseLeadDetailsResponse(response);
 

--- a/apps/web/src/lib/smart-quote-ai.ts
+++ b/apps/web/src/lib/smart-quote-ai.ts
@@ -9,8 +9,7 @@
  * Uses Gemini 2.0 Flash for all AI operations.
  */
 
-import { GoogleGenerativeAI } from "@google/generative-ai";
-import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+import { generateTextWithFallback } from "@/lib/ai/text-fallback";
 import type {
   SmartQuoteLanguage,
   SmartQuoteStage,
@@ -51,19 +50,6 @@ export interface SmartQuoteAIResult {
   copyMap: SmartQuoteCopyMap;
 }
 
-// ============================================================================
-// Gemini Client
-// ============================================================================
-
-function getGeminiClient(): GoogleGenerativeAI {
-  const apiKey = process.env.GOOGLE_AI_API_KEY;
-
-  if (!apiKey) {
-    throw new Error("Missing GOOGLE_AI_API_KEY environment variable");
-  }
-
-  return new GoogleGenerativeAI(apiKey);
-}
 
 // ============================================================================
 // Prompt A: Lead Insight Extraction
@@ -78,8 +64,6 @@ async function extractLeadInsights(
   transcript: string,
   leadName?: string | null,
 ): Promise<LeadInsights> {
-  const genAI = getGeminiClient();
-  const model = genAI.getGenerativeModel({ model: GEMINI_DEFAULT_MODEL });
 
   const prompt = `${PROMPT_A_SYSTEM}
 
@@ -107,8 +91,9 @@ TRANSCRIPT:
 ${transcript}`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = result.response.text();
+    const out = await generateTextWithFallback(prompt);
+    if (!out) throw new Error("AI providers unavailable (Gemini + DeepSeek)");
+    const response = out.text;
     return parseInsightsResponse(response);
   } catch (error) {
     console.error("[SmartQuoteAI] Failed to extract insights:", error);
@@ -174,8 +159,6 @@ Return ONLY JSON matching the schema.`;
 async function generateStrategy(
   insights: LeadInsights,
 ): Promise<StrategyResult> {
-  const genAI = getGeminiClient();
-  const model = genAI.getGenerativeModel({ model: GEMINI_DEFAULT_MODEL });
 
   const prompt = `${PROMPT_B_SYSTEM}
 
@@ -209,8 +192,9 @@ Output schema:
 }`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = result.response.text();
+    const out = await generateTextWithFallback(prompt);
+    if (!out) throw new Error("AI providers unavailable (Gemini + DeepSeek)");
+    const response = out.text;
     return parseStrategyResponse(response, insights);
   } catch (error) {
     console.error("[SmartQuoteAI] Failed to generate strategy:", error);
@@ -338,8 +322,6 @@ async function generateBilingualCopy(
   insights: LeadInsights,
   strategy: StrategyResult,
 ): Promise<SmartQuoteCopyMap> {
-  const genAI = getGeminiClient();
-  const model = genAI.getGenerativeModel({ model: GEMINI_DEFAULT_MODEL });
 
   const topObjectionStr =
     insights.top_objections.length > 0
@@ -399,8 +381,9 @@ Return schema:
 }`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = result.response.text();
+    const out = await generateTextWithFallback(prompt);
+    if (!out) throw new Error("AI providers unavailable (Gemini + DeepSeek)");
+    const response = out.text;
     return parseCopyResponse(response, strategy.route_decision);
   } catch (error) {
     console.error("[SmartQuoteAI] Failed to generate copy:", error);


### PR DESCRIPTION
Hardens text AI against Gemini outages (today's incident: depleted prepaid credits → 429 killed call analysis + smart-quote).

**What it does:** `generateTextWithFallback(prompt)` tries Gemini first; on any failure or empty output it falls back to **DeepSeek** (OpenAI-compatible, called via plain `fetch` — no new dependency). Returns `{text, provider}` or `null` if both are down. Never throws.

**Wired into (live text features):** call-recording `analyzeTranscript` + `extractLeadDetails`, and smart-quote-ai (3 call sites). Each keeps its existing JSON parsing + graceful catch.

**⚠️ Coverage limit (honest):** DeepSeek is **text-only**. It does NOT cover **audio transcription** (the call-recording step that actually failed today), **image generation**, or **vision** — those still require Gemini. This protects the text/reasoning bulk, not the audio path.

**To activate:** set `DEEPSEEK_API_KEY` on local `.env.local` + Vercel prod (documented in `.env.example`). Optional `DEEPSEEK_MODEL` (default `deepseek-chat`).

**Quality:** typecheck 4/4, lint 0 errors, 330 tests pass (+5 new). No migration.

**Follow-ups (same one-line swap):** `projects/ai/gemini.ts`, feedback `extract` route, `apps/api` planning agents — can adopt the same helper next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic AI provider fallback: when the primary AI service is unavailable or overloaded, the app now seamlessly switches to an alternative provider to keep AI-powered features working.

* **Tests**
  * Added comprehensive test coverage for the new fallback AI system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->