### PR TITLE
fix(mobile): valid Android package name + slim EAS uploads

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -2,12 +2,13 @@
 # apps/native, packages/*, and root config. Everything else is dead weight
 # (the first uploads were 83 MB and kept dying with ECONNRESET).
 
-# Big binaries / artifacts
-deploy.zip
+# Big binaries / artifacts (anchored to repo root — apps/native/assets must
+# stay in the archive!)
+/deploy.zip
 *.zip
 *.log
-backend.log
-logo.png
+/backend.log
+/logo.png
 
 # Other apps/services the native build doesn't use
 apps/web
@@ -21,13 +22,13 @@ docs
 supabase
 Planning_Specification_module
 
-# Repo docs/plans not needed to build
-*.md
-*.prd
-*.drawio
-*.php
-*.py
-*.sh
+# Repo docs/plans not needed to build (root only; don't touch app dirs)
+/*.md
+/*.prd
+/*.drawio
+/*.php
+/*.py
+/*.sh
 
 # Node modules are restored on the builder
 node_modules

--- a/.easignore
+++ b/.easignore
@@ -1,13 +1,33 @@
-# Files excluded from the EAS build upload archive (not needed to build the
-# standalone apps/native app; keeps the upload small/fast).
+# Files excluded from the EAS build upload archive. The native app needs only:
+# apps/native, packages/*, and root config. Everything else is dead weight
+# (the first uploads were 83 MB and kept dying with ECONNRESET).
+
+# Big binaries / artifacts
 deploy.zip
 *.zip
 *.log
 backend.log
+logo.png
 
-# Other apps/services the native build doesn't depend on.
+# Other apps/services the native build doesn't use
 apps/web
 apps/api
+apps/mobile
 backend
 workers
 services
+tests
+docs
+supabase
+Planning_Specification_module
+
+# Repo docs/plans not needed to build
+*.md
+*.prd
+*.drawio
+*.php
+*.py
+*.sh
+
+# Node modules are restored on the builder
+node_modules

--- a/apps/native/app.json
+++ b/apps/native/app.json
@@ -17,10 +17,10 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.maiyuri.native"
+      "bundleIdentifier": "com.maiyuri.bricks"
     },
     "android": {
-      "package": "com.maiyuri.native"
+      "package": "com.maiyuri.bricks"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
Replaces #54. com.maiyuri.native -> com.maiyuri.bricks (native is a Java keyword; broke the Gradle build). Root-anchored .easignore: EAS upload 83 MB -> 0.5 MB.