### PR TITLE
feat(ops-planner): P3 polish - auto-variance + capacity editor

### DIFF
--- a/apps/native/app/(tabs)/settings.tsx
+++ b/apps/native/app/(tabs)/settings.tsx
@@ -5,9 +5,14 @@ import {
   ScrollView,
   Switch,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  useProductParams,
+  useSaveProductParams,
+} from '@/hooks/use-ops-planning';
 import {
   useMyProfile,
   usePushStatus,
@@ -16,6 +21,110 @@ import {
 } from '@/hooks/use-push-settings';
 import { registerForPush } from '@/lib/push';
 import { useAuth } from '@/store/auth';
+
+function PlanningParamsSection() {
+  const { data, isLoading } = useProductParams();
+  const save = useSaveProductParams();
+  const [editing, setEditing] = useState<string | null>(null);
+  const [capacity, setCapacity] = useState('');
+  const [curing, setCuring] = useState('');
+
+  const startEdit = (row: {
+    finished_good_id: string;
+    daily_capacity_units: number | null;
+    curing_days: number | null;
+  }) => {
+    setEditing(row.finished_good_id);
+    setCapacity(row.daily_capacity_units != null ? String(row.daily_capacity_units) : '');
+    setCuring(row.curing_days != null ? String(row.curing_days) : '7');
+  };
+
+  const commit = (finished_good_id: string) => {
+    const cap = Number(capacity);
+    const cure = Number(curing);
+    if (Number.isNaN(cap) || cap < 0 || Number.isNaN(cure) || cure < 0) return;
+    save.mutate(
+      { finished_good_id, daily_capacity_units: cap, curing_days: cure },
+      { onSuccess: () => setEditing(null) },
+    );
+  };
+
+  return (
+    <View className="mt-4 rounded-xl border border-slate-200 bg-white p-4">
+      <Text className="text-base font-bold text-ink">🏭 Production planning</Text>
+      <Text className="mt-0.5 text-xs text-slate-400">
+        Daily capacity (units/day) and curing days per product — the planner's
+        hard limits.
+      </Text>
+      {isLoading ? (
+        <ActivityIndicator className="mt-3" color="#f97316" />
+      ) : (
+        (data?.data ?? []).map((row) => (
+          <View key={row.finished_good_id} className="mt-3 border-t border-slate-100 pt-2.5">
+            <View className="flex-row items-center justify-between">
+              <Text className="flex-1 pr-2 text-sm font-medium text-ink" numberOfLines={1}>
+                {row.product_name}
+              </Text>
+              {editing === row.finished_good_id ? null : (
+                <Pressable
+                  onPress={() => startEdit(row)}
+                  className="rounded-lg bg-slate-100 px-2.5 py-1 active:opacity-70"
+                >
+                  <Text className="text-xs font-semibold text-slate-600">Edit</Text>
+                </Pressable>
+              )}
+            </View>
+            {editing === row.finished_good_id ? (
+              <View className="mt-2 flex-row items-center gap-2">
+                <TextInput
+                  value={capacity}
+                  onChangeText={setCapacity}
+                  keyboardType="numeric"
+                  placeholder="units/day"
+                  placeholderTextColor="#94a3b8"
+                  className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
+                />
+                <TextInput
+                  value={curing}
+                  onChangeText={setCuring}
+                  keyboardType="numeric"
+                  placeholder="cure d"
+                  placeholderTextColor="#94a3b8"
+                  className="w-16 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
+                />
+                <Pressable
+                  onPress={() => commit(row.finished_good_id)}
+                  disabled={save.isPending}
+                  className={`rounded-lg px-3 py-1.5 ${save.isPending ? 'bg-slate-200' : 'bg-brand active:opacity-80'}`}
+                >
+                  {save.isPending ? (
+                    <ActivityIndicator size="small" color="#0f172a" />
+                  ) : (
+                    <Text className="text-xs font-semibold text-ink">Save</Text>
+                  )}
+                </Pressable>
+              </View>
+            ) : (
+              <Text className="mt-0.5 text-xs text-slate-500">
+                {row.daily_capacity_units != null
+                  ? `${Number(row.daily_capacity_units).toLocaleString('en-IN')}/day · cure ${row.curing_days}d`
+                  : '⚠️ not set — excluded from planning'}
+                {row.stock_qty != null
+                  ? ` · stock ${Number(row.stock_qty).toLocaleString('en-IN')}`
+                  : ''}
+              </Text>
+            )}
+          </View>
+        ))
+      )}
+      {save.isError ? (
+        <Text className="mt-2 text-xs text-red-500">
+          {save.error instanceof Error ? save.error.message : 'Save failed'}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
 
 const PREF_ROWS: { key: string; label: string; hint: string }[] = [
   { key: 'push_leads', label: '🆕 Lead alerts', hint: 'New/assigned leads, updates, order won' },
@@ -166,6 +275,7 @@ export default function SettingsScreen() {
 
         <PushSection />
         {userId ? <PreferencesSection userId={userId} /> : null}
+        <PlanningParamsSection />
 
         <Pressable
           onPress={signOut}

--- a/apps/native/src/hooks/use-ops-planning.ts
+++ b/apps/native/src/hooks/use-ops-planning.ts
@@ -186,3 +186,34 @@ export function useVariance(days = 14) {
     queryFn: () => api.get<VarianceData>('/api/ops-planning/variance', { days }),
   });
 }
+
+export type ProductParams = {
+  finished_good_id: string;
+  product_name: string;
+  stock_qty: number | null;
+  daily_capacity_units: number | null;
+  curing_days: number | null;
+  min_batch: number | null;
+};
+
+export function useProductParams() {
+  return useQuery({
+    queryKey: ['ops-planning', 'params'],
+    queryFn: () => api.get<ProductParams[]>('/api/ops-planning/params'),
+  });
+}
+
+export function useSaveProductParams() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: {
+      finished_good_id: string;
+      daily_capacity_units: number;
+      curing_days: number;
+      min_batch?: number;
+    }) => api.put('/api/ops-planning/params', body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ops-planning'] });
+    },
+  });
+}

--- a/apps/web/app/api/deliveries/[id]/complete/route.ts
+++ b/apps/web/app/api/deliveries/[id]/complete/route.ts
@@ -37,6 +37,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return error(result.message, 500);
     }
 
