### PR TITLE
feat: phase D — offline cache, infinite scroll, native CI, shared taxonomy

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -1,0 +1,35 @@
+name: Native app CI
+
+# apps/native is standalone (own node_modules, React 19 / Expo SDK 54), so
+# the root turbo pipeline does NOT cover it. This job is the only automated
+# check that the mobile app still compiles.
+
+on:
+  pull_request:
+    paths:
+      - "apps/native/**"
+      - "packages/shared/**"
+  push:
+    branches: [main]
+    paths:
+      - "apps/native/**"
+      - "packages/shared/**"
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/native
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/native/package-lock.json
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Typecheck
+        run: npx tsc --noEmit

--- a/apps/native/app/(tabs)/leads.tsx
+++ b/apps/native/app/(tabs)/leads.tsx
@@ -14,7 +14,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useLeads, useUpdateLead } from '@/hooks/use-leads';
+import { useInfiniteLeads, useUpdateLead } from '@/hooks/use-leads';
 import {
   isoDate,
   LEAD_STATUSES,
@@ -610,10 +610,22 @@ export default function LeadsScreen() {
     }
   }, [params.view]);
 
-  const { data, isLoading, isError, error, refetch, isRefetching } = useLeads({
-    search: search || undefined,
-    limit: 100,
-  });
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteLeads({ search: search || undefined });
+
+  const allLeads = useMemo(
+    () => data?.pages.flatMap((p) => p.data ?? []) ?? [],
+    [data],
+  );
 
   const onSortTap = (key: SortKey) => {
     if (key === sortKey) {
@@ -625,7 +637,7 @@ export default function LeadsScreen() {
   };
 
   const sections = useMemo(() => {
-    const filtered = sortLeads(applyView(data?.data ?? [], view), sortKey, sortDir);
+    const filtered = sortLeads(applyView(allLeads, view), sortKey, sortDir);
     if (!groupByTemp) {
       return [{ title: null as string | null, data: filtered }];
     }
@@ -636,7 +648,7 @@ export default function LeadsScreen() {
         data: filtered.filter((l) => l.lead_temperature === t),
       }))
       .filter((s) => s.data.length > 0);
-  }, [data, view, sortKey, sortDir, groupByTemp]);
+  }, [allLeads, view, sortKey, sortDir, groupByTemp]);
 
   return (
     <SafeAreaView edges={['bottom']} className="flex-1 bg-slate-50">
@@ -746,6 +758,15 @@ export default function LeadsScreen() {
           }
           contentContainerClassName="px-4 pb-6 pt-1"
           stickySectionHeadersEnabled={false}
+          onEndReached={() => {
+            if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+          }}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={
+            isFetchingNextPage ? (
+              <ActivityIndicator className="py-4" color="#f97316" />
+            ) : null
+          }
           refreshControl={
             <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
           }

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -1,11 +1,15 @@
 import '../global.css';
 
-import { QueryClientProvider } from '@tanstack/react-query';
+import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { Stack, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { queryClient } from '@/lib/query-client';
+import {
+  asyncStoragePersister,
+  PERSIST_MAX_AGE,
+  queryClient,
+} from '@/lib/query-client';
 import { initNotificationNavigation, registerForPush } from '@/lib/push';
 import { initAuthListener, useAuth } from '@/store/auth';
 
@@ -34,7 +38,10 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      <QueryClientProvider client={queryClient}>
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={{ persister: asyncStoragePersister, maxAge: PERSIST_MAX_AGE }}
+      >
         <StatusBar style="light" />
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="index" />
@@ -49,7 +56,7 @@ export default function RootLayout() {
             options={{ headerShown: true, title: 'New Lead' }}
           />
         </Stack>
-      </QueryClientProvider>
+      </PersistQueryClientProvider>
     </SafeAreaProvider>
   );
 }

--- a/apps/native/metro.config.js
+++ b/apps/native/metro.config.js
@@ -18,4 +18,9 @@ const config = getDefaultConfig(projectRoot);
 // Let Metro read the linked shared package's source.
 config.watchFolders = [sharedRoot];
 
+// Fallback resolution for the shared package's own runtime deps (e.g. zod
+// imported by packages/shared/src/schemas.ts): resolve them from THIS app's
+// node_modules. Hierarchical lookup still runs first for app code.
+config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
+
 module.exports = withNativeWind(config, { input: './global.css' });

--- a/apps/native/package-lock.json
+++ b/apps/native/package-lock.json
@@ -11,7 +11,9 @@
         "@maiyuri/shared": "file:../../packages/shared",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.47.12",
+        "@tanstack/query-async-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.62.8",
+        "@tanstack/react-query-persist-client": "^5.101.2",
         "expo": "~54.0.0",
         "expo-constants": "~18.0.0",
         "expo-device": "~8.0.10",
@@ -29,6 +31,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^2.0.0",
+        "react-native-worklets": "0.5.1",
         "tailwindcss": "^3.4.17",
         "zod": "^3.24.1",
         "zustand": "^5.0.2"
@@ -1452,7 +1455,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
       "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -3532,162 +3534,6 @@
         "node": ">= 20.19.4"
       }
     },
