### PR TITLE
feat: Maiyuri OneHub — SOP library, Ask Mayur, checklists, links, rhythm

### DIFF
--- a/.github/workflows/odoo-rhythm.yml
+++ b/.github/workflows/odoo-rhythm.yml
@@ -1,0 +1,22 @@
+name: Daily Odoo close-of-day reminder
+
+# OneHub operating rhythm: 12:30 UTC = 18:00 IST — remind accounts/leadership
+# to update expenses, payments and sales in Odoo. Endpoint skips Sundays.
+
+on:
+  schedule:
+    - cron: "30 12 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger rhythm reminder
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/onehub/rhythm")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi

--- a/apps/native/app/(tabs)/_layout.tsx
+++ b/apps/native/app/(tabs)/_layout.tsx
@@ -28,6 +28,25 @@ export default function TabsLayout() {
         options={{
           title: 'Dashboard',
           tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>📊</Text>,
+          headerRight: () => (
+            <Link href={"/onehub" as import("expo-router").Href} asChild>
+              <Pressable
+                style={{
+                  marginRight: 14,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  backgroundColor: '#f97316',
+                  borderRadius: 16,
+                  paddingHorizontal: 10,
+                  paddingVertical: 5,
+                }}
+              >
+                <Text style={{ fontSize: 13, fontWeight: '700', color: '#0f172a' }}>
+                  🧭 OneHub
+                </Text>
+              </Pressable>
+            </Link>
+          ),
         }}
       />
       <Tabs.Screen

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -55,6 +55,7 @@ export default function RootLayout() {
             name="leads/new"
             options={{ headerShown: true, title: 'New Lead' }}
           />
+          <Stack.Screen name="onehub" options={{ headerShown: false }} />
         </Stack>
       </PersistQueryClientProvider>
     </SafeAreaProvider>

--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack } from 'expo-router';
+
+export default function OneHubLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0f172a' },
+        headerTintColor: '#ffffff',
+        headerTitleStyle: { fontWeight: '700' },
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: '🧭 Maiyuri OneHub' }} />
+      <Stack.Screen name="department/[dept]" options={{ title: 'SOPs' }} />
+      <Stack.Screen name="sop/[slug]" options={{ title: 'SOP' }} />
+      <Stack.Screen name="links" options={{ title: 'Important Links' }} />
+      <Stack.Screen name="checklists" options={{ title: 'New Joiners' }} />
+      <Stack.Screen name="checklist/[id]" options={{ title: 'Checklist' }} />
+      <Stack.Screen name="ask" options={{ title: 'Ask Mayur' }} />
+    </Stack>
+  );
+}

