### PR TITLE
feat(ops-planner): AI production & delivery planning backend (P1)

### DIFF
--- a/.github/workflows/plan-reminder.yml
+++ b/.github/workflows/plan-reminder.yml
@@ -1,0 +1,25 @@
+name: Nightly plan reminder
+
+# Previous-night reminder of tomorrow's production & delivery plan.
+# 15:30 UTC = 21:00 IST. The endpoint is silent when tomorrow has no plan
+# items (Sundays, no active plan), so this can fire every night safely.
+# Requires repo secret CRON_SECRET (already configured for morning-digest).
+
+on:
+  schedule:
+    - cron: "30 15 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  send-reminder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger plan notification endpoint
+        run: |
+          status=$(curl -s -o /tmp/notify.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/ops-planning/notify")
+          echo "HTTP $status"
+          cat /tmp/notify.json
+          if [ "$status" -ge 400 ]; then exit 1; fi

--- a/apps/web/app/api/ops-planning/generate/route.ts
+++ b/apps/web/app/api/ops-planning/generate/route.ts
@@ -1,0 +1,30 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // AI advisor call
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { generateDraftPlan } from "@/lib/ops-planning/planning-service";
+
+const generateSchema = z.object({
+  horizon_days: z.number().int().min(3).max(60).default(14),
+  constraint_text: z.string().max(2000).nullable().optional().default(null),
+  selected_order_ids: z.array(z.number().int()).default([]),
+});
+
+// POST /api/ops-planning/generate — returns a DRAFT plan (not persisted)
+export async function POST(request: NextRequest) {
+  try {
+    const parsed = await parseBody(request, generateSchema);
+    if (parsed.error) return parsed.error;
+
+    const draft = await generateDraftPlan(parsed.data);
+    return success(draft);
+  } catch (err) {
+    console.error("ops-plan generation failed:", err);
+    return error(
+      err instanceof Error ? err.message : "Plan generation failed",
+      500,
+    );
+  }
+}

--- a/apps/web/app/api/ops-planning/inputs/route.ts
+++ b/apps/web/app/api/ops-planning/inputs/route.ts
@@ -1,0 +1,46 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // Odoo XML-RPC round-trips
+
+import { success, error } from "@/lib/api-utils";
+import {
+  pullConfirmedSalesOrders,
+  pullFinishedGoodStock,
+} from "@/lib/ops-planning/odoo-planning";
+import { getPlanningInputs } from "@/lib/ops-planning/planning-service";
+
+// GET /api/ops-planning/inputs — cached open orders, products+params, settings
+export async function GET() {
+  try {
+    return success(await getPlanningInputs());
+  } catch (err) {
+    console.error("ops-planning inputs failed:", err);
+    return error("Failed to load planning inputs", 500);
+  }
+}
+
+// POST /api/ops-planning/inputs — refresh from Odoo (orders + stock), then return
+export async function POST() {
+  try {
+    const [ordersRes, stockRes] = await Promise.allSettled([
+      pullConfirmedSalesOrders(),
+      pullFinishedGoodStock(),
+    ]);
+    const inputs = await getPlanningInputs();
+    return success({
+      ...inputs,
+      sync: {
+        orders:
+          ordersRes.status === "fulfilled"
+            ? ordersRes.value
+            : { error: String(ordersRes.reason) },
+        stock:
+          stockRes.status === "fulfilled"
+            ? stockRes.value
+            : { error: String(stockRes.reason) },
+      },
+    });
+  } catch (err) {
+    console.error("ops-planning input sync failed:", err);
+    return error("Failed to sync planning inputs from Odoo", 500);
+  }
+}

--- a/apps/web/app/api/ops-planning/items/[id]/route.ts
+++ b/apps/web/app/api/ops-planning/items/[id]/route.ts
@@ -1,0 +1,51 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, notFound, parseBody } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const patchSchema = z.object({
+  status: z.enum(["planned", "done", "partial", "missed", "moved"]).optional(),
+  actual_quantity: z.number().nonnegative().nullable().optional(),
+  item_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(), // reschedule
+  notes: z.string().nullable().optional(),
+});
+
+// PATCH /api/ops-planning/items/[id] — report actual / reschedule an item
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+
+    const updates: Record<string, unknown> = { ...parsed.data };
+    // Reporting an actual implies a status if none was given.
+    if (
+      parsed.data.actual_quantity != null &&
+      parsed.data.status === undefined
+    ) {
+      updates.status = "done";
+    }
+    if (parsed.data.item_date && parsed.data.status === undefined) {
+      updates.status = "moved";
+    }
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("ops_plan_items")
+      .update(updates)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+
+    if (dbError?.code === "PGRST116") return notFound("Plan item not found");
+    if (dbError) return error("Failed to update plan item", 500);
+
+    return success(data);
+  } catch (err) {
+    console.error("plan item update failed:", err);
+    return error("Failed to update plan item", 500);
+  }
+}

