### PR TITLE
fix(recordings): retry transient Gemini 503s in-process with backoff

### DIFF
--- a/apps/web/src/lib/call-recording/transcription.test.ts
+++ b/apps/web/src/lib/call-recording/transcription.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the Gemini SDK so no real network call is made. `generateContent` is a
+// per-test spy; the class just hands back a model that delegates to it.
+const generateContent = vi.fn();
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: class {
+    getGenerativeModel() {
+      return { generateContent };
+    }
+  },
+}));
+
+import { transcribeAudio, transcriptionBackoffMs } from "./transcription";
+
+const FIVE_OH_THREE =
+  "[GoogleGenerativeAI Error]: [503 Service Unavailable] This model is currently experiencing high demand";
+
+function okResponse(text: string) {
+  return { response: { text: () => text } };
+}
+
+const audio = Buffer.from("fake-audio-bytes");
+
+beforeEach(() => {
+  generateContent.mockReset();
+  process.env.GOOGLE_AI_API_KEY = "test-key";
+  // Deterministic backoff (no jitter) so timing assertions are exact.
+  vi.spyOn(Math, "random").mockReturnValue(0);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("transcribeAudio — transient-503 retry with backoff", () => {
+  it("retries a transient 503 and succeeds on a later attempt", async () => {
+    generateContent
+      .mockRejectedValueOnce(new Error(FIVE_OH_THREE))
+      .mockRejectedValueOnce(new Error(FIVE_OH_THREE))
+      .mockResolvedValueOnce(okResponse("Customer: hello\nTamil"));
+
+    const promise = transcribeAudio(audio, "call.mp3");
+    await vi.runAllTimersAsync(); // let the backoff sleeps elapse
+
+    const result = await promise;
+    expect(result.text).toContain("hello");
+    expect(generateContent).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails fast on a permanent (non-infra) error — no retries", async () => {
+    generateContent.mockRejectedValue(new Error("Invalid argument: malformed audio content"));
+
+    const promise = transcribeAudio(audio, "call.mp3");
+    await expect(promise).rejects.toThrow(/malformed audio/);
+    expect(generateContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("exhausts all attempts on a sustained outage, then rethrows the original error", async () => {
+    generateContent.mockRejectedValue(new Error(FIVE_OH_THREE));
+
+    const promise = transcribeAudio(audio, "call.mp3");
+    // Attach a rejection handler up front so the eventual reject isn't "unhandled".
+    const settled = expect(promise).rejects.toThrow(/503/);
+    await vi.runAllTimersAsync();
+    await settled;
+    expect(generateContent).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+});
+
+describe("transcriptionBackoffMs", () => {
+  it("is exponential (1s, 2s, 4s) with zero jitter", () => {
+    // Math.random is mocked to 0 in beforeEach → jitter contributes nothing.
+    expect(transcriptionBackoffMs(1)).toBe(1000);
+    expect(transcriptionBackoffMs(2)).toBe(2000);
+    expect(transcriptionBackoffMs(3)).toBe(4000);
+  });
+
+  it("adds bounded jitter (never exceeds one base interval)", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.999);
+    // exponential(1) = 1000, jitter < 1000 → strictly within [1000, 2000)
+    const d = transcriptionBackoffMs(1);
+    expect(d).toBeGreaterThanOrEqual(1000);
+    expect(d).toBeLessThan(2000);
+  });
+});

--- a/apps/web/src/lib/call-recording/transcription.ts
+++ b/apps/web/src/lib/call-recording/transcription.ts
@@ -5,9 +5,10 @@
  * Accepts raw audio (WAV, OGG, M4A) natively - no ffmpeg conversion needed.
  */
 
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleGenerativeAI, type GenerativeModel } from "@google/generative-ai";
 import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
 import { log, logError } from "./logger";
+import { isInfraError } from "./notifications";
 import type { TranscriptionResult } from "./types";
 
 function getGeminiClient() {
@@ -16,6 +17,55 @@ function getGeminiClient() {
     throw new Error("Missing GOOGLE_AI_API_KEY");
   }
   return new GoogleGenerativeAI(apiKey);
+}
+
+/**
+ * Transcription attempts: 1 initial + 3 retries. Gemini "503 high demand"
+ * spikes are usually transient (seconds), so we ride them out in-process
+ * rather than failing a real recording and waiting on the 4-hour cron.
+ */
+const MAX_TRANSCRIPTION_ATTEMPTS = 4;
+const BASE_BACKOFF_MS = 1000;
+
+/** Exponential backoff with jitter: ~1s, ~2s, ~4s before retries 1..3. */
+export function transcriptionBackoffMs(retry: number): number {
+  const exponential = BASE_BACKOFF_MS * 2 ** (retry - 1);
+  const jitter = Math.floor(Math.random() * BASE_BACKOFF_MS);
+  return exponential + jitter;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Call Gemini, retrying ONLY transient infra errors (503/5xx, overload, quota,
+ * network) — classified by the SAME `isInfraError` that protects the retry
+ * budget, so "transient" means one thing across the whole pipeline. Permanent
+ * errors (bad audio, unsupported format) fail fast with no wasted retries.
+ * On exhaustion the original error is rethrown, so the processor's catch still
+ * classifies it as infra and the cron resumes it later — backoff and the
+ * retry-budget guard are complementary, not redundant.
+ */
+async function generateContentWithRetry(
+  model: GenerativeModel,
+  parts: Parameters<GenerativeModel["generateContent"]>[0],
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await model.generateContent(parts);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (attempt >= MAX_TRANSCRIPTION_ATTEMPTS || !isInfraError(message)) {
+        throw error;
+      }
+      const nextDelayMs = transcriptionBackoffMs(attempt);
+      log("Gemini transient error — retrying transcription", {
+        attempt,
+        nextDelayMs,
+        error: message.slice(0, 120),
+      });
+      await sleep(nextDelayMs);
+    }
+  }
 }
 
 /**
@@ -43,16 +93,18 @@ Instructions:
 
 At the end, on a new line, state the primary language detected (Tamil, English, or Tamil-English mixed).`;
 
-  try {
-    const result = await model.generateContent([
-      {
-        inlineData: {
-          mimeType,
-          data: base64Audio,
-        },
+  const parts = [
+    {
+      inlineData: {
+        mimeType,
+        data: base64Audio,
       },
-      { text: prompt },
-    ]);
+    },
+    { text: prompt },
+  ];
+
+  try {
+    const result = await generateContentWithRetry(model, parts);
 
     const response = result.response;
     const fullText = response.text();


### PR DESCRIPTION
## Why
Follow-up to #50. PR #50 stopped transient Gemini outages from *burning the retry budget*, but a recording that hits a 503 still had to wait for the 4-hour cron — and the transcription call had **no in-process retry at all** (single `generateContent`). During the 2026-06 incident, a transient `503 "high demand"` spike stranded ~46 real voice notes; staff reported them missing from the app.

## What
- Wrap `generateContent` in `generateContentWithRetry` — retries **only** transient infra errors with exponential backoff (~1s/2s/4s + jitter), 1 initial + 3 retries.
- **Reuses `isInfraError`** (from #50) as the retry predicate — one definition of "transient" across the whole pipeline (retry-here ↔ don't-burn-retry-there can't drift).
- Permanent errors (bad audio, unsupported format) **fail fast** — no wasted retries.
- On exhaustion the original error is **rethrown**, so the processor's retry-budget guard + cron still apply. Backoff (short spikes) and the guard (long outages) are complementary.

## How it complements #50
| Layer | Handles |
|---|---|
| backoff (this PR) | short spikes (seconds) → succeeds same request, lands in app immediately |
| `isInfraError` guard (#50) | long outages (minutes–hours) → no retry burned, cron resumes |

## Tests
`transcription.test.ts` (mocked SDK + fake timers): retry-then-succeed, fail-fast on non-infra, exhaustion-rethrows, exponential backoff timing (1s/2s/4s) + bounded jitter. All green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio transcription reliability by automatically retrying temporary service errors with backoff and jitter.
  * Reduced failed transcriptions caused by brief outages or high-demand responses.
  * Added stronger coverage for retry behavior, including success after temporary failures and no retries for non-transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->