--- a/apps/native/app/onehub/ask.tsx
+++ b/apps/native/app/onehub/ask.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useAskMayur } from '@/hooks/use-onehub';
+
+type Entry = {
+  question: string;
+  answer: string;
+  confidence: number;
+  sources: number;
+};
+
+export default function AskMayurScreen() {
+  const ask = useAskMayur();
+  const [question, setQuestion] = useState('');
+  const [language, setLanguage] = useState<'en' | 'ta'>('en');
+  const [history, setHistory] = useState<Entry[]>([]);
+
+  const submit = () => {
+    const q = question.trim();
+    if (!q || ask.isPending) return;
+    ask.mutate(
+      { question: q, language },
+      {
+        onSuccess: (res) => {
+          setHistory((h) => [
+            {
+              question: q,
+              answer: res.data.answer,
+              confidence: res.data.confidence,
+              sources: res.data.sources?.length ?? 0,
+            },
+            ...h,
+          ]);
+          setQuestion('');
+        },
+      },
+    );
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      className="flex-1 bg-slate-50"
+    >
+      <ScrollView className="flex-1" contentContainerClassName="p-4 pb-4">
+        <View className="flex-row items-center rounded-2xl bg-ink p-4">
+          <Text className="mr-3 text-3xl">🦚</Text>
+          <View className="flex-1">
+            <Text className="text-base font-bold text-white">Mayur</Text>
+            <Text className="text-xs text-slate-300">
+              Ask about products, prices, process, SOPs — I answer from Maiyuri's
+              own knowledge.
+            </Text>
+          </View>
+        </View>
+
+        {history.length === 0 && !ask.isPending ? (
+          <View className="mt-4">
+            <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              Try asking
+            </Text>
+            {[
+              'How do I handle a new lead?',
+              'What should I do during a factory visit?',
+              'Why is Maiyuri better than Kerala bricks?',
+              'இன்று உற்பத்தி திட்டம் எப்படி செய்வது?',
+            ].map((q) => (
+              <Pressable
+                key={q}
+                onPress={() => setQuestion(q)}
+                className="mb-2 rounded-xl border border-slate-200 bg-white p-3 active:opacity-70"
+              >
+                <Text className="text-sm text-slate-600">💬 {q}</Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        {ask.isPending ? (
+          <View className="mt-4 flex-row items-center rounded-xl border border-slate-200 bg-white p-4">
+            <ActivityIndicator color="#f97316" />
+            <Text className="ml-3 text-sm text-slate-500">Mayur is thinking…</Text>
+          </View>
+        ) : null}
+        {ask.isError ? (
+          <Text className="mt-3 text-sm text-red-500">
+            {ask.error instanceof Error ? ask.error.message : 'Something went wrong'}
+          </Text>
+        ) : null}
+
+        {history.map((entry, i) => (
+          <View key={i} className="mt-4">
+            <View className="self-end rounded-2xl rounded-br-sm bg-ink px-4 py-2.5">
+              <Text className="text-sm text-white">{entry.question}</Text>
+            </View>
+            <View className="mt-2 self-start rounded-2xl rounded-tl-sm border border-slate-200 bg-white px-4 py-3">
+              <Text className="text-sm leading-6 text-ink">{entry.answer}</Text>
+              <Text className="mt-2 text-xs text-slate-400">
+                🦚 {entry.sources} source{entry.sources === 1 ? '' : 's'} ·{' '}
+                {Math.round(entry.confidence * 100)}% confident
+              </Text>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+
+      <View className="border-t border-slate-200 bg-white p-3">
+        <View className="mb-2 flex-row gap-2">
+          {(['en', 'ta'] as const).map((l) => (
+            <Pressable
+              key={l}
+              onPress={() => setLanguage(l)}
+              className={`rounded-full px-3 py-1 ${language === l ? 'bg-ink' : 'bg-slate-100'}`}
+            >
+              <Text className={`text-xs font-semibold ${language === l ? 'text-white' : 'text-slate-500'}`}>
+                {l === 'en' ? 'English' : 'தமிழ்'}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        <View className="flex-row items-end gap-2">
+          <TextInput
+            value={question}
+            onChangeText={setQuestion}
+            placeholder={language === 'ta' ? 'உங்கள் கேள்வியை கேளுங்கள்…' : 'Ask Mayur anything…'}
+            placeholderTextColor="#94a3b8"
+            multiline
+            className="max-h-24 flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-ink"
+          />
+          <Pressable
+            onPress={submit}
+            disabled={ask.isPending || !question.trim()}
+            className={`h-11 w-11 items-center justify-center rounded-full ${
+              ask.isPending || !question.trim() ? 'bg-slate-200' : 'bg-brand active:opacity-80'
+            }`}
+          >
+            <Text className="text-lg">➤</Text>
+          </Pressable>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}

--- a/apps/native/app/onehub/checklist/[id].tsx
+++ b/apps/native/app/onehub/checklist/[id].tsx
@@ -1,0 +1,79 @@
+import { useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+import { useChecklists, useTickChecklist } from '@/hooks/use-onehub';
+
+export default function ChecklistRunScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { data, isLoading } = useChecklists();
+  const tick = useTickChecklist(id);
+
+  const run = (data?.data.runs ?? []).find((r) => r.id === id);
+  const template = (data?.data.templates ?? []).find((t) => t.id === run?.template_id);
+
+  if (isLoading || !run || !template) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        {isLoading ? (
+          <ActivityIndicator size="large" color="#f97316" />
+        ) : (
+          <Text className="text-slate-400">Checklist not found</Text>
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-12">
+      <Text className="text-lg font-bold text-ink">👤 {run.subject_name}</Text>
+      {run.completed_at ? (
+        <Text className="mt-1 text-sm font-semibold text-green-600">
+          🎉 Onboarding completed {new Date(run.completed_at).toLocaleDateString('en-IN')}
+        </Text>
+      ) : null}
+
+      {template.phases.map((phase) => (
+        <View key={phase.phase} className="mt-4">
+          <Text className="mb-2 text-sm font-bold uppercase tracking-wider text-slate-500">
+            {phase.phase}
+          </Text>
+          {phase.items.map((item) => {
+            const state = run.statuses?.[item.id];
+            const done = !!state?.done;
+            return (
+              <Pressable
+                key={item.id}
+                onPress={() => tick.mutate({ item_id: item.id, done: !done })}
+                disabled={tick.isPending}
+                className={`mb-2 flex-row items-center rounded-xl border p-3.5 ${
+                  done ? 'border-green-200 bg-green-50' : 'border-slate-200 bg-white'
+                } active:opacity-70`}
+              >
+                <View
+                  className={`mr-3 h-6 w-6 items-center justify-center rounded-md border-2 ${
+                    done ? 'border-green-500 bg-green-500' : 'border-slate-300 bg-white'
+                  }`}
+                >
+                  {done ? <Text className="text-xs font-bold text-white">✓</Text> : null}
+                </View>
+                <View className="flex-1">
+                  <Text className={`text-sm ${done ? 'text-slate-400 line-through' : 'text-ink'}`}>
+                    {item.text}
+                  </Text>
+                  <Text className="text-xs capitalize text-slate-400">
+                    Owner: {item.owner_role.replaceAll('_', ' ')}
+                    {state?.at ? ` · done ${new Date(state.at).toLocaleDateString('en-IN')}` : ''}
+                  </Text>
+                </View>
+              </Pressable>
+            );
+          })}
+        </View>
+      ))}
+      {tick.isError ? (
+        <Text className="mt-2 text-sm text-red-500">
+          {tick.error instanceof Error ? tick.error.message : 'Update failed'}
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/checklists.tsx
+++ b/apps/native/app/onehub/checklists.tsx
@@ -1,0 +1,105 @@
+import { Link } from 'expo-router';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useChecklists, useStartChecklist } from '@/hooks/use-onehub';
+
+export default function ChecklistsScreen() {
+  const { data, isLoading } = useChecklists();
+  const start = useStartChecklist();
+  const [name, setName] = useState('');
+
+  const template = data?.data.templates[0];
+  const runs = data?.data.runs ?? [];
+  const totalItems = (t: typeof template) =>
+    (t?.phases ?? []).reduce((s, p) => s + p.items.length, 0);
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-10">
+      {isLoading ? (
+        <ActivityIndicator size="large" color="#f97316" className="mt-10" />
+      ) : (
+        <>
+          {/* start a new run */}
+          <View className="rounded-xl border border-slate-200 bg-white p-4">
+            <Text className="text-sm font-bold text-ink">Start onboarding a new joiner</Text>
+            <View className="mt-2 flex-row gap-2">
+              <TextInput
+                value={name}
+                onChangeText={setName}
+                placeholder="Joiner's name"
+                placeholderTextColor="#94a3b8"
+                className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-ink"
+              />
+              <Pressable
+                onPress={() =>
+                  template &&
+                  name.trim() &&
+                  start.mutate(
+                    { template_id: template.id, subject_name: name.trim() },
+                    { onSuccess: () => setName('') },
+                  )
+                }
+                disabled={start.isPending || !name.trim() || !template}
+                className={`items-center justify-center rounded-lg px-4 ${
+                  start.isPending || !name.trim() ? 'bg-slate-200' : 'bg-brand active:opacity-80'
+                }`}
+              >
+                {start.isPending ? (
+                  <ActivityIndicator size="small" color="#0f172a" />
+                ) : (
+                  <Text className="text-sm font-semibold text-ink">Start</Text>
+                )}
+              </Pressable>
+            </View>
+            {start.isError ? (
+              <Text className="mt-2 text-xs text-red-500">
+                {start.error instanceof Error ? start.error.message : 'Failed'}
+              </Text>
+            ) : null}
+          </View>
+
+          {/* runs */}
+          <Text className="mb-2 mt-4 text-base font-bold text-ink">In progress</Text>
+          {runs.length === 0 ? (
+            <Text className="text-sm text-slate-400">No joiners being onboarded yet.</Text>
+          ) : (
+            runs.map((run) => {
+              const done = Object.keys(run.statuses ?? {}).length;
+              const total = totalItems(template);
+              const pct = total ? Math.round((done / total) * 100) : 0;
+              return (
+                <Link key={run.id} href={`/onehub/checklist/${run.id}` as import("expo-router").Href} asChild>
+                  <Pressable className="mb-2 rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+                    <View className="flex-row items-center justify-between">
+                      <Text className="text-base font-semibold text-ink">
+                        {run.completed_at ? '🎉 ' : '👤 '}
+                        {run.subject_name}
+                      </Text>
+                      <Text className="text-sm font-bold text-slate-500">{pct}%</Text>
+                    </View>
+                    <View className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+                      <View
+                        className={`h-2 rounded-full ${run.completed_at ? 'bg-green-500' : 'bg-brand'}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </View>
+                    <Text className="mt-1 text-xs text-slate-400">
+                      {done}/{total} done · started {new Date(run.started_at).toLocaleDateString('en-IN')}
+                    </Text>
+                  </Pressable>
+                </Link>
+              );
+            })
+          )}
+        </>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/department/[dept].tsx
+++ b/apps/native/app/onehub/department/[dept].tsx
@@ -1,0 +1,50 @@
+import { Link, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+import { useSops } from '@/hooks/use-onehub';
+import { DEPARTMENTS } from '../index';
+
+export default function DepartmentSops() {
+  const { dept } = useLocalSearchParams<{ dept: string }>();
+  const { data, isLoading } = useSops(dept);
+  const meta = DEPARTMENTS.find((d) => d.key === dept);
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-10">
+      <Text className="mb-3 text-lg font-bold text-ink">
+        {meta?.icon} {meta?.label ?? dept} <Text className="text-sm text-slate-400">{meta?.ta}</Text>
+      </Text>
+      {isLoading ? (
+        <ActivityIndicator size="large" color="#f97316" className="mt-10" />
+      ) : (data?.data ?? []).length === 0 ? (
+        <View className="rounded-xl border border-slate-200 bg-white p-5">
+          <Text className="text-sm text-slate-400">
+            No SOPs here yet — they'll appear as the library grows.
+          </Text>
+        </View>
+      ) : (
+        (data?.data ?? []).map((sop) => (
+          <Link key={sop.id} href={`/onehub/sop/${sop.slug}` as import("expo-router").Href} asChild>
+            <Pressable className="mb-2 rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+              <View className="flex-row items-center justify-between">
+                <Text className="flex-1 text-base font-semibold text-ink" numberOfLines={1}>
+                  {sop.title_en}
+                </Text>
+                {sop.status === 'draft' ? (
+                  <View className="ml-2 rounded-full bg-slate-200 px-2 py-0.5">
+                    <Text className="text-xs text-slate-600">draft</Text>
+                  </View>
+                ) : null}
+              </View>
+              {sop.title_ta ? (
+                <Text className="text-sm text-slate-500">{sop.title_ta}</Text>
+              ) : null}
+              <Text className="mt-1 text-xs text-slate-400">
+                {sop.steps.length} steps · v{sop.version}
+              </Text>
+            </Pressable>
+          </Link>
+        ))
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/index.tsx
+++ b/apps/native/app/onehub/index.tsx
@@ -1,0 +1,88 @@
+import { Link } from 'expo-router';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useSops } from '@/hooks/use-onehub';
+
+export const DEPARTMENTS: { key: string; label: string; ta: string; icon: string }[] = [
+  { key: 'sales', label: 'Sales', ta: 'விற்பனை', icon: '🤝' },
+  { key: 'production', label: 'Production', ta: 'உற்பத்தி', icon: '🏭' },
+  { key: 'dispatch', label: 'Dispatch', ta: 'டெலிவரி', icon: '🚚' },
+  { key: 'accounts', label: 'Accounts & Odoo', ta: 'கணக்கு', icon: '💰' },
+  { key: 'hr', label: 'HR / Admin', ta: 'நிர்வாகம்', icon: '👥' },
+  { key: 'safety', label: 'Safety', ta: 'பாதுகாப்பு', icon: '🦺' },
+];
+
+export default function OneHubHome() {
+  const { data } = useSops();
+  const counts = new Map<string, number>();
+  for (const sop of data?.data ?? []) {
+    counts.set(sop.department, (counts.get(sop.department) ?? 0) + 1);
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-10">
+      {/* brand promise */}
+      <View className="rounded-2xl bg-ink p-5">
+        <Text className="text-lg font-bold text-white">Vanakkam! 👋</Text>
+        <Text className="mt-2 text-2xl font-bold text-brand">
+          நம் மண். நம் வீடு. நம் அறிவு.
+        </Text>
+        <Text className="mt-1 text-sm text-slate-300">
+          Our soil. Our home. Our wisdom. — One place for SOPs, checklists,
+          links and answers.
+        </Text>
+      </View>
+
+      {/* Ask Mayur */}
+      <Link href={"/onehub/ask" as import("expo-router").Href} asChild>
+        <Pressable className="mt-3 flex-row items-center rounded-2xl border-2 border-brand bg-orange-50 p-4 active:opacity-70">
+          <Text className="mr-3 text-3xl">🦚</Text>
+          <View className="flex-1">
+            <Text className="text-base font-bold text-ink">Ask Mayur</Text>
+            <Text className="text-xs text-slate-500">
+              Any question about products, process, SOPs — English or தமிழ்
+            </Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
+
+      {/* SOP library */}
+      <Text className="mb-2 mt-5 text-base font-bold text-ink">📖 SOP Library</Text>
+      <View className="flex-row flex-wrap justify-between">
+        {DEPARTMENTS.map((d) => (
+          <Link key={d.key} href={`/onehub/department/${d.key}` as import("expo-router").Href} asChild>
+            <Pressable className="mb-3 w-[48.5%] rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+              <Text className="text-2xl">{d.icon}</Text>
+              <Text className="mt-1 text-sm font-semibold text-ink">{d.label}</Text>
+              <Text className="text-xs text-slate-400">
+                {d.ta} · {counts.get(d.key) ?? 0} SOP{(counts.get(d.key) ?? 0) === 1 ? '' : 's'}
+              </Text>
+            </Pressable>
+          </Link>
+        ))}
+      </View>
+
+      {/* other sections */}
+      <Link href={"/onehub/checklists" as import("expo-router").Href} asChild>
+        <Pressable className="mb-3 flex-row items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+          <Text className="mr-3 text-2xl">✅</Text>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-ink">New Joiners Checklist</Text>
+            <Text className="text-xs text-slate-400">Onboarding steps, owners, progress</Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
+      <Link href={"/onehub/links" as import("expo-router").Href} asChild>
+        <Pressable className="mb-3 flex-row items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+          <Text className="mr-3 text-2xl">🔗</Text>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-ink">Important Links</Text>
+            <Text className="text-xs text-slate-400">Odoo, brochure, calculator, socials</Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/links.tsx
+++ b/apps/native/app/onehub/links.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { ActivityIndicator, Linking, Pressable, ScrollView, Text, View } from 'react-native';
+import { useOneHubLinks } from '@/hooks/use-onehub';
+
+export default function LinksScreen() {
+  const { data, isLoading } = useOneHubLinks();
+
+  const byCategory = useMemo(() => {
+    const map = new Map<string, NonNullable<typeof data>['data']>();
+    for (const link of data?.data ?? []) {
+      const arr = map.get(link.category) ?? [];
+      arr.push(link);
+      map.set(link.category, arr);
+    }
+    return [...map.entries()];
+  }, [data]);
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-10">
+      {isLoading ? (
+        <ActivityIndicator size="large" color="#f97316" className="mt-10" />
+      ) : (
+        byCategory.map(([category, links]) => (
+          <View key={category} className="mb-4">
+            <Text className="mb-2 text-base font-bold text-ink">{category}</Text>
+            {links!.map((link) => {
+              const placeholder = link.url === 'https://';
+              return (
+                <Pressable
+                  key={link.id}
+                  disabled={placeholder}
+                  onPress={() => Linking.openURL(link.url)}
+                  className={`mb-2 rounded-xl border border-slate-200 bg-white p-3.5 ${placeholder ? 'opacity-50' : 'active:opacity-70'}`}
+                >
+                  <View className="flex-row items-center justify-between">
+                    <Text className="flex-1 text-sm font-semibold text-ink" numberOfLines={1}>
+                      🔗 {link.name}
+                    </Text>
+                    {placeholder ? (
+                      <Text className="text-xs text-amber-600">link pending</Text>
+                    ) : (
+                      <Text className="text-slate-400">↗</Text>
+                    )}
+                  </View>
+                  {link.purpose ? (
+                    <Text className="mt-0.5 text-xs text-slate-400">{link.purpose}</Text>
+                  ) : null}
+                </Pressable>
+              );
+            })}
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/sop/[slug].tsx
+++ b/apps/native/app/onehub/sop/[slug].tsx
@@ -1,0 +1,124 @@
+import { useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { useSops } from '@/hooks/use-onehub';
+
+type Lang = 'both' | 'en' | 'ta';
+
+export default function SopViewer() {
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+  const { data, isLoading } = useSops();
+  const [lang, setLang] = useState<Lang>('both');
+  const sop = (data?.data ?? []).find((s) => s.slug === slug);
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#f97316" />
+      </View>
+    );
+  }
+  if (!sop) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white px-6">
+        <Text className="text-slate-400">SOP not found</Text>
+      </View>
+    );
+  }
+
+  const showEn = lang !== 'ta';
+  const showTa = lang !== 'en';
+
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerClassName="pb-12">
+      <View className="bg-ink px-5 pb-5 pt-4">
+        {showEn ? (
+          <Text className="text-xl font-bold text-white">{sop.title_en}</Text>
+        ) : null}
+        {showTa && sop.title_ta ? (
+          <Text className={`${showEn ? 'mt-0.5 text-base text-brand' : 'text-xl font-bold text-brand'}`}>
+            {sop.title_ta}
+          </Text>
+        ) : null}
+        {sop.purpose_en && showEn ? (
+          <Text className="mt-2 text-sm text-slate-300">{sop.purpose_en}</Text>
+        ) : null}
+        {sop.purpose_ta && showTa ? (
+          <Text className="mt-1 text-sm text-slate-400">{sop.purpose_ta}</Text>
+        ) : null}
+
+        {/* language toggle */}
+        <View className="mt-3 flex-row gap-2">
+          {(['both', 'en', 'ta'] as Lang[]).map((l) => (
+            <Pressable
+              key={l}
+              onPress={() => setLang(l)}
+              className={`rounded-full px-3 py-1 ${lang === l ? 'bg-brand' : 'bg-slate-700'}`}
+            >
+              <Text className={`text-xs font-semibold ${lang === l ? 'text-ink' : 'text-slate-300'}`}>
+                {l === 'both' ? 'EN + த' : l === 'en' ? 'English' : 'தமிழ்'}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      <View className="px-5 pt-4">
+        {sop.steps.map((step, i) => (
+          <View key={i} className="mb-3 flex-row rounded-xl border border-slate-100 bg-slate-50 p-3.5">
+            <View className="mr-3 items-center">
+              <View className="h-8 w-8 items-center justify-center rounded-full bg-ink">
+                <Text className="text-sm font-bold text-white">{i + 1}</Text>
+              </View>
+              {step.icon ? <Text className="mt-1 text-lg">{step.icon}</Text> : null}
+            </View>
+            <View className="flex-1">
+              {showEn ? (
+                <Text className="text-[15px] leading-5 text-ink">{step.en}</Text>
+              ) : null}
+              {showTa && step.ta ? (
+                <Text className={`text-[15px] leading-6 ${showEn ? 'mt-1 text-slate-500' : 'text-ink'}`}>
+                  {step.ta}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        ))}
+
+        {sop.warning_en || sop.warning_ta ? (
+          <View className="mt-2 rounded-xl border-2 border-red-200 bg-red-50 p-4">
+            <Text className="text-xs font-bold uppercase tracking-wider text-red-500">
+              ⚠️ Important / முக்கியம்
+            </Text>
+            {showEn && sop.warning_en ? (
+              <Text className="mt-1 text-sm leading-5 text-red-700">{sop.warning_en}</Text>
+            ) : null}
+            {showTa && sop.warning_ta ? (
+              <Text className="mt-1 text-sm leading-6 text-red-600">{sop.warning_ta}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        {sop.video_url ? (
+          <Pressable
+            onPress={() => Linking.openURL(sop.video_url!)}
+            className="mt-4 flex-row items-center justify-center rounded-xl bg-ink py-3 active:opacity-80"
+          >
+            <Text className="font-semibold text-white">▶️ Watch video guide</Text>
+          </Pressable>
+        ) : null}
+
+        <Text className="mt-6 text-center text-xs text-slate-400">
+          v{sop.version} · updated {new Date(sop.updated_at).toLocaleDateString('en-IN')}
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/native/src/hooks/use-onehub.ts
+++ b/apps/native/src/hooks/use-onehub.ts
@@ -1,0 +1,114 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export type SopStep = { en: string; ta?: string; icon?: string };
+
+export type Sop = {
+  id: string;
+  department: 'sales' | 'production' | 'dispatch' | 'accounts' | 'hr' | 'safety';
+  slug: string;
+  title_en: string;
+  title_ta: string | null;
+  purpose_en: string | null;
+  purpose_ta: string | null;
+  steps: SopStep[];
+  warning_en: string | null;
+  warning_ta: string | null;
+  video_url: string | null;
+  version: number;
+  status: 'draft' | 'published';
+  updated_at: string;
+};
+
+export type OneHubLink = {
+  id: string;
+  category: string;
+  name: string;
+  purpose: string | null;
+  url: string;
+  sort_order: number;
+  updated_at: string;
+};
+
+export type ChecklistTemplate = {
+  id: string;
+  name: string;
+  phases: { phase: string; items: { id: string; text: string; owner_role: string }[] }[];
+};
+
+export type ChecklistRun = {
+  id: string;
+  template_id: string;
+  subject_name: string;
+  statuses: Record<string, { done: boolean; by: string; at: string }>;
+  started_at: string;
+  completed_at: string | null;
+};
+
+export function useSops(department?: string) {
+  return useQuery({
+    queryKey: ['onehub', 'sops', department ?? 'all'],
+    queryFn: () => api.get<Sop[]>('/api/onehub/sops', department ? { department } : undefined),
+  });
+}
+
+export function useSaveSop() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: Partial<Sop>) => api.post<Sop>('/api/onehub/sops', body),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['onehub', 'sops'] }),
+  });
+}
+
+export function useOneHubLinks() {
+  return useQuery({
+    queryKey: ['onehub', 'links'],
+    queryFn: () => api.get<OneHubLink[]>('/api/onehub/links'),
+  });
+}
+
+export function useChecklists() {
+  return useQuery({
+    queryKey: ['onehub', 'checklists'],
+    queryFn: () =>
+      api.get<{ templates: ChecklistTemplate[]; runs: ChecklistRun[] }>(
+        '/api/onehub/checklists',
+      ),
+  });
+}
+
+export function useStartChecklist() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { template_id: string; subject_name: string }) =>
+      api.post<ChecklistRun>('/api/onehub/checklists', body),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['onehub', 'checklists'] }),
+  });
+}
+
+export function useTickChecklist(runId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { item_id: string; done: boolean }) =>
+      api.patch<ChecklistRun>(`/api/onehub/checklists/runs/${runId}`, body),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['onehub', 'checklists'] }),
+  });
+}
+
+export type AskAnswer = {
+  answer: string;
+  sources: { content: string; sourceType: string; score: number }[];
+  confidence: number;
+};
+
+/** Ask Mayur — thin client over the existing RAG endpoint (Tamil-capable). */
+export function useAskMayur() {
+  return useMutation({
+    mutationFn: (body: { question: string; language: 'en' | 'ta' }) =>
+      api.post<AskAnswer>('/api/knowledge/ask', {
+        question: body.question,
+        language: body.language,
+        maxSources: 4,
+      }),
+  });
+}

--- a/apps/web/app/api/onehub/checklists/route.ts
+++ b/apps/web/app/api/onehub/checklists/route.ts
@@ -1,0 +1,58 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/onehub/checklists — templates + all runs (small volumes)
+export async function GET() {
+  try {
+    const [{ data: templates }, { data: runs }] = await Promise.all([
+      supabaseAdmin
+        .from("onehub_checklist_templates")
+        .select("*")
+        .eq("is_active", true),
+      supabaseAdmin
+        .from("onehub_checklist_runs")
+        .select("*")
+        .order("started_at", { ascending: false })
+        .limit(50),
+    ]);
+    return success({ templates: templates ?? [], runs: runs ?? [] });
+  } catch (err) {
+    console.error("onehub checklists GET failed:", err);
+    return error("Failed to load checklists", 500);
+  }
+}
+
+const createRunSchema = z.object({
+  template_id: z.string().uuid(),
+  subject_name: z.string().min(1),
+  subject_user_id: z.string().uuid().nullable().optional(),
+});
+
+// POST /api/onehub/checklists — start a checklist run for a new joiner
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (user.role !== "founder" && user.role !== "owner" && user.role !== "accountant") {
+      return error("Not allowed to start checklists", 403);
+    }
+    const parsed = await parseBody(request, createRunSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("onehub_checklist_runs")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to start checklist", 500);
+    return success(data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("onehub checklists POST failed:", err);
+    return error("Failed to start checklist", 500);
+  }
+}

--- a/apps/web/app/api/onehub/checklists/runs/[id]/route.ts
+++ b/apps/web/app/api/onehub/checklists/runs/[id]/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, notFound, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const tickSchema = z.object({
+  item_id: z.string().min(1),
+  done: z.boolean(),
+});
+
+// PATCH /api/onehub/checklists/runs/[id] — tick/untick one item
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const user = await requireAuth(request);
+    const parsed = await parseBody(request, tickSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data: run } = await supabaseAdmin
+      .from("onehub_checklist_runs")
+      .select("id, statuses, template_id")
+      .eq("id", params.id)
+      .single();
+    if (!run) return notFound("Checklist run not found");
+
+    const statuses = { ...(run.statuses as Record<string, unknown>) };
+    if (parsed.data.done) {
+      statuses[parsed.data.item_id] = {
+        done: true,
+        by: user.id,
+        at: new Date().toISOString(),
+      };
+    } else {
+      delete statuses[parsed.data.item_id];
+    }
+
+    // Completed when every template item is ticked.
+    const { data: template } = await supabaseAdmin
+      .from("onehub_checklist_templates")
+      .select("phases")
+      .eq("id", run.template_id)
+      .single();
+    const allItems = ((template?.phases as { items: { id: string }[] }[]) ?? [])
+      .flatMap((p) => p.items.map((i) => i.id));
+    const complete =
+      allItems.length > 0 && allItems.every((id) => statuses[id]);
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("onehub_checklist_runs")
+      .update({
+        statuses,
+        completed_at: complete ? new Date().toISOString() : null,
+      })
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update checklist", 500);
+    return success(data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("checklist run PATCH failed:", err);
+    return error("Failed to update checklist", 500);
+  }
+}

--- a/apps/web/app/api/onehub/links/route.ts
+++ b/apps/web/app/api/onehub/links/route.ts
@@ -1,0 +1,67 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const linkSchema = z.object({
+  id: z.string().uuid().optional(),
+  category: z.string().min(1),
+  name: z.string().min(1),
+  purpose: z.string().nullable().optional(),
+  url: z.string().url(),
+  sort_order: z.number().int().default(0),
+});
+
+// GET /api/onehub/links — everyone (authenticated)
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("onehub_links")
+      .select("*")
+      .order("category")
+      .order("sort_order");
+    if (dbError) return error("Failed to load links", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("onehub links GET failed:", err);
+    return error("Failed to load links", 500);
+  }
+}
+
+// POST /api/onehub/links — upsert (founder/owner)
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (user.role !== "founder" && user.role !== "owner") {
+      return error("Only founders can edit links", 403);
+    }
+    const parsed = await parseBody(request, linkSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const result = id
+      ? await supabaseAdmin
+          .from("onehub_links")
+          .update({ ...fields, owner_id: user.id, updated_at: new Date().toISOString() })
+          .eq("id", id)
+          .select("*")
+          .single()
+      : await supabaseAdmin
+          .from("onehub_links")
+          .insert({ ...fields, owner_id: user.id })
+          .select("*")
+          .single();
+
+    if (result.error || !result.data) {
+      return error(`Failed to save link: ${result.error?.message}`, 500);
+    }
+    return success(result.data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("onehub links POST failed:", err);
+    return error("Failed to save link", 500);
+  }
+}

--- a/apps/web/app/api/onehub/rhythm/route.ts
+++ b/apps/web/app/api/onehub/rhythm/route.ts
@@ -1,0 +1,48 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import {
+  filterByPushPref,
+  getUserIdsByRoles,
+  sendPushToUsers,
+} from "@/lib/push/fcm";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * POST /api/onehub/rhythm — daily operating-rhythm reminder (18:00 IST via
+ * GitHub Action): nudge accounts/leadership to close the day in Odoo.
+ * Part of the OneHub "Daily Reminders" discipline. Skips Sundays.
+ */
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+
+  try {
+    const istNow = new Date(Date.now() + 5.5 * 3600 * 1000);
+    if (istNow.getUTCDay() === 0) return success({ sent: 0, reason: "Sunday" });
+
+    const staff = await getUserIdsByRoles(["accountant", "founder", "owner"]);
+    const recipients = await filterByPushPref(staff, "push_ops");
+    if (!recipients.length) return success({ sent: 0, reason: "no recipients" });
+
+    const res = await sendPushToUsers(recipients, {
+      title: "🧾 Close the day in Odoo",
+      body: "Update today's expenses, payments and sales entries before end of day.",
+      data: { url: "/onehub" },
+    });
+    return success({ sent: res.sent, failed: res.failed });
+  } catch (err) {
+    console.error("rhythm reminder failed:", err);
+    return error("Rhythm reminder failed", 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/apps/web/app/api/onehub/sops/route.ts
+++ b/apps/web/app/api/onehub/sops/route.ts
@@ -1,0 +1,149 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // publish path embeds into the RAG store
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { routes } from "@maiyuri/api";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const stepSchema = z.object({
+  en: z.string().min(1),
+  ta: z.string().optional().default(""),
+  icon: z.string().optional(),
+});
+
+const sopSchema = z.object({
+  id: z.string().uuid().optional(), // present = update
+  department: z.enum(["sales", "production", "dispatch", "accounts", "hr", "safety"]),
+  slug: z.string().min(2).regex(/^[a-z0-9-]+$/),
+  title_en: z.string().min(2),
+  title_ta: z.string().nullable().optional(),
+  purpose_en: z.string().nullable().optional(),
+  purpose_ta: z.string().nullable().optional(),
+  steps: z.array(stepSchema).min(1).max(10),
+  warning_en: z.string().nullable().optional(),
+  warning_ta: z.string().nullable().optional(),
+  video_url: z.string().url().nullable().optional().or(z.literal("").transform(() => null)),
+  status: z.enum(["draft", "published"]).default("draft"),
+});
+
+/** Flatten an SOP into RAG-ingestible text (EN + TA together). */
+function sopToRagContent(sop: {
+  title_en: string;
+  title_ta?: string | null;
+  purpose_en?: string | null;
+  department: string;
+  steps: { en: string; ta?: string }[];
+  warning_en?: string | null;
+}): string {
+  const lines = [
+    `SOP: ${sop.title_en}${sop.title_ta ? ` / ${sop.title_ta}` : ""}`,
+    `Department: ${sop.department}`,
+    sop.purpose_en ? `Purpose: ${sop.purpose_en}` : "",
+    "Steps:",
+    ...sop.steps.map(
+      (s, i) => `${i + 1}. ${s.en}${s.ta ? ` (${s.ta})` : ""}`,
+    ),
+    sop.warning_en ? `Important warning: ${sop.warning_en}` : "",
+  ];
+  return lines.filter(Boolean).join("\n");
+}
+
+// GET /api/onehub/sops?department=sales — published for everyone; drafts for founder/owner
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const department = searchParams.get("department");
+
+    let includeDrafts = false;
+    try {
+      const user = await requireAuth(request);
+      includeDrafts = user.role === "founder" || user.role === "owner";
+    } catch {
+      // Machine-auth callers (middleware-bypassed) see published only.
+    }
+
+    let query = supabaseAdmin
+      .from("onehub_sops")
+      .select("*")
+      .order("department")
+      .order("title_en");
+    if (department) query = query.eq("department", department);
+    if (!includeDrafts) query = query.eq("status", "published");
+
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load SOPs", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("onehub sops GET failed:", err);
+    return error("Failed to load SOPs", 500);
+  }
+}
+
+// POST /api/onehub/sops — create/update (founder/owner). Publishing ingests into RAG.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (user.role !== "founder" && user.role !== "owner") {
+      return error("Only founders can edit SOPs", 403);
+    }
+
+    const parsed = await parseBody(request, sopSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const row = {
+      ...fields,
+      owner_id: user.id,
+      ...(id ? {} : {}),
+    };
+
+    const result = id
+      ? await supabaseAdmin
+          .from("onehub_sops")
+          .update({ ...row, updated_at: new Date().toISOString() })
+          .eq("id", id)
+          .select("*")
+          .single()
+      : await supabaseAdmin
+          .from("onehub_sops")
+          .upsert(row, { onConflict: "slug" })
+          .select("*")
+          .single();
+
+    if (result.error || !result.data) {
+      return error(`Failed to save SOP: ${result.error?.message}`, 500);
+    }
+    const sop = result.data;
+
+    // Publish → embed into the knowledge base so Ask Mayur can cite it.
+    if (sop.status === "published") {
+      try {
+        const ingest = await routes.knowledge.ingestKnowledge({
+          content: sopToRagContent(sop),
+          title: `SOP: ${sop.title_en}`,
+          category: "sop",
+          tags: ["sop", sop.department],
+          contentType: "manual",
+          metadata: { sop_slug: sop.slug, department: sop.department },
+        });
+        if (ingest.success) {
+          await supabaseAdmin
+            .from("onehub_sops")
+            .update({ rag_synced_at: new Date().toISOString() })
+            .eq("id", sop.id);
+        }
+      } catch (ragErr) {
+        console.error("SOP RAG ingest failed (SOP saved):", ragErr);
+      }
+    }
+
+    return success(sop);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("onehub sops POST failed:", err);
+    return error("Failed to save SOP", 500);
+  }
+}

--- a/supabase/migrations/20260705150000_onehub.sql
+++ b/supabase/migrations/20260705150000_onehub.sql
@@ -1,0 +1,208 @@
+-- ============================================================================
+-- Maiyuri OneHub: SOP library, important links, new-joiner checklists.
+-- Company-foundation content seeds into the existing coach_knowledge_base.
+-- Writes go through service-role API routes; RLS grants authenticated reads.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.onehub_sops (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  department TEXT NOT NULL CHECK (department IN ('sales','production','dispatch','accounts','hr','safety')),
+  slug TEXT NOT NULL UNIQUE,
+  title_en TEXT NOT NULL,
+  title_ta TEXT,
+  purpose_en TEXT,
+  purpose_ta TEXT,
+  -- [{"en":"...","ta":"...","icon":"📞"}] — 5-7 visual-first steps
+  steps JSONB NOT NULL DEFAULT '[]',
+  warning_en TEXT,
+  warning_ta TEXT,
+  video_url TEXT,
+  owner_id UUID REFERENCES public.users(id),
+  version INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','published')),
+  approved_by UUID REFERENCES public.users(id),
+  rag_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_onehub_sops_department ON public.onehub_sops(department);
+
+CREATE TABLE IF NOT EXISTS public.onehub_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  category TEXT NOT NULL,
+  name TEXT NOT NULL,
+  purpose TEXT,
+  url TEXT NOT NULL,
+  owner_id UUID REFERENCES public.users(id),
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.onehub_checklist_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  -- [{"phase":"Day 1","items":[{"id":"d1-1","text":"...","owner_role":"admin"}]}]
+  phases JSONB NOT NULL DEFAULT '[]',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.onehub_checklist_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES public.onehub_checklist_templates(id),
+  subject_user_id UUID REFERENCES public.users(id),
+  subject_name TEXT NOT NULL, -- joiner may not have an app account yet
+  -- {"d1-1": {"done": true, "by": "<uuid>", "at": "iso"}}
+  statuses JSONB NOT NULL DEFAULT '{}',
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+ALTER TABLE public.onehub_sops ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onehub_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onehub_checklist_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.onehub_checklist_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "auth read sops" ON public.onehub_sops FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read links" ON public.onehub_links FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read checklist templates" ON public.onehub_checklist_templates FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read checklist runs" ON public.onehub_checklist_runs FOR SELECT TO authenticated USING (true);
+
+-- ============================================================================
+-- SEED: 3 SOPs (EN + TA drafts — owner reviews in-app)
+-- ============================================================================
+
+INSERT INTO public.onehub_sops (department, slug, title_en, title_ta, purpose_en, purpose_ta, steps, warning_en, warning_ta, status, version)
+VALUES
+(
+  'sales', 'new-lead-handling',
+  'New Lead Handling', 'புதிய லீட் கையாளுதல்',
+  'Respond fast and capture the right details the moment a new lead arrives.',
+  'புதிய லீட் வந்தவுடன் விரைவாக பதிலளித்து சரியான விவரங்களை பதிவு செய்யவும்.',
+  '[
+    {"icon":"⚡","en":"Open the lead within 10 minutes of the push alert","ta":"புஷ் அறிவிப்பு வந்த 10 நிமிடத்திற்குள் லீடை திறக்கவும்"},
+    {"icon":"📞","en":"Call the customer — introduce yourself and Maiyuri Bricks","ta":"வாடிக்கையாளரை அழையுங்கள் — உங்களையும் மையூரி பிரிக்ஸ்-ஐயும் அறிமுகம் செய்யவும்"},
+    {"icon":"❓","en":"Ask four things: site location, construction type, quantity needed, timeline","ta":"நான்கு விஷயங்கள் கேளுங்கள்: இடம், கட்டுமான வகை, தேவையான அளவு, காலம்"},
+    {"icon":"📝","en":"Record the answers as a note on the lead in the app","ta":"பதில்களை ஆப்பில் லீட் நோட்டாக பதிவு செய்யவும்"},
+    {"icon":"🌡️","en":"Set temperature (hot/warm/cold) and the next follow-up date","ta":"லீட் நிலை (hot/warm/cold) மற்றும் அடுத்த follow-up தேதியை அமைக்கவும்"},
+    {"icon":"📲","en":"Send brochure and calculator link on WhatsApp","ta":"WhatsApp-ல் brochure மற்றும் calculator link அனுப்பவும்"},
+    {"icon":"🏭","en":"Invite them for a factory visit","ta":"தொழிற்சாலை பார்வைக்கு அழைக்கவும்"}
+  ]'::jsonb,
+  'Never quote a final price on the first call. Share the standard rate and promise a detailed estimate after understanding the site.',
+  'முதல் அழைப்பில் இறுதி விலை சொல்ல வேண்டாம். நிலையான விலையை பகிர்ந்து, இடத்தை புரிந்த பிறகு விரிவான மதிப்பீடு தருவதாக சொல்லுங்கள்.',
+  'published', 1
+),
+(
+  'sales', 'factory-visit',
+  'Factory Visit', 'தொழிற்சாலை பார்வை',
+  'Convert visitors by showing proof: process, strength, and honest pricing.',
+  'செயல்முறை, வலிமை, நேர்மையான விலை — இவற்றை காட்டி பார்வையாளர்களை வாடிக்கையாளர்களாக மாற்றுங்கள்.',
+  '[
+    {"icon":"📅","en":"Confirm the visit one day before — call plus WhatsApp","ta":"பார்வைக்கு முதல் நாள் உறுதி செய்யவும் — அழைப்பு மற்றும் WhatsApp"},
+    {"icon":"🧱","en":"Keep ready: sample bricks, water test, demo wall","ta":"தயாராக வைக்கவும்: மாதிரி செங்கல், தண்ணீர் சோதனை, டெமோ சுவர்"},
+    {"icon":"🤝","en":"Welcome them, offer water/tea, share the 5-minute Maiyuri story","ta":"வரவேற்று, தண்ணீர்/தேநீர் கொடுத்து, 5 நிமிட மையூரி கதையை சொல்லுங்கள்"},
+    {"icon":"⚙️","en":"Show the full process — from red soil to finished interlock brick","ta":"முழு செயல்முறையை காட்டுங்கள் — செம்மண்ணிலிருந்து முடிக்கப்பட்ட இன்டர்லாக் செங்கல் வரை"},
+    {"icon":"💪","en":"Demonstrate strength: locking, load bearing, water absorption comparison","ta":"வலிமையை நிரூபிக்கவும்: லாக்கிங், சுமை தாங்குதல், தண்ணீர் உறிஞ்சுதல் ஒப்பீடு"},
+    {"icon":"🧮","en":"Explain price WITH transport for their site using the calculator","ta":"Calculator மூலம் அவர்களின் இடத்திற்கு போக்குவரத்து உட்பட விலையை விளக்குங்கள்"},
+    {"icon":"✅","en":"Before they leave: agree the next step and record it in the app","ta":"அவர்கள் செல்லும் முன்: அடுத்த நடவடிக்கையை முடிவு செய்து ஆப்பில் பதிவு செய்யவும்"}
+  ]'::jsonb,
+  'Never let a visitor leave without a recorded next step (quote, booking, or follow-up date).',
+  'அடுத்த நடவடிக்கை பதிவு செய்யாமல் எந்த பார்வையாளரையும் அனுப்ப வேண்டாம்.',
+  'published', 1
+),
+(
+  'production', 'daily-production-planning',
+  'Daily Production Planning', 'தினசரி உற்பத்தி திட்டமிடல்',
+  'Plan production from confirmed orders so curing, stock and deliveries stay on schedule.',
+  'உறுதிசெய்யப்பட்ட ஆர்டர்களின் அடிப்படையில் உற்பத்தியை திட்டமிடுங்கள்.',
+  '[
+    {"icon":"📋","en":"Every evening, open the Plan tab in the Maiyuri app","ta":"ஒவ்வொரு மாலையும் மையூரி ஆப்பில் Plan டேபை திறக்கவும்"},
+    {"icon":"🔄","en":"Tap Sync Odoo to load confirmed sales orders","ta":"உறுதிசெய்யப்பட்ட ஆர்டர்களை ஏற்ற Sync Odoo-ஐ தட்டவும்"},
+    {"icon":"☑️","en":"Select the orders to prioritise; type any constraints (machine service, leave)","ta":"முன்னுரிமை ஆர்டர்களை தேர்வு செய்யவும்; தடைகள் இருந்தால் எழுதவும்"},
+    {"icon":"⚡","en":"Tap Generate Plan and review: quantities, curing days, delivery dates","ta":"Generate Plan தட்டி சரிபார்க்கவும்: அளவுகள், க்யூரிங் நாட்கள், டெலிவரி தேதிகள்"},
+    {"icon":"✅","en":"Activate the plan — supervisors and drivers get tomorrow''s plan at 9 PM automatically","ta":"திட்டத்தை Activate செய்யவும் — நாளைய திட்டம் இரவு 9 மணிக்கு தானாக அனுப்பப்படும்"},
+    {"icon":"🏭","en":"Next day, report actual production in the Production tab by evening","ta":"மறுநாள் மாலைக்குள் உண்மையான உற்பத்தியை Production டேபில் பதிவு செய்யவும்"},
+    {"icon":"📊","en":"Check Variance weekly; discuss gaps in the Saturday review","ta":"வாரந்தோறும் Variance பார்க்கவும்; சனிக்கிழமை மீட்டிங்கில் இடைவெளிகளை பேசவும்"}
+  ]'::jsonb,
+  'Do not produce items that are not in the plan without informing the founder — it blocks curing space and working capital.',
+  'திட்டத்தில் இல்லாத பொருட்களை நிறுவனர் அனுமதியின்றி உற்பத்தி செய்ய வேண்டாம்.',
+  'published', 1
+)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ============================================================================
+-- SEED: New Joiners checklist template (spec section 3)
+-- ============================================================================
+
+INSERT INTO public.onehub_checklist_templates (name, phases)
+SELECT 'New Joiners Checklist', '[
+  {"phase":"Before Joining","items":[
+    {"id":"bj-1","text":"Offer letter issued","owner_role":"accountant"},
+    {"id":"bj-2","text":"ID proof collected","owner_role":"accountant"},
+    {"id":"bj-3","text":"Bank details collected","owner_role":"accountant"},
+    {"id":"bj-4","text":"Role explained","owner_role":"founder"},
+    {"id":"bj-5","text":"Joining date confirmed","owner_role":"accountant"}
+  ]},
+  {"phase":"Day 1","items":[
+    {"id":"d1-1","text":"Factory introduction","owner_role":"production_supervisor"},
+    {"id":"d1-2","text":"Safety briefing","owner_role":"production_supervisor"},
+    {"id":"d1-3","text":"Role explanation","owner_role":"founder"},
+    {"id":"d1-4","text":"WhatsApp groups added","owner_role":"accountant"},
+    {"id":"d1-5","text":"App / Odoo login access given","owner_role":"accountant"},
+    {"id":"d1-6","text":"Daily reporting format explained","owner_role":"founder"}
+  ]},
+  {"phase":"First 7 Days","items":[
+    {"id":"w1-1","text":"Product training completed","owner_role":"sales"},
+    {"id":"w1-2","text":"Production process observed","owner_role":"production_supervisor"},
+    {"id":"w1-3","text":"Customer handling training","owner_role":"sales"},
+    {"id":"w1-4","text":"Odoo basic update training","owner_role":"accountant"},
+    {"id":"w1-5","text":"Daily report submitted for 5 days","owner_role":"founder"}
+  ]},
+  {"phase":"First 30 Days","items":[
+    {"id":"m1-1","text":"Can independently perform role","owner_role":"founder"},
+    {"id":"m1-2","text":"SOPs understood","owner_role":"founder"},
+    {"id":"m1-3","text":"Mistakes reviewed","owner_role":"founder"},
+    {"id":"m1-4","text":"Performance feedback given","owner_role":"founder"},
+    {"id":"m1-5","text":"Probation continuation decision","owner_role":"founder"}
+  ]}
+]'::jsonb
+WHERE NOT EXISTS (SELECT 1 FROM public.onehub_checklist_templates WHERE name = 'New Joiners Checklist');
+
+-- ============================================================================
+-- SEED: base links (user fills in the rest from the app)
+-- ============================================================================
+
+INSERT INTO public.onehub_links (category, name, purpose, url, sort_order)
+SELECT * FROM (VALUES
+  ('Operations', 'Maiyuri App', 'Leads, planning, production, deliveries', 'https://mb.maiyuri.com', 1),
+  ('Operations', 'Odoo ERP', 'Orders, invoices, inventory', 'https://crm.maiyuri.com', 2),
+  ('Sales', 'Brochure', 'Share with customers on WhatsApp (add link)', 'https://', 10),
+  ('Sales', 'Brick Calculator', 'Estimate quantity for customer site (add link)', 'https://', 11),
+  ('Marketing', 'Instagram', 'Add link', 'https://', 20),
+  ('Marketing', 'YouTube', 'Add link', 'https://', 21),
+  ('Marketing', 'Google Reviews', 'Add link', 'https://', 22)
+) AS v(category, name, purpose, url, sort_order)
+WHERE NOT EXISTS (SELECT 1 FROM public.onehub_links);
+
+-- ============================================================================
+-- SEED: Company Foundation → existing coach_knowledge_base (culture brain)
+-- ============================================================================
+
+INSERT INTO public.coach_knowledge_base (slug, category, title, content, tags, is_active)
+VALUES
+(
+  'onehub-brand-promise', 'brand_story', 'Maiyuri Brand Promise',
+  'நம் மண். நம் வீடு. நம் அறிவு. (Our soil. Our home. Our wisdom.) Maiyuri Bricks exists to bring back red-soil wisdom with modern engineering: smart interlock bricks that build cooler, stronger, more honest homes for our community.',
+  ARRAY['brand','promise','culture'], true
+),
+(
+  'onehub-product-philosophy', 'product', 'Product Philosophy',
+  'Smart interlock bricks made from local red soil. Interlocking design reduces cement use and builds faster. Red soil keeps homes naturally cooler. Every brick is cured properly before dispatch — quality over speed, always.',
+  ARRAY['product','philosophy'], true
+),
+(
+  'onehub-differentiators', 'kerala_comparison', 'Why Maiyuri vs Kerala mud bricks / regular bricks',
+  'Kerala mud interlock bricks are often cheaper but travel far, crack in transit, and quality varies batch to batch. Maiyuri bricks are made locally with tested red soil, machine compaction, proper curing, and we stand behind every delivery with proof photos and after-delivery support. Regular red bricks need more cement, more labour and build slower walls that hold more heat.',
+  ARRAY['comparison','kerala','objection'], true
+)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
The in-app Maiyuri Operating System (per the approved OneHub plan):

**Backend** (migration already applied + seeded on production):
- onehub_sops / onehub_links / onehub_checklist_templates / onehub_checklist_runs
- 3 published bilingual SOPs (new-lead-handling, factory-visit, daily-production-planning), New Joiners 4-phase template, base links, Company Foundation entries in coach_knowledge_base
- /api/onehub: sops (publish → RAG ingest so Ask Mayur cites SOPs), links, checklists + runs ticking, rhythm reminder
- odoo-rhythm.yml: 18:00 IST close-the-day-in-Odoo push

**Mobile**: 🧭 OneHub from Dashboard — Start Here (brand promise), department SOP grid, EN/தமிழ் visual SOP viewer, links directory, New Joiners checklist runs with progress, Ask Mayur chat (EN/TA) over /api/knowledge/ask.

Verified: web + native tsc, expo export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OneHub SOP, link, and checklist screens backed by new data endpoints.
  * Users with the right access can now create, update, and review checklist runs and checklist templates.
  * Added a daily reminder job that sends a close-of-day prompt on schedule.
  * Published SOP content is now available for browsing, with draft visibility for authorized roles.
* **Bug Fixes**
  * Checklist item updates now correctly reflect completion status and overall run completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->