--- a/apps/web/app/api/ops-planning/notify/route.ts
+++ b/apps/web/app/api/ops-planning/notify/route.ts
@@ -1,0 +1,119 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  filterByPushPref,
+  getUserIdsByRoles,
+  sendPushToUsers,
+  sendPushToUser,
+} from "@/lib/push/fcm";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * POST/GET /api/ops-planning/notify — the previous-night reminder.
+ * Called by the plan-reminder GitHub Action at ~21:00 IST. Sends tomorrow's
+ * plan summary to supervisors/leadership, and each driver their deliveries.
+ * Lean policy: nothing sent when tomorrow has no plan items (e.g. Sundays).
+ */
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+
+  try {
+    const tomorrow = new Date(Date.now() + 5.5 * 3600 * 1000 + 86400000)
+      .toISOString()
+      .slice(0, 10);
+
+    const { data: plan } = await supabaseAdmin
+      .from("ops_plans")
+      .select("id, name")
+      .eq("status", "active")
+      .maybeSingle();
+    if (!plan) return success({ sent: 0, reason: "no active plan" });
+
+    const { data: items } = await supabaseAdmin
+      .from("ops_plan_items")
+      .select("*")
+      .eq("plan_id", plan.id)
+      .eq("item_date", tomorrow)
+      .neq("status", "done");
+
+    if (!items?.length) return success({ sent: 0, reason: "empty day" });
+
+    const production = items.filter((i) => i.item_type === "production");
+    const deliveries = items.filter((i) => i.item_type === "delivery");
+
+    const prodSummary = production
+      .map((i) => `${Number(i.quantity).toLocaleString("en-IN")}× ${i.product_name}`)
+      .join(" · ");
+    const delSummary = deliveries
+      .map((i) => i.customer_name)
+      .filter(Boolean)
+      .join(", ");
+
+    const bodyParts: string[] = [];
+    if (production.length) bodyParts.push(`🏭 ${prodSummary}`);
+    if (deliveries.length)
+      bodyParts.push(`🚚 ${deliveries.length} deliver${deliveries.length === 1 ? "y" : "ies"}${delSummary ? ` (${delSummary})` : ""}`);
+
+    // Leadership + supervisors get the whole picture.
+    const staff = await getUserIdsByRoles([
+      "founder",
+      "owner",
+      "production_supervisor",
+    ]);
+    const recipients = await filterByPushPref(staff, "push_ops");
+    let sent = 0;
+    if (recipients.length) {
+      const res = await sendPushToUsers(recipients, {
+        title: "📋 Tomorrow's plan",
+        body: bodyParts.join("  |  "),
+        data: { url: "/plan" },
+      });
+      sent += res.sent;
+    }
+
+    // Drivers: their own delivery count for tomorrow (from the live
+    // deliveries table, which carries assignments).
+    const { data: driverRows } = await supabaseAdmin
+      .from("deliveries")
+      .select("assigned_driver_id")
+      .gte("scheduled_date", `${tomorrow}T00:00:00`)
+      .lte("scheduled_date", `${tomorrow}T23:59:59`)
+      .not("assigned_driver_id", "is", null)
+      .not("status", "in", "(delivered,cancelled)");
+    const counts = new Map<string, number>();
+    for (const r of driverRows ?? []) {
+      const id = r.assigned_driver_id as string;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    const allowedDrivers = new Set(
+      await filterByPushPref([...counts.keys()], "push_ops"),
+    );
+    for (const [driverId, count] of counts) {
+      if (!allowedDrivers.has(driverId)) continue;
+      const res = await sendPushToUser(driverId, {
+        title: `🚚 ${count} deliver${count === 1 ? "y" : "ies"} tomorrow`,
+        body: "Check addresses tonight — plan your route.",
+        data: { url: "/deliveries" },
+      });
+      sent += res.sent;
+    }
+
+    return success({ sent, date: tomorrow, items: items.length });
+  } catch (err) {
+    console.error("plan notify failed:", err);
+    return error("Plan notification failed", 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/apps/web/app/api/ops-planning/plans/active/route.ts
+++ b/apps/web/app/api/ops-planning/plans/active/route.ts
@@ -1,0 +1,40 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/ops-planning/plans/active?from=yyyy-mm-dd&to=yyyy-mm-dd
+// Returns the active plan with its items (optionally date-windowed) — the
+// calendar feed.
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    const { data: plan } = await supabaseAdmin
+      .from("ops_plans")
+      .select("*")
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (!plan) return success({ plan: null, items: [] });
+
+    let query = supabaseAdmin
+      .from("ops_plan_items")
+      .select("*")
+      .eq("plan_id", plan.id)
+      .order("item_date", { ascending: true });
+    if (from) query = query.gte("item_date", from);
+    if (to) query = query.lte("item_date", to);
+
+    const { data: items, error: dbError } = await query;
+    if (dbError) return error("Failed to load plan items", 500);
+
+    return success({ plan, items: items ?? [] });
+  } catch (err) {
+    console.error("active plan fetch failed:", err);
+    return error("Failed to load active plan", 500);
+  }
+}

--- a/apps/web/app/api/ops-planning/plans/route.ts
+++ b/apps/web/app/api/ops-planning/plans/route.ts
@@ -1,0 +1,54 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { getUserFromRequest } from "@/lib/supabase-server";
+import { activatePlan, type DraftPlan } from "@/lib/ops-planning/planning-service";
+
+const itemSchema = z.object({
+  item_type: z.enum(["production", "delivery"]),
+  item_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  finished_good_id: z.string().uuid().nullable(),
+  product_name: z.string(),
+  quantity: z.number().nonnegative(),
+  sale_order_ref: z.string(),
+  customer_name: z.string(),
+});
+
+const draftSchema = z.object({
+  name: z.string().min(1),
+  horizon_start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  horizon_end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  constraint_text: z.string().nullable(),
+  selected_order_refs: z.array(z.string()),
+  ai_rationale: z.string(),
+  ai_used: z.boolean(),
+  ai_priorities: z.unknown(),
+  items: z.array(itemSchema),
+  promises: z.array(z.unknown()),
+  warnings: z.array(z.unknown()),
+  totals: z.object({
+    production_units: z.number(),
+    production_runs: z.number(),
+    deliveries: z.number(),
+  }),
+});
+
+// POST /api/ops-planning/plans — persist + activate a draft plan
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    const parsed = await parseBody(request, draftSchema);
+    if (parsed.error) return parsed.error;
+
+    const result = await activatePlan(parsed.data as DraftPlan, user?.id ?? null);
+    return success(result);
+  } catch (err) {
+    console.error("plan activation failed:", err);
+    return error(
+      err instanceof Error ? err.message : "Plan activation failed",
+      500,
+    );
+  }
+}

--- a/apps/web/app/api/ops-planning/promise/route.ts
+++ b/apps/web/app/api/ops-planning/promise/route.ts
@@ -1,0 +1,28 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { getPromiseDate } from "@/lib/ops-planning/planning-service";
+
+const promiseSchema = z.object({
+  finished_good_id: z.string().uuid(),
+  quantity: z.number().positive(),
+});
+
+// POST /api/ops-planning/promise — "when could we deliver X units of Y?"
+export async function POST(request: NextRequest) {
+  try {
+    const parsed = await parseBody(request, promiseSchema);
+    if (parsed.error) return parsed.error;
+
+    const result = await getPromiseDate(
+      parsed.data.finished_good_id,
+      parsed.data.quantity,
+    );
+    return success(result);
+  } catch (err) {
+    console.error("promise-date simulation failed:", err);
+    return error("Promise simulation failed", 500);
+  }
+}

--- a/apps/web/app/api/ops-planning/variance/route.ts
+++ b/apps/web/app/api/ops-planning/variance/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/ops-planning/variance?days=14 — plan-vs-actual across recent plans.
+// Only PAST (or today's) items count: future planned items aren't "misses".
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const days = Math.min(90, Math.max(1, Number(searchParams.get("days") ?? 14)));
+    const today = new Date(Date.now() + 5.5 * 3600 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const from = new Date(Date.now() - days * 86400000 + 5.5 * 3600 * 1000)
+      .toISOString()
+      .slice(0, 10);
+
+    const { data: items, error: dbError } = await supabaseAdmin
+      .from("ops_plan_items")
+      .select(
+        "id, item_type, item_date, product_name, finished_good_id, quantity, actual_quantity, status, sale_order_ref, customer_name",
+      )
+      .gte("item_date", from)
+      .lte("item_date", today)
+      .order("item_date", { ascending: false });
+
+    if (dbError) return error("Failed to load variance data", 500);
+
+    const production = (items ?? []).filter((i) => i.item_type === "production");
+    const planned = production.reduce((s, i) => s + Number(i.quantity), 0);
+    const actual = production.reduce(
+      (s, i) => s + Number(i.actual_quantity ?? 0),
+      0,
+    );
+    const deliveries = (items ?? []).filter((i) => i.item_type === "delivery");
+    const deliveriesDone = deliveries.filter((i) => i.status === "done").length;
+
+    return success({
+      window: { from, to: today },
+      production: {
+        planned_units: planned,
+        actual_units: actual,
+        fulfillment_pct: planned > 0 ? Math.round((actual / planned) * 100) : null,
+      },
+      deliveries: {
+        planned: deliveries.length,
+        completed: deliveriesDone,
+      },
+      items: items ?? [],
+    });
+  } catch (err) {
+    console.error("variance rollup failed:", err);
+    return error("Variance rollup failed", 500);
+  }
+}

--- a/apps/web/src/lib/odoo-service.ts
+++ b/apps/web/src/lib/odoo-service.ts
@@ -836,3 +836,16 @@ export async function fullSync(
     },
   };
 }
+
+/**
+ * Generic Odoo RPC access for other modules (ops planning). Exposed here so
+ * the auth + XML-RPC plumbing stays in one place.
+ */
+export async function odooExecute(
+  model: string,
+  method: string,
+  args: unknown[],
+  kwargs: Record<string, unknown> = {},
+): Promise<unknown> {
+  return execute(model, method, args, kwargs);
+}

