### PR TITLE
fix(recordings): don't burn retries on AI-provider outages + dedupe alerts

### DIFF
--- a/apps/web/app/api/recordings/process/route.ts
+++ b/apps/web/app/api/recordings/process/route.ts
@@ -14,6 +14,10 @@ import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { startCronLog } from "@/lib/health/cron-logger";
 import { processRecording } from "@/lib/call-recording/processor";
 import { log, logError } from "@/lib/call-recording/logger";
+import {
+  isInfraError,
+  sendInfraOutageAlert,
+} from "@/lib/call-recording/notifications";
 import type { CallRecording } from "@/lib/call-recording/types";
 
 export const dynamic = "force-dynamic";
@@ -199,7 +203,16 @@ async function handleProcess(request: NextRequest): Promise<NextResponse> {
         retry: recording.retry_count,
       });
 
-      await processRecording(recording);
+      try {
+        await processRecording(recording);
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        // Infra/provider outage → one aggregated alert (per-recording alert is suppressed in the processor).
+        if (isInfraError(errMsg)) {
+          await sendInfraOutageAlert(1, errMsg).catch(() => {});
+        }
+        throw error;
+      }
       await cronLog.success();
 
       return NextResponse.json({
@@ -228,6 +241,8 @@ async function handleProcess(request: NextRequest): Promise<NextResponse> {
     log(`Batch processing ${pendingRecordings.length} pending recordings`);
 
     const results: Array<{ id: string; status: string; error?: string }> = [];
+    let infraFailures = 0;
+    let lastInfraError = "";
 
     for (const recording of pendingRecordings) {
       if (recording.processing_status === "completed") {
@@ -249,8 +264,19 @@ async function handleProcess(request: NextRequest): Promise<NextResponse> {
         const errMsg = error instanceof Error ? error.message : String(error);
         logError(`Batch processing failed for ${recording.id}`, error);
         results.push({ id: recording.id, status: "failed", error: errMsg });
+        if (isInfraError(errMsg)) {
+          infraFailures++;
+          lastInfraError = errMsg;
+        }
         // Continue processing remaining recordings — don't let one failure stop the batch
       }
+    }
+
+    // One aggregated alert for an AI-provider/infra outage (per-recording alerts
+    // are suppressed in the processor for these). Recordings stay pending with
+    // retries intact and auto-resume once it clears.
+    if (infraFailures > 0) {
+      await sendInfraOutageAlert(infraFailures, lastInfraError).catch(() => {});
     }
 
     await cronLog.success();

--- a/apps/web/src/lib/call-recording/infra-error.test.ts
+++ b/apps/web/src/lib/call-recording/infra-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isInfraError } from "./notifications";
+
+describe("isInfraError", () => {
+  it("classifies AI-provider/infra outages as infra (should NOT burn a retry)", () => {
+    // The exact errors seen during the 2026-06 incident:
+    expect(isInfraError("[429 Too Many Requests] Your prepayment credits are depleted")).toBe(true);
+    expect(isInfraError("[400 Bad Request] API key expired. Please renew the API key.")).toBe(true);
+    expect(isInfraError("API_KEY_INVALID")).toBe(true);
+    expect(isInfraError("RESOURCE_EXHAUSTED: quota exceeded")).toBe(true);
+    expect(isInfraError("503 Service Unavailable - model overloaded")).toBe(true);
+    expect(isInfraError("fetch failed")).toBe(true);
+    expect(isInfraError("ETIMEDOUT")).toBe(true);
+  });
+
+  it("treats genuine per-recording failures as NOT infra (so they consume a retry + alert)", () => {
+    expect(isInfraError("No JSON found in response")).toBe(false);
+    expect(isInfraError("Telegram file download failed: file not found")).toBe(false);
+    expect(isInfraError("Unsupported audio format")).toBe(false);
+    expect(isInfraError("")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/call-recording/notifications.ts
+++ b/apps/web/src/lib/call-recording/notifications.ts
@@ -240,3 +240,39 @@ export async function sendErrorNotification(
 
   await sendTelegramMessage(message, adminChatId);
 }
+
+/**
+ * Classify an error as an infrastructure / AI-provider outage rather than a
+ * problem with a specific recording. These (depleted credits, expired/invalid
+ * key, quota/rate limits, 5xx, network) are transient and NOT the recording's
+ * fault — so they must not burn its retry budget, and they should produce one
+ * throttled alert instead of one-per-recording spam.
+ */
+export function isInfraError(message: string): boolean {
+  const m = (message || "").toLowerCase();
+  return /\b429\b|resource_exhausted|prepayment credits|depleted|quota|rate.?limit|api key expired|api_key_invalid|api key not valid|\b5\d\d\b|overload|unavailable|timeout|timed ?out|fetch failed|econnreset|enotfound|network/.test(
+    m,
+  );
+}
+
+/**
+ * One aggregated alert for an AI-provider/infra outage affecting N recordings —
+ * replaces the per-recording failure spam. The recordings are left pending with
+ * their retry budget intact, so they auto-resume once the outage clears.
+ */
+export async function sendInfraOutageAlert(
+  count: number,
+  sampleError: string,
+): Promise<void> {
+  const adminChatId =
+    process.env.TELEGRAM_ADMIN_CHAT_ID ?? process.env.TELEGRAM_CHAT_ID;
+
+  if (!adminChatId) return;
+
+  const message =
+    `\u{26A0}\u{FE0F} *Call recording processing paused*\n\n` +
+    `${count} recording(s) hit an AI-provider/infra error and were left *pending* — no retry consumed, they will auto-resume once it clears.\n\n` +
+    `\u{1F4A1} *Cause:* ${sampleError.slice(0, 180)}`;
+
+  await sendTelegramMessage(message, adminChatId);
+}

--- a/apps/web/src/lib/call-recording/processor.ts
+++ b/apps/web/src/lib/call-recording/processor.ts
@@ -13,7 +13,11 @@ import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { uploadToGoogleDrive } from "./gdrive-storage";
 import { transcribeAudio } from "./transcription";
 import { analyzeTranscript, extractLeadDetails } from "./analysis";
-import { sendCallRecordingNotification, sendErrorNotification } from "./notifications";
+import {
+  sendCallRecordingNotification,
+  sendErrorNotification,
+  isInfraError,
+} from "./notifications";
 import { notifyLeadPush } from "@/lib/push/fcm";
 import { logError, logProgress } from "./logger";
 import {
@@ -412,16 +416,22 @@ export async function processRecording(
   } catch (error) {
     logError(`Processing failed for ${id}`, error);
 
+    const message = error instanceof Error ? error.message : String(error);
+    const infra = isInfraError(message);
+
     await updateStatus(id, "failed", {
-      error_message: error instanceof Error ? error.message : String(error),
-      retry_count: recording.retry_count + 1,
+      error_message: message,
+      // Infra / AI-provider outages (depleted credits, expired key, quota, 5xx,
+      // network) aren't this recording's fault — don't burn a retry, or a
+      // transient outage permanently strands real calls at retry_count >= 3.
+      retry_count: infra ? recording.retry_count : recording.retry_count + 1,
     });
 
-    // Send error notification
-    await sendErrorNotification(
-      id,
-      error instanceof Error ? error.message : String(error),
-    ).catch(() => {});
+    // Per-recording alert only for genuine per-recording failures. Infra outages
+    // are alerted once, aggregated, by the caller (see process route).
+    if (!infra) {
+      await sendErrorNotification(id, message).catch(() => {});
+    }
 
     throw error;
   }


### PR DESCRIPTION
Hardening prompted by today's incident: Gemini **credits depleted → then expired key** caused the call-recording processor to (a) burn all 3 retries on legitimate recordings — stranding them at `retry_count=3` (we had to manually reset 3), and (b) spam the Telegram channel with one failure alert *per recording per attempt*.

### Changes
- **`isInfraError()`** classifies AI-provider/infra failures (429/quota/credit-depletion, expired/invalid key, 5xx, network) vs genuine per-recording failures.
- **processor.ts:** on an infra error, the recording's `retry_count` is **not incremented** (stays recoverable, auto-resumes once the outage clears) and the per-recording Telegram alert is **suppressed**.
- **process route:** sends **one aggregated** "processing paused — N recordings, no retry burned" alert per run (batch + single mode) for infra outages. Genuine per-recording failures are unchanged — they still consume a retry and get their detailed alert.
- Unit tests for the classifier, including the exact error strings from this incident.

### Why
Without this, every provider outage permanently strands real calls and floods the ops channel. Now an outage is quiet, self-healing, and leaves nothing stuck.

Quality: typecheck 4/4, lint 0 errors, **327 tests** pass (+2). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced call recording processing to intelligently handle infrastructure and provider outages, distinguishing them from individual recording failures
  * Infrastructure failures no longer consume retry attempts—affected recordings remain pending and retry automatically when service recovers
  * Added alerting system to notify administrators when infrastructure issues occur

* **Tests**
  * Added test coverage for infrastructure outage detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->