+    // Auto-variance: mark the matching active-plan delivery item done.
+    try {
+      const { supabaseAdmin } = await import("@/lib/supabase-admin");
+      const { matchDeliveryDone } = await import(
+        "@/lib/ops-planning/variance-matcher"
+      );
+      const { data: deliveryRow } = await supabaseAdmin
+        .from("deliveries")
+        .select("odoo_sale_name, origin, total_quantity")
+        .eq("id", id)
+        .single();
+      if (deliveryRow) await matchDeliveryDone(deliveryRow);
+    } catch (matchErr) {
+      console.error("delivery variance match failed:", matchErr);
+    }
+
     // Return warning if Odoo sync failed but local update succeeded
     if (result.error) {
       const responseData = (result.data as Record<string, unknown>) ?? {};

--- a/apps/web/app/api/ops-planning/params/route.ts
+++ b/apps/web/app/api/ops-planning/params/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/ops-planning/params — all products with their planning knobs
+export async function GET() {
+  try {
+    const { data: goods, error: dbError } = await supabaseAdmin
+      .from("finished_goods")
+      .select("id, name, stock_qty, product_planning_params(daily_capacity_units, curing_days, min_batch)")
+      .eq("is_active", true)
+      .order("name");
+    if (dbError) return error("Failed to load planning params", 500);
+
+    const rows = (goods ?? []).map((g) => {
+      const p = Array.isArray(g.product_planning_params)
+        ? g.product_planning_params[0]
+        : g.product_planning_params;
+      return {
+        finished_good_id: g.id,
+        product_name: g.name,
+        stock_qty: g.stock_qty ?? null,
+        daily_capacity_units: p ? Number(p.daily_capacity_units) : null,
+        curing_days: p ? Number(p.curing_days) : null,
+        min_batch: p ? Number(p.min_batch) : null,
+      };
+    });
+    return success(rows);
+  } catch (err) {
+    console.error("params GET failed:", err);
+    return error("Failed to load planning params", 500);
+  }
+}
+
+const putSchema = z.object({
+  finished_good_id: z.string().uuid(),
+  daily_capacity_units: z.number().nonnegative(),
+  curing_days: z.number().int().min(0).max(60).default(7),
+  min_batch: z.number().nonnegative().default(0),
+});
+
+// PUT /api/ops-planning/params — upsert one product's planning knobs
+export async function PUT(request: NextRequest) {
+  try {
+    const parsed = await parseBody(request, putSchema);
+    if (parsed.error) return parsed.error;
+
+    const { error: dbError } = await supabaseAdmin
+      .from("product_planning_params")
+      .upsert(
+        {
+          finished_good_id: parsed.data.finished_good_id,
+          daily_capacity_units: parsed.data.daily_capacity_units,
+          curing_days: parsed.data.curing_days,
+          min_batch: parsed.data.min_batch,
+          is_active: true,
+        },
+        { onConflict: "finished_good_id" },
+      );
+    if (dbError) return error(`Failed to save: ${dbError.message}`, 500);
+
+    return success({ saved: true });
+  } catch (err) {
+    console.error("params PUT failed:", err);
+    return error("Failed to save planning params", 500);
+  }
+}

--- a/apps/web/app/api/production/orders/[id]/route.ts
+++ b/apps/web/app/api/production/orders/[id]/route.ts
@@ -69,6 +69,21 @@ export async function PUT(request: NextRequest, { params }: Params) {
       return error("Failed to update production order", 500);
     }
 
+    // Auto-variance: reported actuals flow into the active ops plan.
+    if (parsed.data.actual_quantity != null && order) {
+      const { matchProductionActual } = await import(
+        "@/lib/ops-planning/variance-matcher"
+      );
+      await matchProductionActual({
+        finished_good_id:
+          ((order as Record<string, unknown>).finished_good_id as string) ??
+          null,
+        scheduled_date:
+          ((order as Record<string, unknown>).scheduled_date as string) ?? null,
+        actual_quantity: parsed.data.actual_quantity,
+      });
+    }
+
     return success<ProductionOrder>(order);
   } catch (err) {
     console.error("Error updating production order:", err);

--- a/apps/web/src/lib/ops-planning/variance-matcher.ts
+++ b/apps/web/src/lib/ops-planning/variance-matcher.ts
@@ -1,0 +1,113 @@
+/**
+ * Auto-variance: when real work is reported through the existing production /
+ * delivery flows, find the corresponding item in the ACTIVE plan and record
+ * the actual against it — variance appears with zero extra data entry.
+ * Best-effort by design: failures log and never break the reporting request.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+async function activePlanId(): Promise<string | null> {
+  const { data } = await supabaseAdmin
+    .from("ops_plans")
+    .select("id")
+    .eq("status", "active")
+    .maybeSingle();
+  return (data?.id as string) ?? null;
+}
+
+/**
+ * A production order's actual_quantity was reported. Match it to the active
+ * plan's production item for the same product on the order's scheduled date
+ * (falling back to the earliest still-open production item for that product).
+ */
+export async function matchProductionActual(order: {
+  finished_good_id: string | null;
+  scheduled_date: string | null;
+  actual_quantity: number | null;
+}): Promise<void> {
+  try {
+    if (!order.finished_good_id || order.actual_quantity == null) return;
+    const planId = await activePlanId();
+    if (!planId) return;
+
+    const date = order.scheduled_date?.slice(0, 10);
+    let query = supabaseAdmin
+      .from("ops_plan_items")
+      .select("id, quantity")
+      .eq("plan_id", planId)
+      .eq("item_type", "production")
+      .eq("finished_good_id", order.finished_good_id)
+      .in("status", ["planned", "partial"])
+      .order("item_date", { ascending: true })
+      .limit(1);
+    if (date) query = query.eq("item_date", date);
+
+    let { data: items } = await query;
+    if (!items?.length && date) {
+      // No exact-date match — fall back to the earliest open item.
+      const fallback = await supabaseAdmin
+        .from("ops_plan_items")
+        .select("id, quantity")
+        .eq("plan_id", planId)
+        .eq("item_type", "production")
+        .eq("finished_good_id", order.finished_good_id)
+        .in("status", ["planned", "partial"])
+        .order("item_date", { ascending: true })
+        .limit(1);
+      items = fallback.data;
+    }
+    const item = items?.[0];
+    if (!item) return;
+
+    const actual = Number(order.actual_quantity);
+    await supabaseAdmin
+      .from("ops_plan_items")
+      .update({
+        actual_quantity: actual,
+        status: actual >= Number(item.quantity) ? "done" : "partial",
+        notes: "auto-matched from production report",
+      })
+      .eq("id", item.id);
+  } catch (err) {
+    console.error("variance match (production) failed:", err);
+  }
+}
+
+/**
+ * A delivery was completed. Match by the Odoo sale-order reference the plan
+ * items carry (sale_order_ref == deliveries.odoo_sale_name / origin).
+ */
+export async function matchDeliveryDone(delivery: {
+  odoo_sale_name?: string | null;
+  origin?: string | null;
+  total_quantity?: number | null;
+}): Promise<void> {
+  try {
+    const ref = delivery.odoo_sale_name ?? delivery.origin;
+    if (!ref) return;
+    const planId = await activePlanId();
+    if (!planId) return;
+
+    const { data: items } = await supabaseAdmin
+      .from("ops_plan_items")
+      .select("id, quantity")
+      .eq("plan_id", planId)
+      .eq("item_type", "delivery")
+      .eq("sale_order_ref", ref)
+      .in("status", ["planned", "moved"])
+      .limit(1);
+    const item = items?.[0];
+    if (!item) return;
+
+    await supabaseAdmin
+      .from("ops_plan_items")
+      .update({
+        actual_quantity: delivery.total_quantity ?? item.quantity,
+        status: "done",
+        notes: "auto-matched from delivery completion",
+      })
+      .eq("id", item.id);
+  } catch (err) {
+    console.error("variance match (delivery) failed:", err);
+  }
+}


### PR DESCRIPTION
Final planner piece (user-approved plan, 'complete everything'):

- Auto-variance: production actual reports and delivery completions auto-match to active-plan items (done/partial + actuals) — variance requires zero extra data entry
- /api/ops-planning/params GET/PUT — per-product capacity + curing knobs
- Settings → 🏭 Production planning: inline editor for units/day + curing days; unset products flagged

Verified: web + native tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ops planning parameter management for viewing and updating active planning settings.
  * Added automatic variance matching when production orders are updated or deliveries are completed.

* **Bug Fixes**
  * Improved order and delivery completion flows so matching issues are logged without blocking the main response.
  * Better handles missing data by falling back gracefully when planning or match details aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->