--- a/apps/web/src/lib/ops-planning/ai-advisor.ts
+++ b/apps/web/src/lib/ops-planning/ai-advisor.ts
@@ -1,0 +1,160 @@
+/**
+ * AI advisor for the ops planner. The LLM proposes order priorities, capacity
+ * overrides parsed from the user's free-text constraints, and a plain-language
+ * rationale. It NEVER schedules — the deterministic scheduler enforces all
+ * hard constraints regardless of what comes back here.
+ *
+ * Fail-open design: any API/parse/validation failure degrades to FIFO
+ * priorities (commitment date, then order date) with a note in the rationale.
+ */
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { z } from "zod";
+import { GEMINI_MODEL } from "@/lib/ai/models";
+import type { CapacityOverride } from "./scheduler";
+
+const adviceSchema = z.object({
+  priorities: z
+    .array(
+      z.object({
+        order_ref: z.string(),
+        rank: z.number().int().min(1),
+        reason: z.string().optional().default(""),
+      }),
+    )
+    .default([]),
+  capacity_overrides: z
+    .array(
+      z.object({
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        finished_good_id: z.string().optional(),
+        capacity: z.number().nonnegative().optional(),
+        blocked: z.boolean().optional(),
+      }),
+    )
+    .default([]),
+  narrative: z.string().default(""),
+});
+
+export type PlanningAdvice = z.infer<typeof adviceSchema> & {
+  ai_used: boolean;
+};
+
+export type AdvisorInput = {
+  start_date: string;
+  horizon_days: number;
+  constraint_text: string | null;
+  orders: {
+    order_ref: string;
+    customer_name: string;
+    date_order: string | null;
+    commitment_date: string | null;
+    remaining_units: number;
+    lines: { product_name: string; remaining: number }[];
+  }[];
+  products: {
+    finished_good_id: string;
+    product_name: string;
+    daily_capacity: number;
+    curing_days: number;
+    stock_qty: number;
+  }[];
+};
+
+/** FIFO fallback: earliest commitment first, then earliest order date. */
+export function fifoPriorities(
+  orders: AdvisorInput["orders"],
+): PlanningAdvice["priorities"] {
+  return [...orders]
+    .sort((a, b) => {
+      const ca = a.commitment_date ?? "9999";
+      const cb = b.commitment_date ?? "9999";
+      if (ca !== cb) return ca < cb ? -1 : 1;
+      const da = a.date_order ?? "9999";
+      const db = b.date_order ?? "9999";
+      return da <= db ? -1 : 1;
+    })
+    .map((o, i) => ({
+      order_ref: o.order_ref,
+      rank: i + 1,
+      reason: "FIFO (commitment/order date)",
+    }));
+}
+
+export async function getPlanningAdvice(
+  input: AdvisorInput,
+): Promise<PlanningAdvice> {
+  const fallback: PlanningAdvice = {
+    priorities: fifoPriorities(input.orders),
+    capacity_overrides: [],
+    narrative:
+      "Planned first-in-first-out by commitment/order date (AI advisor unavailable).",
+    ai_used: false,
+  };
+
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey || input.orders.length === 0) return fallback;
+
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({
+      model: GEMINI_MODEL.FLASH_LITE,
+      generationConfig: { temperature: 0.3, maxOutputTokens: 2048 },
+    });
+
+    const prompt = `You are the production planning advisor for Maiyuri Bricks, an interlocking-brick factory in Tamil Nadu.
+
+FACTS
+- Planning window starts ${input.start_date}, ${input.horizon_days} days.
+- Work days: Monday–Saturday. Sundays: no production, no deliveries (the scheduler enforces this — never suggest Sundays).
+- Bricks cure after production before dispatch (per-product curing days below).
+
+PRODUCTS (capacity/day, curing days, current dispatchable stock):
+${input.products.map((p) => `- ${p.product_name} [id=${p.finished_good_id}]: ${p.daily_capacity}/day, cure ${p.curing_days}d, stock ${p.stock_qty}`).join("\n")}
+
+OPEN SALES ORDERS to plan (remaining units by product):
+${input.orders
+  .map(
+    (o) =>
+      `- ${o.order_ref} | ${o.customer_name} | ordered ${o.date_order ?? "?"} | committed ${o.commitment_date ?? "none"} | ${o.lines.map((l) => `${l.remaining}× ${l.product_name}`).join(", ")}`,
+  )
+  .join("\n")}
+
+OWNER'S CONSTRAINTS (free text, may be empty):
+"""${input.constraint_text ?? ""}"""
+
+TASK
+1. Rank ALL listed orders for production priority (rank 1 = first). Consider: explicit owner instructions above (highest weight), committed dates, order age, customer urgency hints, batching efficiency (same product back-to-back).
+2. Translate owner constraints into capacity_overrides: dates with blocked=true (no production) or a reduced absolute "capacity" number, optionally per finished_good_id. Only dates within the window. If a constraint names a weekday (e.g. "no production Thursday"), resolve it to the actual date(s) in the window.
+3. Write a short narrative (3-5 sentences, plain language a factory owner reads at a glance) explaining the plan logic and any risks.
+
+Respond with ONLY a JSON code block:
+\`\`\`json
+{"priorities":[{"order_ref":"SO001","rank":1,"reason":"..."}],"capacity_overrides":[{"date":"YYYY-MM-DD","blocked":true}],"narrative":"..."}
+\`\`\``;
+
+    const result = await model.generateContent(prompt);
+    const text = result.response.text();
+    const jsonMatch = text.match(/```json\s*([\s\S]*?)\s*```/) ?? [
+      null,
+      text.trim(),
+    ];
+    const parsed = adviceSchema.parse(JSON.parse(jsonMatch[1] ?? "{}"));
+
+    // Guard: every open order must have a rank; add missing ones after AI's.
+    const ranked = new Set(parsed.priorities.map((p) => p.order_ref));
+    let nextRank =
+      parsed.priorities.reduce((m, p) => Math.max(m, p.rank), 0) + 1;
+    for (const o of fifoPriorities(input.orders)) {
+      if (!ranked.has(o.order_ref)) {
+        parsed.priorities.push({ ...o, rank: nextRank++ });
+      }
+    }
+
+    return { ...parsed, ai_used: true };
+  } catch (err) {
+    console.error("Planning AI advisor failed, using FIFO:", err);
+    return fallback;
+  }
+}
+
+export type { CapacityOverride };

--- a/apps/web/src/lib/ops-planning/odoo-planning.ts
+++ b/apps/web/src/lib/ops-planning/odoo-planning.ts
@@ -1,0 +1,175 @@
+/**
+ * Odoo pulls for the ops planner: confirmed sales orders (with line
+ * quantities) and live finished-good stock. Results are mirrored into
+ * Supabase (sales_order_cache, finished_goods.stock_qty) so plan generation
+ * is fast and tolerant of Odoo being slow/unreachable.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { odooExecute } from "@/lib/odoo-service";
+
+type OdooSaleOrder = {
+  id: number;
+  name: string;
+  partner_id: [number, string] | false;
+  state: string;
+  date_order: string | false;
+  commitment_date: string | false;
+  amount_total: number;
+};
+
+type OdooSaleOrderLine = {
+  id: number;
+  order_id: [number, string] | false;
+  product_id: [number, string] | false;
+  product_uom_qty: number;
+  qty_delivered: number;
+  name: string | false;
+};
+
+export type CachedOrderLine = {
+  odoo_product_id: number | null;
+  finished_good_id: string | null;
+  product_name: string;
+  qty_ordered: number;
+  qty_delivered: number;
+};
+
+/**
+ * Pull confirmed sale orders ('sale' = confirmed, 'done' = locked) with their
+ * lines and upsert into sales_order_cache. remaining_units counts only lines
+ * that map to a synced finished good (those are what the factory plans for).
+ */
+export async function pullConfirmedSalesOrders(): Promise<{
+  synced: number;
+  openOrders: number;
+}> {
+  // Map of odoo product -> local finished good
+  const { data: goods } = await supabaseAdmin
+    .from("finished_goods")
+    .select("id, odoo_product_id, name")
+    .eq("is_active", true);
+  const fgByOdooId = new Map(
+    (goods ?? []).map((g) => [g.odoo_product_id as number, g]),
+  );
+
+  const orders = (await odooExecute(
+    "sale.order",
+    "search_read",
+    [[["state", "in", ["sale", "done"]]]],
+    {
+      fields: [
+        "id",
+        "name",
+        "partner_id",
+        "state",
+        "date_order",
+        "commitment_date",
+        "amount_total",
+      ],
+      order: "date_order desc",
+      limit: 300,
+    },
+  )) as OdooSaleOrder[];
+
+  if (!orders.length) return { synced: 0, openOrders: 0 };
+
+  const lines = (await odooExecute(
+    "sale.order.line",
+    "search_read",
+    [[["order_id", "in", orders.map((o) => o.id)]]],
+    {
+      fields: [
+        "id",
+        "order_id",
+        "product_id",
+        "product_uom_qty",
+        "qty_delivered",
+        "name",
+      ],
+      limit: 4000,
+    },
+  )) as OdooSaleOrderLine[];
+
+  const linesByOrder = new Map<number, CachedOrderLine[]>();
+  for (const line of lines) {
+    const orderId = Array.isArray(line.order_id) ? line.order_id[0] : null;
+    if (!orderId) continue;
+    const odooProductId = Array.isArray(line.product_id)
+      ? line.product_id[0]
+      : null;
+    const fg = odooProductId ? fgByOdooId.get(odooProductId) : undefined;
+    const entry: CachedOrderLine = {
+      odoo_product_id: odooProductId,
+      finished_good_id: (fg?.id as string) ?? null,
+      product_name:
+        (Array.isArray(line.product_id) ? line.product_id[1] : null) ??
+        (line.name || "Product"),
+      qty_ordered: Number(line.product_uom_qty) || 0,
+      qty_delivered: Number(line.qty_delivered) || 0,
+    };
+    const arr = linesByOrder.get(orderId) ?? [];
+    arr.push(entry);
+    linesByOrder.set(orderId, arr);
+  }
+
+  let openOrders = 0;
+  const rows = orders.map((o) => {
+    const orderLines = linesByOrder.get(o.id) ?? [];
+    // Planable remaining = only lines that map to a finished good we make.
+    const remaining = orderLines
+      .filter((l) => l.finished_good_id)
+      .reduce((sum, l) => sum + Math.max(0, l.qty_ordered - l.qty_delivered), 0);
+    if (remaining > 0 && o.state !== "done") openOrders += 1;
+    return {
+      odoo_order_id: o.id,
+      name: o.name,
+      partner_name: Array.isArray(o.partner_id) ? o.partner_id[1] : null,
+      state: o.state,
+      date_order: o.date_order || null,
+      commitment_date: o.commitment_date || null,
+      amount_total: o.amount_total ?? null,
+      lines: orderLines,
+      remaining_units: remaining,
+      synced_at: new Date().toISOString(),
+    };
+  });
+
+  const { error } = await supabaseAdmin
+    .from("sales_order_cache")
+    .upsert(rows, { onConflict: "odoo_order_id" });
+  if (error) throw new Error(`sales_order_cache upsert failed: ${error.message}`);
+
+  return { synced: rows.length, openOrders };
+}
+
+/**
+ * Refresh finished_goods.stock_qty from Odoo's qty_available (one read for
+ * all synced products).
+ */
+export async function pullFinishedGoodStock(): Promise<{ updated: number }> {
+  const { data: goods } = await supabaseAdmin
+    .from("finished_goods")
+    .select("id, odoo_product_id")
+    .eq("is_active", true);
+  const ids = (goods ?? [])
+    .map((g) => g.odoo_product_id as number)
+    .filter(Boolean);
+  if (!ids.length) return { updated: 0 };
+
+  const products = (await odooExecute("product.product", "read", [ids], {
+    fields: ["id", "qty_available"],
+  })) as { id: number; qty_available: number }[];
+
+  const now = new Date().toISOString();
+  let updated = 0;
+  for (const p of products) {
+    const good = (goods ?? []).find((g) => g.odoo_product_id === p.id);
+    if (!good) continue;
+    const { error } = await supabaseAdmin
+      .from("finished_goods")
+      .update({ stock_qty: p.qty_available ?? 0, stock_synced_at: now })
+      .eq("id", good.id);
+    if (!error) updated += 1;
+  }
+  return { updated };
+}