-    "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.84.1.tgz",
-      "integrity": "sha512-NswINguTz0eg1Dc0oGO/1dejXSr6iQaz8/NnCRn5HJdA3dGfqadS7zlYv0YjiWpgKgcW6uENaIEgJOQww0KSpw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.84.1",
-        "hermes-parser": "0.32.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.84.1.tgz",
-      "integrity": "sha512-vorvcvptGxtK0qTDCFQb+W3CU6oIhzcX5dduetWRBoAhXdthEQM0MQnF+GTXoXL8/luffKgy7PlZRG/WeI/oRQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.84.1"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.84.1.tgz",
-      "integrity": "sha512-3GpmCKk21f4oe32bKIdmkdn+WydvhhZL+1nsoFBGi30Qrq9vL16giKu31OcnWshYz139x+mVAvCyoyzgn8RXSw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.25.2",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-        "@babel/plugin-transform-regenerator": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@react-native/babel-plugin-codegen": "0.84.1",
-        "babel-plugin-syntax-hermes-parser": "0.32.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.84.1.tgz",
-      "integrity": "sha512-n1RIU0QAavgCg1uC5+s53arL7/mpM+16IBhJ3nCFSd/iK5tUmCwxQDcIDC703fuXfpub/ZygeSjVN8bcOWn0gA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/parser": "^7.25.3",
-        "hermes-parser": "0.32.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "tinyglobby": "^0.2.15",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-parser": "0.32.0"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
-      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.32.0"
-      }
-    },
-    "node_modules/@react-native/metro-config": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.84.1.tgz",
-      "integrity": "sha512-KlRawK4aXxRLlR3HYVfZKhfQp7sejQefQ/LttUWUkErhKO0AFt+yznoSLq7xwIrH9K3A3YwImHuFVtUtuDmurA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native/js-polyfills": "0.84.1",
-        "@react-native/metro-babel-transformer": "0.84.1",
-        "metro-config": "^0.83.3",
-        "metro-runtime": "^0.83.3"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      }
-    },
-    "node_modules/@react-native/metro-config/node_modules/@react-native/js-polyfills": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.84.1.tgz",
-      "integrity": "sha512-UsTe2AbUugsfyI7XIHMQq4E7xeC8a6GrYwuK+NohMMMJMxmyM3JkzIk+GB9e2il6ScEQNMJNaj+q+i5za8itxQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.4"
-      }
-    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
@@ -3934,11 +3780,38 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tanstack/query-async-storage-persister": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-async-storage-persister/-/query-async-storage-persister-5.101.2.tgz",
+      "integrity": "sha512-jf7zvVKZ5q2j/xuhbTIBUpw5xt6cw/ioOFQquxK7fRY0AmMQP8A0JVMOgYoeQLA4PKdeT7RxsuLAF0Lft9oJ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2",
+        "@tanstack/query-persist-client-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
       "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-persist-client-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.101.2.tgz",
+      "integrity": "sha512-rgMsbvBVpSPDUsprC9FYxojdG0Q1LH6yq1i3DXz2aps4VEqv2l4Msj3YDqIifU3xkl/DrYe9YWntZAJLrM6xTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -3957,6 +3830,23 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-persist-client": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.101.2.tgz",
+      "integrity": "sha512-19UpaRtf0lvB2QAJ2MoixxtGf3osMOd508g99EsttUj4+3eLs+ulnNgYjB7AkQMHrRlcbVXqpVNqWkB4a7g8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-persist-client-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.2",
         "react": "^18 || ^19"
       }
     },
@@ -9595,29 +9485,39 @@
       }
     },
     "node_modules/react-native-worklets": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.3.tgz",
-      "integrity": "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
+        "semver": "7.7.2"
       },
       "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
+        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "0.81 - 0.85"
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -16,7 +16,9 @@
     "@maiyuri/shared": "file:../../packages/shared",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.47.12",
+    "@tanstack/query-async-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.62.8",
+    "@tanstack/react-query-persist-client": "^5.101.2",
     "expo": "~54.0.0",
     "expo-constants": "~18.0.0",
     "expo-device": "~8.0.10",
@@ -34,6 +36,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^2.0.0",
+    "react-native-worklets": "0.5.1",
     "tailwindcss": "^3.4.17",
     "zod": "^3.24.1",
     "zustand": "^5.0.2"

--- a/apps/native/src/hooks/use-leads.ts
+++ b/apps/native/src/hooks/use-leads.ts
@@ -1,5 +1,10 @@
 import type { Lead } from '@maiyuri/shared';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { api } from '@/lib/api';
 
 export type LeadFilters = {
@@ -19,6 +24,29 @@ export function useLeads(filters: LeadFilters = {}) {
   return useQuery({
     queryKey: ['leads', filters],
     queryFn: () => api.get<Lead[]>('/api/leads', { limit: 50, ...filters }),
+  });
+}
+
+const PAGE_SIZE = 50;
+
+/**
+ * Server-paginated lead list for the Leads screen — pages accumulate as the
+ * user scrolls, so large books of business aren't silently truncated.
+ * Key starts with 'leads' so the existing mutations' invalidations hit it.
+ */
+export function useInfiniteLeads(filters: Omit<LeadFilters, 'page' | 'limit'> = {}) {
+  return useInfiniteQuery({
+    queryKey: ['leads', 'infinite', filters],
+    queryFn: ({ pageParam }) =>
+      api.get<Lead[]>('/api/leads', { ...filters, page: pageParam, limit: PAGE_SIZE }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, pages) => {
+      const total = lastPage.meta?.total ?? 0;
+      const loaded = pages.reduce((n, p) => n + (p.data?.length ?? 0), 0);
+      return loaded < total && (lastPage.data?.length ?? 0) > 0
+        ? pages.length + 1
+        : undefined;
+    },
   });
 }
 

--- a/apps/native/src/lib/lead-taxonomy.ts
+++ b/apps/native/src/lib/lead-taxonomy.ts
@@ -1,42 +1,14 @@
 /**
- * Lead taxonomy display metadata — mirrors apps/web/src/lib/lead-taxonomy.ts
- * (kept light: value/label/emoji only). If the web taxonomy changes, update
- * this copy to match.
+ * Lead taxonomy display metadata — re-exported from @maiyuri/shared (the
+ * single source of truth shared with the web app) under the local names the
+ * native screens use.
  */
-import type { LeadStatus, LeadTemperature, PipelineStage } from '@maiyuri/shared';
-
-export interface TaxonomyOption<T extends string> {
-  value: T;
-  label: string;
-  emoji: string;
-}
-
-export const PIPELINE_STAGES: TaxonomyOption<PipelineStage>[] = [
-  { value: 'new_inquiry', label: 'New Inquiry', emoji: '💬' },
-  { value: 'qualified_lead', label: 'Qualified Lead', emoji: '✅' },
-  { value: 'quote_shared', label: 'Quote Shared', emoji: '📄' },
-  { value: 'factory_visit_proof', label: 'Factory Visit / Proof', emoji: '🏭' },
-  { value: 'decision_pending', label: 'Decision Pending', emoji: '⏳' },
-  { value: 'finalisation', label: 'Finalisation / Closing', emoji: '🤝' },
-  { value: 'order_won', label: 'Order Won', emoji: '🎉' },
-  { value: 'closed_lost', label: 'Closed Lost', emoji: '❌' },
-];
-
-export const LEAD_STATUSES: TaxonomyOption<LeadStatus>[] = [
-  { value: 'new_contact_pending', label: 'New - Contact Pending', emoji: '🆕' },
-  { value: 'contact_attempted', label: 'Contact Attempted', emoji: '📞' },
-  { value: 'connected', label: 'Connected', emoji: '✅' },
-  { value: 'follow_up_scheduled', label: 'Follow-Up Scheduled', emoji: '🔁' },
-  { value: 'waiting_for_customer', label: 'Waiting for Customer', emoji: '⏳' },
-  { value: 'nurture_later', label: 'Nurture Later', emoji: '🌱' },
-  { value: 'closed', label: 'Closed', emoji: '🔒' },
-];
-
-export const LEAD_TEMPERATURES: TaxonomyOption<LeadTemperature>[] = [
-  { value: 'hot', label: 'Hot', emoji: '🔥' },
-  { value: 'warm', label: 'Warm', emoji: '🟡' },
-  { value: 'cold', label: 'Cold', emoji: '❄️' },
-];
+export type { TaxonomyDisplayOption as TaxonomyOption } from '@maiyuri/shared';
+export {
+  LEAD_STATUS_OPTIONS as LEAD_STATUSES,
+  LEAD_TEMPERATURE_OPTIONS as LEAD_TEMPERATURES,
+  PIPELINE_STAGE_OPTIONS as PIPELINE_STAGES,
+} from '@maiyuri/shared';
 
 /** yyyy-mm-dd for today + offsetDays (matches web LeadQuickActions.isoDate). */
 export function isoDate(offsetDays: number): string {

--- a/apps/native/src/lib/query-client.ts
+++ b/apps/native/src/lib/query-client.ts
@@ -1,12 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { QueryClient } from '@tanstack/react-query';
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       // Mobile networks are flaky; give cached data a sensible lifetime.
       staleTime: 30_000,
+      // Keep data in cache long enough to survive offline app restarts —
+      // must be >= the persister maxAge below or restored data is dropped.
+      gcTime: 24 * 60 * 60 * 1000,
       retry: 2,
       refetchOnWindowFocus: false,
     },
   },
 });