--- a/apps/web/src/lib/ops-planning/planning-service.ts
+++ b/apps/web/src/lib/ops-planning/planning-service.ts
@@ -1,0 +1,283 @@
+/**
+ * Ops-planning service: loads inputs, orchestrates AI advice + deterministic
+ * scheduling, persists plans, and reads them back for the calendar/variance.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { getPlanningAdvice, type AdvisorInput } from "./ai-advisor";
+import {
+  schedule,
+  simulatePromise,
+  type DemandOrder,
+  type PlanningProduct,
+  type SchedulerConfig,
+  type PlanItemDraft,
+  type OrderPromise,
+  type PlanWarning,
+} from "./scheduler";
+import type { CachedOrderLine } from "./odoo-planning";
+
+export type OpenOrder = {
+  odoo_order_id: number;
+  name: string;
+  partner_name: string | null;
+  state: string;
+  date_order: string | null;
+  commitment_date: string | null;
+  amount_total: number | null;
+  lines: CachedOrderLine[];
+  remaining_units: number;
+};
+
+export type PlanningInputs = {
+  open_orders: OpenOrder[];
+  products: (PlanningProduct & { has_params: boolean })[];
+  settings: {
+    work_days: number[];
+    max_deliveries_per_day: number;
+    default_constraints_note: string | null;
+  };
+  active_plan: { id: string; name: string; horizon_start: string; horizon_end: string } | null;
+  stock_synced_at: string | null;
+  orders_synced_at: string | null;
+};
+
+const todayIST = (): string =>
+  new Date(Date.now() + 5.5 * 3600 * 1000).toISOString().slice(0, 10);
+
+export async function getPlanningInputs(): Promise<PlanningInputs> {
+  const [{ data: cacheRows }, { data: goods }, { data: params }, { data: settingsRow }, { data: active }] =
+    await Promise.all([
+      supabaseAdmin
+        .from("sales_order_cache")
+        .select("*")
+        .eq("state", "sale")
+        .gt("remaining_units", 0)
+        .order("date_order", { ascending: true }),
+      supabaseAdmin
+        .from("finished_goods")
+        .select("id, name, stock_qty, stock_synced_at")
+        .eq("is_active", true),
+      supabaseAdmin.from("product_planning_params").select("*"),
+      supabaseAdmin.from("planning_settings").select("*").eq("id", 1).single(),
+      supabaseAdmin
+        .from("ops_plans")
+        .select("id, name, horizon_start, horizon_end")
+        .eq("status", "active")
+        .maybeSingle(),
+    ]);
+
+  const paramsByFg = new Map(
+    (params ?? []).map((p) => [p.finished_good_id as string, p]),
+  );
+
+  const products = (goods ?? []).map((g) => {
+    const p = paramsByFg.get(g.id as string);
+    return {
+      finished_good_id: g.id as string,
+      product_name: g.name as string,
+      daily_capacity: Number(p?.daily_capacity_units ?? 0),
+      curing_days: Number(p?.curing_days ?? 7),
+      stock_qty: Number(g.stock_qty ?? 0),
+      has_params: !!p && Number(p.daily_capacity_units) > 0,
+    };
+  });
+
+  return {
+    open_orders: (cacheRows ?? []) as OpenOrder[],
+    products,
+    settings: {
+      work_days: (settingsRow?.work_days as number[]) ?? [1, 2, 3, 4, 5, 6],
+      max_deliveries_per_day: Number(settingsRow?.max_deliveries_per_day ?? 4),
+      default_constraints_note:
+        (settingsRow?.default_constraints_note as string) ?? null,
+    },
+    active_plan: active
+      ? {
+          id: active.id as string,
+          name: active.name as string,
+          horizon_start: active.horizon_start as string,
+          horizon_end: active.horizon_end as string,
+        }
+      : null,
+    stock_synced_at: (goods?.[0]?.stock_synced_at as string) ?? null,
+    orders_synced_at: (cacheRows?.[0]?.synced_at as string) ?? null,
+  };
+}
+
+export type DraftPlan = {
+  name: string;
+  horizon_start: string;
+  horizon_end: string;
+  constraint_text: string | null;
+  selected_order_refs: string[];
+  ai_rationale: string;
+  ai_used: boolean;
+  ai_priorities: unknown;
+  items: PlanItemDraft[];
+  promises: OrderPromise[];
+  warnings: PlanWarning[];
+  totals: { production_units: number; production_runs: number; deliveries: number };
+};
+
+export async function generateDraftPlan(opts: {
+  horizon_days: number;
+  constraint_text: string | null;
+  selected_order_ids: number[]; // odoo_order_id list; empty = all open
+}): Promise<DraftPlan> {
+  const inputs = await getPlanningInputs();
+
+  const scope = inputs.open_orders.filter(
+    (o) =>
+      opts.selected_order_ids.length === 0 ||
+      opts.selected_order_ids.includes(o.odoo_order_id),
+  );
+
+  const advisorInput: AdvisorInput = {
+    start_date: todayIST(),
+    horizon_days: opts.horizon_days,
+    constraint_text: opts.constraint_text,
+    orders: scope.map((o) => ({
+      order_ref: o.name,
+      customer_name: o.partner_name ?? "Customer",
+      date_order: o.date_order,
+      commitment_date: o.commitment_date,
+      remaining_units: o.remaining_units,
+      lines: o.lines
+        .filter((l) => l.finished_good_id)
+        .map((l) => ({
+          product_name: l.product_name,
+          remaining: Math.max(0, l.qty_ordered - l.qty_delivered),
+        })),
+    })),
+    products: inputs.products,
+  };
+
+  const advice = await getPlanningAdvice(advisorInput);
+  const rankByRef = new Map(advice.priorities.map((p) => [p.order_ref, p.rank]));
+
+  const demand: DemandOrder[] = scope.map((o, i) => ({
+    order_ref: o.name,
+    customer_name: o.partner_name ?? "Customer",
+    priority_rank: rankByRef.get(o.name) ?? 1000 + i,
+    commitment_date: o.commitment_date,
+    lines: o.lines
+      .filter((l) => l.finished_good_id)
+      .map((l) => ({
+        finished_good_id: l.finished_good_id as string,
+        product_name: l.product_name,
+        remaining: Math.max(0, l.qty_ordered - l.qty_delivered),
+      }))
+      .filter((l) => l.remaining > 0),
+  }));
+
+  const config: SchedulerConfig = {
+    start_date: todayIST(),
+    horizon_days: opts.horizon_days,
+    work_days: inputs.settings.work_days,
+    max_deliveries_per_day: inputs.settings.max_deliveries_per_day,
+    capacity_overrides: advice.capacity_overrides,
+  };
+
+  const result = schedule(inputs.products, demand, config);
+
+  const productionItems = result.items.filter((i) => i.item_type === "production");
+  const horizon_end = new Date(
+    new Date(`${config.start_date}T00:00:00Z`).getTime() +
+      (opts.horizon_days - 1) * 86400000,
+  )
+    .toISOString()
+    .slice(0, 10);
+
+  return {
+    name: `Plan ${config.start_date} → ${horizon_end}`,
+    horizon_start: config.start_date,
+    horizon_end,
+    constraint_text: opts.constraint_text,
+    selected_order_refs: scope.map((o) => o.name),
+    ai_rationale: advice.narrative,
+    ai_used: advice.ai_used,
+    ai_priorities: advice.priorities,
+    items: result.items,
+    promises: result.promises,
+    warnings: result.warnings,
+    totals: {
+      production_units: productionItems.reduce((s, i) => s + i.quantity, 0),
+      production_runs: productionItems.length,
+      deliveries: result.items.filter((i) => i.item_type === "delivery").length,
+    },
+  };
+}
+
+export async function activatePlan(
+  draft: DraftPlan,
+  userId: string | null,
+): Promise<{ plan_id: string }> {
+  // Supersede any currently-active plan.
+  await supabaseAdmin
+    .from("ops_plans")
+    .update({ status: "superseded" })
+    .eq("status", "active");
+
+  const { data: plan, error } = await supabaseAdmin
+    .from("ops_plans")
+    .insert({
+      name: draft.name,
+      horizon_start: draft.horizon_start,
+      horizon_end: draft.horizon_end,
+      status: "active",
+      constraint_text: draft.constraint_text,
+      selected_order_refs: draft.selected_order_refs,
+      ai_rationale: draft.ai_rationale,
+      ai_priorities: draft.ai_priorities,
+      warnings: draft.warnings,
+      totals: draft.totals,
+      created_by: userId,
+      activated_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error || !plan) throw new Error(`plan insert failed: ${error?.message}`);
+
+  if (draft.items.length) {
+    const { error: itemsErr } = await supabaseAdmin.from("ops_plan_items").insert(
+      draft.items.map((i) => ({
+        plan_id: plan.id,
+        item_type: i.item_type,
+        item_date: i.item_date,
+        finished_good_id: i.finished_good_id,
+        product_name: i.product_name,
+        quantity: i.quantity,
+        sale_order_ref: i.sale_order_ref,
+        customer_name: i.customer_name,
+      })),
+    );
+    if (itemsErr) throw new Error(`plan items insert failed: ${itemsErr.message}`);
+  }
+
+  return { plan_id: plan.id as string };
+}
+
+export async function getPromiseDate(finishedGoodId: string, qty: number) {
+  const inputs = await getPlanningInputs();
+  const demand: DemandOrder[] = inputs.open_orders.map((o, i) => ({
+    order_ref: o.name,
+    customer_name: o.partner_name ?? "Customer",
+    priority_rank: i + 1,
+    commitment_date: o.commitment_date,
+    lines: o.lines
+      .filter((l) => l.finished_good_id)
+      .map((l) => ({
+        finished_good_id: l.finished_good_id as string,
+        product_name: l.product_name,
+        remaining: Math.max(0, l.qty_ordered - l.qty_delivered),
+      }))
+      .filter((l) => l.remaining > 0),
+  }));
+
+  return simulatePromise(inputs.products, demand, finishedGoodId, qty, {
+    start_date: todayIST(),
+    horizon_days: 60,
+    work_days: inputs.settings.work_days,
+    max_deliveries_per_day: inputs.settings.max_deliveries_per_day,
+  });
+}

--- a/apps/web/src/lib/ops-planning/scheduler.test.ts
+++ b/apps/web/src/lib/ops-planning/scheduler.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import {
+  addDays,
+  isoWeekday,
+  schedule,
+  simulatePromise,
+  type DemandOrder,
+  type PlanningProduct,
+  type SchedulerConfig,
+} from "./scheduler";
+
+// 2026-07-06 is a Monday.
+const MON = "2026-07-06";
+const WORK_WEEK = [1, 2, 3, 4, 5, 6]; // Mon–Sat
+
+const baseConfig: SchedulerConfig = {
+  start_date: MON,
+  horizon_days: 30,
+  work_days: WORK_WEEK,
+  max_deliveries_per_day: 4,
+};
+
+function product(over: Partial<PlanningProduct> = {}): PlanningProduct {
+  return {
+    finished_good_id: "fg-8mud",
+    product_name: "8 inch mud interlock",
+    daily_capacity: 1000,
+    curing_days: 7,
+    stock_qty: 0,
+    ...over,
+  };
+}
+
+function order(over: Partial<DemandOrder> = {}): DemandOrder {
+  return {
+    order_ref: "SO001",
+    customer_name: "Kumar",
+    priority_rank: 1,
+    lines: [
+      { finished_good_id: "fg-8mud", product_name: "8 inch mud interlock", remaining: 1000 },
+    ],
+    ...over,
+  };
+}
+
+describe("date helpers", () => {
+  it("addDays crosses months", () => {
+    expect(addDays("2026-07-30", 3)).toBe("2026-08-02");
+  });
+  it("isoWeekday: 2026-07-06 is Monday(1), 2026-07-12 is Sunday(7)", () => {
+    expect(isoWeekday("2026-07-06")).toBe(1);
+    expect(isoWeekday("2026-07-12")).toBe(7);
+  });
+});
+
+describe("curing", () => {
+  it("delivery happens only after curing completes", () => {
+    const res = schedule([product()], [order()], baseConfig);
+    const prod = res.items.filter((i) => i.item_type === "production");
+    const del = res.items.find((i) => i.item_type === "delivery");
+    expect(prod).toHaveLength(1);
+    expect(prod[0].item_date).toBe(MON);
+    // produced Mon 6th + 7 curing days = Mon 13th (a workday)
+    expect(del?.item_date).toBe("2026-07-13");
+    expect(res.promises[0].promised_delivery_date).toBe("2026-07-13");
+  });
+
+  it("curing landing on Sunday pushes delivery to Monday", () => {
+    // Produce Sat 11th (block Mon-Fri), curing 1 → ready Sun 12th → deliver Mon 13th
+    const res = schedule(
+      [product({ curing_days: 1 })],
+      [order()],
+      {
+        ...baseConfig,
+        capacity_overrides: [
+          { date: "2026-07-06", blocked: true },
+          { date: "2026-07-07", blocked: true },
+          { date: "2026-07-08", blocked: true },
+          { date: "2026-07-09", blocked: true },
+          { date: "2026-07-10", blocked: true },
+        ],
+      },
+    );
+    const prod = res.items.filter((i) => i.item_type === "production");
+    expect(prod[0].item_date).toBe("2026-07-11"); // Saturday
+    const del = res.items.find((i) => i.item_type === "delivery");
+    expect(del?.item_date).toBe("2026-07-13"); // Monday, not Sunday 12th
+  });
+});
+
+describe("working days", () => {
+  it("never schedules production on Sunday", () => {
+    // 2500 units at 1000/day starting Sat 11th → Sat, Mon, Tue (skips Sun 12th)
+    const res = schedule(
+      [product()],
+      [order({ lines: [{ finished_good_id: "fg-8mud", product_name: "x", remaining: 2500 }] })],
+      { ...baseConfig, start_date: "2026-07-11" },
+    );
+    const dates = res.items
+      .filter((i) => i.item_type === "production")
+      .map((i) => i.item_date);
+    expect(dates).toEqual(["2026-07-11", "2026-07-13", "2026-07-14"]);
+    expect(dates.some((d) => isoWeekday(d) === 7)).toBe(false);
+  });
+});
+
+describe("capacity", () => {
+  it("splits demand across days at daily capacity", () => {
+    const res = schedule(
+      [product()],
+      [order({ lines: [{ finished_good_id: "fg-8mud", product_name: "x", remaining: 2500 }] })],
+      baseConfig,
+    );
+    const qtys = res.items
+      .filter((i) => i.item_type === "production")
+      .map((i) => i.quantity);
+    expect(qtys).toEqual([1000, 1000, 500]);
+  });
+
+  it("respects blocked-day overrides", () => {
+    const res = schedule(
+      [product()],
+      [order({ lines: [{ finished_good_id: "fg-8mud", product_name: "x", remaining: 2000 }] })],
+      {
+        ...baseConfig,
+        capacity_overrides: [{ date: "2026-07-07", blocked: true }], // Tue blocked
+      },
+    );
+    const dates = res.items
+      .filter((i) => i.item_type === "production")
+      .map((i) => i.item_date);
+    expect(dates).toEqual(["2026-07-06", "2026-07-08"]); // Mon, Wed
+  });
+
+  it("higher-priority order gets capacity first", () => {
+    const res = schedule(
+      [product()],
+      [
+        order({ order_ref: "SO-LOW", priority_rank: 2 }),
+        order({ order_ref: "SO-HIGH", priority_rank: 1 }),
+      ],
+      baseConfig,
+    );
+    const high = res.promises.find((p) => p.order_ref === "SO-HIGH")!;
+    const low = res.promises.find((p) => p.order_ref === "SO-LOW")!;
+    expect(high.promised_delivery_date! < low.promised_delivery_date!).toBe(true);
+  });
+});
+
+describe("stock", () => {
+  it("serves from stock before producing", () => {
+    const res = schedule([product({ stock_qty: 600 })], [order()], baseConfig);
+    const prod = res.items.filter((i) => i.item_type === "production");
+    expect(prod).toHaveLength(1);
+    expect(prod[0].quantity).toBe(400);
+  });
+
+  it("full stock coverage delivers without any production", () => {
+    const res = schedule([product({ stock_qty: 5000 })], [order()], baseConfig);
+    expect(res.items.filter((i) => i.item_type === "production")).toHaveLength(0);
+    const del = res.items.find((i) => i.item_type === "delivery");
+    expect(del?.item_date).toBe(MON); // dispatchable immediately
+  });
+});
+
+describe("deliveries per day cap", () => {
+  it("bumps overflow deliveries to the next workday", () => {
+    const products = [product({ stock_qty: 10_000 })];
+    const orders = [1, 2, 3].map((n) =>
+      order({ order_ref: `SO00${n}`, priority_rank: n }),
+    );
+    const res = schedule(products, orders, {
+      ...baseConfig,
+      max_deliveries_per_day: 2,
+    });
+    const dels = res.items
+      .filter((i) => i.item_type === "delivery")
+      .map((i) => i.item_date);
+    expect(dels).toEqual([MON, MON, "2026-07-07"]);
+  });
+});
+
+describe("lateness & warnings", () => {
+  it("flags orders promised after their commitment date", () => {
+    const res = schedule(
+      [product()],
+      [order({ commitment_date: "2026-07-08T00:00:00Z" })], // needs 13th
+      baseConfig,
+    );
+    expect(res.promises[0].late_vs_commitment).toBe(true);
+    expect(res.warnings.some((w) => w.type === "late_order")).toBe(true);
+  });
+
+  it("warns when a line has no planning parameters", () => {
+    const res = schedule(
+      [product()],
+      [
+        order({
+          lines: [{ finished_good_id: "fg-unknown", product_name: "mystery", remaining: 10 }],
+        }),
+      ],
+      baseConfig,
+    );
+    expect(res.warnings.some((w) => w.type === "unfulfillable")).toBe(true);
+    expect(res.promises[0].unfulfilled_units).toBe(10);
+  });
+});
+
+describe("simulatePromise", () => {
+  it("accounts for existing demand ahead of the prospect", () => {
+    const clean = simulatePromise([product()], [], "fg-8mud", 1000, baseConfig);
+    const busy = simulatePromise(
+      [product()],
+      [order({ lines: [{ finished_good_id: "fg-8mud", product_name: "x", remaining: 3000 }] })],
+      "fg-8mud",
+      1000,
+      baseConfig,
+    );
+    expect(clean.promised_delivery_date).toBe("2026-07-13");
+    expect(busy.promised_delivery_date! > clean.promised_delivery_date!).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ops-planning/scheduler.ts
+++ b/apps/web/src/lib/ops-planning/scheduler.ts
@@ -1,0 +1,335 @@
+/**
+ * Deterministic production & delivery scheduler.
+ *
+ * Pure module — no I/O, no Date.now() (caller supplies start date) — so every
+ * business rule is unit-testable:
+ *   - per-product daily capacity (with per-date overrides / blocked days)
+ *   - curing: units produced on day D are dispatchable from D + curing_days
+ *   - working days only (default Mon–Sat; Sundays never produce or deliver)
+ *   - stock on hand is dispatchable immediately
+ *   - one delivery per order, scheduled when ALL its lines are ready
+ *   - deliveries-per-day cap
+ *   - per-order promised delivery date + lateness vs Odoo commitment_date
+ *
+ * The AI advisor only influences `priority_rank` and `capacity_overrides` —
+ * this module enforces the hard constraints regardless.
+ */
+
+export type PlanningProduct = {
+  finished_good_id: string;
+  product_name: string;
+  daily_capacity: number;
+  curing_days: number;
+  stock_qty: number;
+};
+
+export type DemandLine = {
+  finished_good_id: string;
+  product_name: string;
+  remaining: number;
+};
+
+export type DemandOrder = {
+  order_ref: string;
+  customer_name: string;
+  /** 1 = plan first. Ties broken by commitment/order date by the caller. */
+  priority_rank: number;
+  commitment_date?: string | null;
+  lines: DemandLine[];
+};
+
+export type CapacityOverride = {
+  date: string; // yyyy-mm-dd
+  finished_good_id?: string; // absent = all products
+  capacity?: number; // absolute units for that day
+  blocked?: boolean; // no production at all
+};
+
+export type SchedulerConfig = {
+  start_date: string; // yyyy-mm-dd — first day production may be scheduled
+  horizon_days: number; // items emitted only within this window
+  work_days: number[]; // ISO weekday numbers, 1=Mon … 7=Sun
+  max_deliveries_per_day: number;
+  capacity_overrides?: CapacityOverride[];
+  /** How far past the horizon promise dates may search. Default 120 days. */
+  max_lookahead_days?: number;
+};
+
+export type PlanItemDraft = {
+  item_type: "production" | "delivery";
+  item_date: string;
+  finished_good_id: string | null;
+  product_name: string;
+  quantity: number;
+  sale_order_ref: string;
+  customer_name: string;
+};
+
+export type OrderPromise = {
+  order_ref: string;
+  customer_name: string;
+  promised_delivery_date: string | null;
+  late_vs_commitment: boolean;
+  unfulfilled_units: number;
+};
+
+export type PlanWarning = {
+  type: "late_order" | "beyond_horizon" | "unfulfillable" | "no_capacity";
+  message: string;
+  order_ref?: string;
+};
+
+export type ScheduleResult = {
+  items: PlanItemDraft[];
+  promises: OrderPromise[];
+  warnings: PlanWarning[];
+};
+
+// ---------- date helpers (UTC-safe on yyyy-mm-dd strings) ----------
+
+export function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** ISO weekday: 1=Mon … 7=Sun. */
+export function isoWeekday(iso: string): number {
+  const day = new Date(`${iso}T00:00:00Z`).getUTCDay(); // 0=Sun
+  return day === 0 ? 7 : day;
+}
+
+function nextWorkday(iso: string, workDays: number[]): string {
+  let d = iso;
+  for (let i = 0; i < 8; i++) {
+    if (workDays.includes(isoWeekday(d))) return d;
+    d = addDays(d, 1);
+  }
+  return d; // workDays empty — caller validated, unreachable in practice
+}
+
+// ---------- core ----------
+
+export function schedule(
+  products: PlanningProduct[],
+  orders: DemandOrder[],
+  config: SchedulerConfig,
+): ScheduleResult {
+  const lookahead = config.max_lookahead_days ?? 120;
+  const productById = new Map(products.map((p) => [p.finished_good_id, p]));
+  const stockLeft = new Map(
+    products.map((p) => [p.finished_good_id, Math.max(0, p.stock_qty)]),
+  );
+  // capacityUsed[date][productId] = units already scheduled
+  const capacityUsed = new Map<string, Map<string, number>>();
+  const deliveriesPerDay = new Map<string, number>();
+
+  const items: PlanItemDraft[] = [];
+  const promises: OrderPromise[] = [];
+  const warnings: PlanWarning[] = [];
+
+  const horizonEnd = addDays(config.start_date, config.horizon_days - 1);
+  const hardEnd = addDays(config.start_date, lookahead);
+
+  const overrideFor = (date: string, productId: string) => {
+    const specific = config.capacity_overrides?.find(
+      (o) => o.date === date && o.finished_good_id === productId,
+    );
+    const global = config.capacity_overrides?.find(
+      (o) => o.date === date && !o.finished_good_id,
+    );
+    return specific ?? global;
+  };
+
+  const capacityOn = (date: string, product: PlanningProduct): number => {
+    if (!config.work_days.includes(isoWeekday(date))) return 0;
+    const ov = overrideFor(date, product.finished_good_id);
+    if (ov?.blocked) return 0;
+    const base = ov?.capacity ?? product.daily_capacity;
+    const used =
+      capacityUsed.get(date)?.get(product.finished_good_id) ?? 0;
+    return Math.max(0, base - used);
+  };
+
+  const consumeCapacity = (date: string, productId: string, qty: number) => {
+    const day = capacityUsed.get(date) ?? new Map<string, number>();
+    day.set(productId, (day.get(productId) ?? 0) + qty);
+    capacityUsed.set(date, day);
+  };
+
+  const sorted = [...orders].sort((a, b) => a.priority_rank - b.priority_rank);
+
+  for (const order of sorted) {
+    let orderReadyDate = config.start_date; // latest ready date across lines
+    let unfulfilled = 0;
+    const productionAllocations: {
+      date: string;
+      productId: string;
+      productName: string;
+      qty: number;
+    }[] = [];
+
+    for (const line of order.lines) {
+      const product = productById.get(line.finished_good_id);
+      if (!product) {
+        unfulfilled += line.remaining;
+        warnings.push({
+          type: "unfulfillable",
+          order_ref: order.order_ref,
+          message: `${order.order_ref}: no planning parameters for ${line.product_name} — line skipped`,
+        });
+        continue;
+      }
+
+      let needed = line.remaining;
+
+      // 1) Serve from dispatchable stock (ready immediately).
+      const stock = stockLeft.get(product.finished_good_id) ?? 0;
+      const fromStock = Math.min(stock, needed);
+      if (fromStock > 0) {
+        stockLeft.set(product.finished_good_id, stock - fromStock);
+        needed -= fromStock;
+        // Stock is ready now; order ready date unchanged (>= start_date).
+      }
+
+      // 2) Produce the rest across working days.
+      let cursor = config.start_date;
+      while (needed > 0 && cursor <= hardEnd) {
+        const avail = capacityOn(cursor, product);
+        if (avail > 0) {
+          const make = Math.min(avail, needed);
+          consumeCapacity(cursor, product.finished_good_id, make);
+          productionAllocations.push({
+            date: cursor,
+            productId: product.finished_good_id,
+            productName: product.product_name,
+            qty: make,
+          });
+          needed -= make;
+          // Batch dispatchable after curing, on a working day.
+          const ready = nextWorkday(
+            addDays(cursor, product.curing_days),
+            config.work_days,
+          );
+          if (ready > orderReadyDate) orderReadyDate = ready;
+        }
+        cursor = addDays(cursor, 1);
+      }
+
+      if (needed > 0) {
+        unfulfilled += needed;
+        warnings.push({
+          type: "no_capacity",
+          order_ref: order.order_ref,
+          message: `${order.order_ref}: ${needed} × ${line.product_name} cannot be produced within ${lookahead} days`,
+        });
+      }
+    }
+
+    // Emit production items that fall inside the visible horizon.
+    for (const alloc of productionAllocations) {
+      if (alloc.date <= horizonEnd) {
+        items.push({
+          item_type: "production",
+          item_date: alloc.date,
+          finished_good_id: alloc.productId,
+          product_name: alloc.productName,
+          quantity: alloc.qty,
+          sale_order_ref: order.order_ref,
+          customer_name: order.customer_name,
+        });
+      }
+    }
+
+    // 3) Delivery slot: first working day >= orderReadyDate with capacity.
+    const totalUnits = order.lines.reduce((s, l) => s + l.remaining, 0);
+    const deliverableUnits = totalUnits - unfulfilled;
+    let promisedDate: string | null = null;
+
+    if (deliverableUnits > 0) {
+      let dDate = nextWorkday(orderReadyDate, config.work_days);
+      for (let i = 0; i < lookahead; i++) {
+        const count = deliveriesPerDay.get(dDate) ?? 0;
+        if (count < config.max_deliveries_per_day) break;
+        dDate = nextWorkday(addDays(dDate, 1), config.work_days);
+      }
+      deliveriesPerDay.set(dDate, (deliveriesPerDay.get(dDate) ?? 0) + 1);
+      promisedDate = dDate;
+
+      if (dDate <= horizonEnd) {
+        items.push({
+          item_type: "delivery",
+          item_date: dDate,
+          finished_good_id: order.lines[0]?.finished_good_id ?? null,
+          product_name: order.lines.map((l) => l.product_name).join(", "),
+          quantity: deliverableUnits,
+          sale_order_ref: order.order_ref,
+          customer_name: order.customer_name,
+        });
+      } else {
+        warnings.push({
+          type: "beyond_horizon",
+          order_ref: order.order_ref,
+          message: `${order.order_ref}: delivery lands ${dDate}, beyond this plan's horizon`,
+        });
+      }
+    }
+
+    const late =
+      !!order.commitment_date &&
+      !!promisedDate &&
+      promisedDate > order.commitment_date.slice(0, 10);
+    if (late) {
+      warnings.push({
+        type: "late_order",
+        order_ref: order.order_ref,
+        message: `${order.order_ref} (${order.customer_name}): promised ${promisedDate}, committed ${order.commitment_date!.slice(0, 10)}`,
+      });
+    }
+
+    promises.push({
+      order_ref: order.order_ref,
+      customer_name: order.customer_name,
+      promised_delivery_date: promisedDate,
+      late_vs_commitment: late,
+      unfulfilled_units: unfulfilled,
+    });
+  }
+
+  return { items, promises, warnings };
+}
+
+/**
+ * Promise-date simulation: "if a new order for `qty` of `productId` arrived
+ * now, when could we deliver?" Runs the same scheduler with the synthetic
+ * order appended at lowest priority after existing demand.
+ */
+export function simulatePromise(
+  products: PlanningProduct[],
+  existingOrders: DemandOrder[],
+  productId: string,
+  qty: number,
+  config: SchedulerConfig,
+): { promised_delivery_date: string | null; unfulfilled_units: number } {
+  const product = products.find((p) => p.finished_good_id === productId);
+  if (!product) return { promised_delivery_date: null, unfulfilled_units: qty };
+
+  const synthetic: DemandOrder = {
+    order_ref: "__SIMULATION__",
+    customer_name: "Prospect",
+    priority_rank: Number.MAX_SAFE_INTEGER,
+    lines: [
+      {
+        finished_good_id: productId,
+        product_name: product.product_name,
+        remaining: qty,
+      },
+    ],
+  };
+  const result = schedule(products, [...existingOrders, synthetic], config);
+  const sim = result.promises.find((p) => p.order_ref === "__SIMULATION__");
+  return {
+    promised_delivery_date: sim?.promised_delivery_date ?? null,
+    unfulfilled_units: sim?.unfulfilled_units ?? qty,
+  };
+}