+
+/**
+ * Persist the query cache to AsyncStorage so the app opens instantly with
+ * last-known data on brick-yard / site-visit connectivity (or fully offline),
+ * then refetches in the background.
+ */
+export const asyncStoragePersister = createAsyncStoragePersister({
+  storage: AsyncStorage,
+  key: 'mb.query-cache',
+  throttleTime: 2_000,
+});
+
+export const PERSIST_MAX_AGE = 24 * 60 * 60 * 1000; // 24h

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@
 export * from "./types";
 export * from "./schemas";
 export * from "./utils";
+export * from "./taxonomy";

--- a/packages/shared/src/taxonomy.ts
+++ b/packages/shared/src/taxonomy.ts
@@ -1,0 +1,39 @@
+// Lead taxonomy display metadata — value/label/emoji for the categorical
+// lead fields, shared by web and mobile so the vocabularies can't drift.
+// (The web app additionally styles these with Tailwind classes in
+// apps/web/src/lib/lead-taxonomy.ts; colours stay app-side by design.)
+
+import type { LeadStatus, LeadTemperature, PipelineStage } from "./types";
+
+export interface TaxonomyDisplayOption<T extends string> {
+  value: T;
+  label: string;
+  emoji: string;
+}
+
+export const PIPELINE_STAGE_OPTIONS: TaxonomyDisplayOption<PipelineStage>[] = [
+  { value: "new_inquiry", label: "New Inquiry", emoji: "💬" },
+  { value: "qualified_lead", label: "Qualified Lead", emoji: "✅" },
+  { value: "quote_shared", label: "Quote Shared", emoji: "📄" },
+  { value: "factory_visit_proof", label: "Factory Visit / Proof", emoji: "🏭" },
+  { value: "decision_pending", label: "Decision Pending", emoji: "⏳" },
+  { value: "finalisation", label: "Finalisation / Closing", emoji: "🤝" },
+  { value: "order_won", label: "Order Won", emoji: "🎉" },
+  { value: "closed_lost", label: "Closed Lost", emoji: "❌" },
+];
+
+export const LEAD_STATUS_OPTIONS: TaxonomyDisplayOption<LeadStatus>[] = [
+  { value: "new_contact_pending", label: "New - Contact Pending", emoji: "🆕" },
+  { value: "contact_attempted", label: "Contact Attempted", emoji: "📞" },
+  { value: "connected", label: "Connected", emoji: "✅" },
+  { value: "follow_up_scheduled", label: "Follow-Up Scheduled", emoji: "🔁" },
+  { value: "waiting_for_customer", label: "Waiting for Customer", emoji: "⏳" },
+  { value: "nurture_later", label: "Nurture Later", emoji: "🌱" },
+  { value: "closed", label: "Closed", emoji: "🔒" },
+];
+
+export const LEAD_TEMPERATURE_OPTIONS: TaxonomyDisplayOption<LeadTemperature>[] = [
+  { value: "hot", label: "Hot", emoji: "🔥" },
+  { value: "warm", label: "Warm", emoji: "🟡" },
+  { value: "cold", label: "Cold", emoji: "❄️" },
+];


### PR DESCRIPTION
- Query cache persisted to AsyncStorage (24h) — offline-tolerant startup on weak networks
- Leads: server-paginated infinite scroll (removes the silent 100-lead cap)
- native-ci workflow: typechecks apps/native on PRs (standalone app was previously unchecked by CI)
- Lead taxonomy display metadata moved to @maiyuri/shared — web and mobile can no longer drift
- Metro: resolve shared package runtime deps (zod) from app node_modules; pin react-native-worklets (was pruned as transitive peer)

Verified: native + shared + web tsc, expo export bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)