--- a/supabase/migrations/20260705100000_ops_planning.sql
+++ b/supabase/migrations/20260705100000_ops_planning.sql
@@ -1,0 +1,127 @@
+-- ============================================================================
+-- Ops Planning Module: AI production & delivery planner
+-- Tables: product_planning_params, planning_settings, ops_plans,
+--         ops_plan_items, sales_order_cache
+-- All writes go through API routes using the service role; RLS grants
+-- authenticated users read access (mirrors production-module pattern).
+-- ============================================================================
+
+-- Live finished-good stock mirrored from Odoo (qty_available)
+ALTER TABLE public.finished_goods
+  ADD COLUMN IF NOT EXISTS stock_qty NUMERIC(14,2),
+  ADD COLUMN IF NOT EXISTS stock_synced_at TIMESTAMPTZ;
+
+-- Per-product planning parameters (the knobs the founder edits)
+CREATE TABLE IF NOT EXISTS public.product_planning_params (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  finished_good_id UUID NOT NULL UNIQUE REFERENCES public.finished_goods(id) ON DELETE CASCADE,
+  daily_capacity_units NUMERIC(12,2) NOT NULL DEFAULT 0, -- max units producible per working day
+  curing_days INTEGER NOT NULL DEFAULT 7,                -- days from production to dispatchable
+  min_batch NUMERIC(12,2) NOT NULL DEFAULT 0,            -- smallest sensible production run (0 = none)
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Global planning settings (single row, id = 1)
+CREATE TABLE IF NOT EXISTS public.planning_settings (
+  id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  -- Working days as ISO weekday numbers (1=Mon ... 7=Sun). Default Mon-Sat.
+  work_days INTEGER[] NOT NULL DEFAULT '{1,2,3,4,5,6}',
+  max_deliveries_per_day INTEGER NOT NULL DEFAULT 4,
+  default_constraints_note TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO public.planning_settings (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- A generated & saved plan (one active at a time; older ones superseded)
+CREATE TABLE IF NOT EXISTS public.ops_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,                                    -- e.g. "Plan 05 Jul – 18 Jul"
+  horizon_start DATE NOT NULL,
+  horizon_end DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','active','superseded','archived')),
+  constraint_text TEXT,                                  -- what the user typed
+  selected_order_refs TEXT[] NOT NULL DEFAULT '{}',      -- odoo order names planned for
+  ai_rationale TEXT,                                     -- AI narrative shown in app
+  ai_priorities JSONB,                                   -- raw validated AI output (audit)
+  warnings JSONB NOT NULL DEFAULT '[]',                  -- [{type, message, order_ref?}]
+  totals JSONB NOT NULL DEFAULT '{}',                    -- {production_units, deliveries, ...}
+  created_by UUID REFERENCES public.users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  activated_at TIMESTAMPTZ
+);
+
+-- Individual scheduled items (a production run or a delivery slot on a date)
+CREATE TABLE IF NOT EXISTS public.ops_plan_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id UUID NOT NULL REFERENCES public.ops_plans(id) ON DELETE CASCADE,
+  item_type TEXT NOT NULL CHECK (item_type IN ('production','delivery')),
+  item_date DATE NOT NULL,
+  finished_good_id UUID REFERENCES public.finished_goods(id),
+  product_name TEXT NOT NULL,                            -- denormalised for display
+  quantity NUMERIC(12,2) NOT NULL,
+  sale_order_ref TEXT,                                   -- odoo sale.order name (e.g. SO0042)
+  customer_name TEXT,
+  lead_id UUID REFERENCES public.leads(id),
+  production_order_id UUID REFERENCES public.production_orders(id), -- linked when reported
+  delivery_id UUID REFERENCES public.deliveries(id),
+  status TEXT NOT NULL DEFAULT 'planned'
+    CHECK (status IN ('planned','done','partial','missed','moved')),
+  actual_quantity NUMERIC(12,2),                         -- filled on reporting -> variance
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_plan_items_plan ON public.ops_plan_items(plan_id);
+CREATE INDEX IF NOT EXISTS idx_ops_plan_items_date ON public.ops_plan_items(item_date);
+CREATE INDEX IF NOT EXISTS idx_ops_plans_status ON public.ops_plans(status);
+
+-- Local mirror of confirmed Odoo sales orders (fast + offline-tolerant planning)
+CREATE TABLE IF NOT EXISTS public.sales_order_cache (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  odoo_order_id INTEGER NOT NULL UNIQUE,
+  name TEXT NOT NULL,                                    -- SO number
+  partner_name TEXT,
+  state TEXT NOT NULL,                                   -- sale | done | cancel
+  date_order TIMESTAMPTZ,
+  commitment_date TIMESTAMPTZ,                           -- customer-promised date if set in Odoo
+  amount_total NUMERIC(14,2),
+  -- [{odoo_product_id, finished_good_id?, product_name, qty_ordered, qty_delivered, uom}]
+  lines JSONB NOT NULL DEFAULT '[]',
+  remaining_units NUMERIC(14,2) NOT NULL DEFAULT 0,      -- sum(ordered - delivered) over planable lines
+  synced_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sales_order_cache_state ON public.sales_order_cache(state);
+
+-- updated_at triggers (reuse the shared trigger fn created in earlier migrations)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at_column') THEN
+    CREATE TRIGGER trg_ppp_updated BEFORE UPDATE ON public.product_planning_params
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    CREATE TRIGGER trg_opi_updated BEFORE UPDATE ON public.ops_plan_items
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+-- RLS: authenticated read; writes go through service-role API routes.
+ALTER TABLE public.product_planning_params ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.planning_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ops_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ops_plan_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sales_order_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "auth read planning params" ON public.product_planning_params
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read planning settings" ON public.planning_settings
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read ops plans" ON public.ops_plans
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read ops plan items" ON public.ops_plan_items
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read sales order cache" ON public.sales_order_cache
+  FOR SELECT TO authenticated USING (true);


### PR DESCRIPTION
Backend core of the AI production/delivery planner:

- **Migration** (needs manual apply in Supabase SQL editor): planning params (capacity/curing per product), settings (Mon–Sat, delivery cap), ops_plans + ops_plan_items (plan-vs-actual), sales_order_cache; finished_goods.stock_qty
- **Odoo pulls**: confirmed sale.order(+lines) → open-order cache with remaining qty; product qty_available → stock
- **Deterministic scheduler** (pure lib, **14 unit tests passing**): daily capacity + overrides, curing offsets, Sunday-free weeks, stock-first, delivery caps, promise dates, lateness warnings
- **Gemini AI advisor** (fail-open → FIFO): prioritisation, free-text constraints → structured overrides, owner narrative — scheduler re-enforces hard constraints regardless
- **Routes** under `/api/ops-planning/*` (floor-plan module owns /api/planning): inputs / generate / plans / plans/active / items/[id] / promise / variance / notify
- **plan-reminder.yml**: nightly 21:00 IST reminder of tomorrow's plan (leadership + supervisors + per-driver)

Mobile Plan tab (P2) follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full ops-planning workflow, including plan generation, activation, active-plan viewing, variance tracking, and promise-date checks.
  * Added scheduled and manual reminder notifications for upcoming plans.
  * Added plan item updates and sync actions for refreshing planning data.

* **Bug Fixes**
  * Improved scheduling around workdays, capacity limits, delivery timing, and stock availability.
  * Added clearer error handling and validation for planning actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->