### PR TITLE
fix+hardening: planning params save, app-wide UX feedback, Sentry

### DIFF
--- a/apps/native/app.json
+++ b/apps/native/app.json
@@ -32,7 +32,8 @@
           "color": "#f97316",
           "defaultChannel": "default"
         }
-      ]
+      ],
+      "@sentry/react-native"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/native/app/(tabs)/deliveries.tsx
+++ b/apps/native/app/(tabs)/deliveries.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useCompleteDelivery, useDeliveries } from '@/hooks/use-deliveries';
+import { toast } from '@/lib/toast';
 
 const STATUS_STYLE: Record<DeliveryStatus, { bg: string; label: string }> = {
   draft: { bg: 'bg-slate-400', label: 'Draft' },
@@ -114,7 +115,12 @@ function MarkDeliveredModal({
         recipientName: recipient.trim() || undefined,
         notes: notes.trim() || undefined,
       },
-      { onSuccess: onClose },
+      {
+        onSuccess: () => {
+          toast.success('Delivery marked as delivered');
+          onClose();
+        },
+      },
     );
   };
 

--- a/apps/native/app/(tabs)/plan.tsx
+++ b/apps/native/app/(tabs)/plan.tsx
@@ -23,6 +23,7 @@ import {
   type OpenOrder,
   type PlanItem,
 } from '@/hooks/use-ops-planning';
+import { toast } from '@/lib/toast';
 
 // ---------------- helpers ----------------
 
@@ -256,6 +257,7 @@ function PlanSegment() {
       onSuccess: () => {
         setDraft(null);
         setSelected(new Set());
+        toast.success('Plan activated — tomorrow’s plan will be sent at 9 PM');
       },
     });
   };
@@ -702,8 +704,11 @@ function CalendarSegment() {
               <Pressable
                 onPress={() => {
                   if (!reportItem) return;
-                  const qty = Number(reportQty);
-                  if (Number.isNaN(qty) || qty < 0) return;
+                  const qty = Number(reportQty.replace(/[,\s]/g, ''));
+                  if (Number.isNaN(qty) || qty < 0) {
+                    toast.error('Enter a valid produced quantity (number ≥ 0)');
+                    return;
+                  }
                   update.mutate(
                     {
                       id: reportItem.id,
@@ -712,7 +717,12 @@ function CalendarSegment() {
                         status: qty >= Number(reportItem.quantity) ? 'done' : 'partial',
                       },
                     },
-                    { onSuccess: () => setReportItem(null) },
+                    {
+                      onSuccess: () => {
+                        setReportItem(null);
+                        toast.success('Production recorded');
+                      },
+                    },
                   );
                 }}
                 disabled={update.isPending}

--- a/apps/native/app/(tabs)/production.tsx
+++ b/apps/native/app/(tabs)/production.tsx
@@ -17,6 +17,7 @@ import {
   useSubmitForApproval,
   useUpdateProductionOrder,
 } from '@/hooks/use-production';
+import { toast } from '@/lib/toast';
 
 const STATUS_STYLE: Record<ProductionOrderStatus, { bg: string; label: string }> = {
   draft: { bg: 'bg-slate-400', label: 'Draft' },
@@ -65,17 +66,30 @@ function OrderActionsModal({
     if (!order) return;
     update.mutate(
       { id: order.id, body: { status } },
-      { onSuccess: () => setApplied((a) => ({ ...a, status })) },
+      {
+        onSuccess: () => {
+          setApplied((a) => ({ ...a, status }));
+          toast.success('Status updated');
+        },
+      },
     );
   };
 
   const saveQty = () => {
     if (!order) return;
-    const value = Number(qty);
-    if (Number.isNaN(value) || value < 0) return;
+    const value = Number(qty.replace(/[,\s]/g, ''));
+    if (Number.isNaN(value) || value < 0) {
+      toast.error('Enter a valid produced quantity (number ≥ 0)');
+      return;
+    }
     update.mutate(
       { id: order.id, body: { actual_quantity: value } },
-      { onSuccess: () => setApplied((a) => ({ ...a, actual_quantity: value })) },
+      {
+        onSuccess: () => {
+          setApplied((a) => ({ ...a, actual_quantity: value }));
+          toast.success('Quantity saved');
+        },
+      },
     );
   };
 
@@ -160,7 +174,12 @@ function OrderActionsModal({
                   order &&
                   approval.mutate(
                     { id: order.id },
-                    { onSuccess: () => setApplied((a) => ({ ...a, status: 'pending_approval' })) },
+                    {
+                      onSuccess: () => {
+                        setApplied((a) => ({ ...a, status: 'pending_approval' }));
+                        toast.success('Sent for approval');
+                      },
+                    },
                   )
                 }
                 disabled={busy}

--- a/apps/native/app/(tabs)/settings.tsx
+++ b/apps/native/app/(tabs)/settings.tsx
@@ -28,6 +28,8 @@ function PlanningParamsSection() {
   const [editing, setEditing] = useState<string | null>(null);
   const [capacity, setCapacity] = useState('');
   const [curing, setCuring] = useState('');
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [savedId, setSavedId] = useState<string | null>(null);
 
   const startEdit = (row: {
     finished_good_id: string;
@@ -35,17 +37,34 @@ function PlanningParamsSection() {
     curing_days: number | null;
   }) => {
     setEditing(row.finished_good_id);
+    setFieldError(null);
     setCapacity(row.daily_capacity_units != null ? String(row.daily_capacity_units) : '');
     setCuring(row.curing_days != null ? String(row.curing_days) : '7');
   };
 
   const commit = (finished_good_id: string) => {
-    const cap = Number(capacity);
-    const cure = Number(curing);
-    if (Number.isNaN(cap) || cap < 0 || Number.isNaN(cure) || cure < 0) return;
+    // Tolerate stray spaces/commas the numeric keypad can introduce, then
+    // give a VISIBLE error instead of silently doing nothing.
+    const cap = Number(capacity.replace(/[,\s]/g, ''));
+    const cure = Number(curing.replace(/[,\s]/g, ''));
+    if (Number.isNaN(cap) || cap < 0) {
+      setFieldError('Enter a valid daily quantity (number ≥ 0).');
+      return;
+    }
+    if (Number.isNaN(cure) || cure < 0) {
+      setFieldError('Enter valid curing days (number ≥ 0).');
+      return;
+    }
+    setFieldError(null);
     save.mutate(
       { finished_good_id, daily_capacity_units: cap, curing_days: cure },
-      { onSuccess: () => setEditing(null) },
+      {
+        onSuccess: () => {
+          setEditing(null);
+          setSavedId(finished_good_id);
+          setTimeout(() => setSavedId((id) => (id === finished_good_id ? null : id)), 2500);
+        },
+      },
     );
   };
 
@@ -75,35 +94,58 @@ function PlanningParamsSection() {
               )}
             </View>
             {editing === row.finished_good_id ? (
-              <View className="mt-2 flex-row items-center gap-2">
-                <TextInput
-                  value={capacity}
-                  onChangeText={setCapacity}
-                  keyboardType="numeric"
-                  placeholder="units/day"
-                  placeholderTextColor="#94a3b8"
-                  className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
-                />
-                <TextInput
-                  value={curing}
-                  onChangeText={setCuring}
-                  keyboardType="numeric"
-                  placeholder="cure d"
-                  placeholderTextColor="#94a3b8"
-                  className="w-16 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
-                />
-                <Pressable
-                  onPress={() => commit(row.finished_good_id)}
-                  disabled={save.isPending}
-                  className={`rounded-lg px-3 py-1.5 ${save.isPending ? 'bg-slate-200' : 'bg-brand active:opacity-80'}`}
-                >
-                  {save.isPending ? (
-                    <ActivityIndicator size="small" color="#0f172a" />
-                  ) : (
-                    <Text className="text-xs font-semibold text-ink">Save</Text>
-                  )}
-                </Pressable>
-              </View>
+              <>
+                <View className="mt-2 flex-row items-center gap-2">
+                  <TextInput
+                    value={capacity}
+                    onChangeText={(t) => {
+                      setCapacity(t);
+                      if (fieldError) setFieldError(null);
+                    }}
+                    keyboardType="numeric"
+                    placeholder="units/day"
+                    placeholderTextColor="#94a3b8"
+                    className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
+                  />
+                  <TextInput
+                    value={curing}
+                    onChangeText={(t) => {
+                      setCuring(t);
+                      if (fieldError) setFieldError(null);
+                    }}
+                    keyboardType="numeric"
+                    placeholder="cure d"
+                    placeholderTextColor="#94a3b8"
+                    className="w-16 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-ink"
+                  />
+                  <Pressable
+                    onPress={() => commit(row.finished_good_id)}
+                    disabled={save.isPending}
+                    className={`rounded-lg px-3 py-1.5 ${save.isPending ? 'bg-slate-200' : 'bg-brand active:opacity-80'}`}
+                  >
+                    {save.isPending ? (
+                      <ActivityIndicator size="small" color="#0f172a" />
+                    ) : (
+                      <Text className="text-xs font-semibold text-ink">Save</Text>
+                    )}
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      setEditing(null);
+                      setFieldError(null);
+                    }}
+                    className="rounded-lg px-2 py-1.5 active:opacity-70"
+                  >
+                    <Text className="text-xs font-semibold text-slate-400">Cancel</Text>
+                  </Pressable>
+                </View>
+                <Text className="mt-1 text-[11px] text-slate-400">
+                  Daily quantity (units/day) · curing days
+                </Text>
+                {fieldError ? (
+                  <Text className="mt-1 text-xs text-red-500">{fieldError}</Text>
+                ) : null}
+              </>
             ) : (
               <Text className="mt-0.5 text-xs text-slate-500">
                 {row.daily_capacity_units != null
@@ -112,6 +154,9 @@ function PlanningParamsSection() {
                 {row.stock_qty != null
                   ? ` · stock ${Number(row.stock_qty).toLocaleString('en-IN')}`
                   : ''}
+                {savedId === row.finished_good_id ? (
+                  <Text className="font-semibold text-green-600">  ✓ Saved</Text>
+                ) : null}
               </Text>
             )}
           </View>

--- a/apps/native/app/(tabs)/settings.tsx
+++ b/apps/native/app/(tabs)/settings.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/hooks/use-push-settings';
 import { registerForPush } from '@/lib/push';
 import { useAuth } from '@/store/auth';
+import { toast } from '@/lib/toast';
 
 function PlanningParamsSection() {
   const { data, isLoading } = useProductParams();
@@ -260,7 +261,10 @@ function PreferencesSection({ userId }: { userId: string }) {
   >;
 
   const toggle = (key: string, value: boolean) => {
-    update.mutate({ ...prefs, [key]: value });
+    update.mutate(
+      { ...prefs, [key]: value },
+      { onSuccess: () => toast.success('Notification settings saved') },
+    );
   };
 
   return (

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -12,8 +12,13 @@ import {
 } from '@/lib/query-client';
 import { initNotificationNavigation, registerForPush } from '@/lib/push';
 import { initAuthListener, useAuth } from '@/store/auth';
+import { initSentry, Sentry, setSentryUser } from '@/lib/sentry';
+import { ToastHost } from '@/components/ToastHost';
 
-export default function RootLayout() {
+// Initialise crash reporting before the app tree renders (no-op without a DSN).
+initSentry();
+
+function RootLayout() {
   const router = useRouter();
   const session = useAuth((s) => s.session);
 
@@ -21,6 +26,13 @@ export default function RootLayout() {
     const unsubscribe = initAuthListener();
     return unsubscribe;
   }, []);
+
+  // Attribute crashes to the signed-in user.
+  useEffect(() => {
+    setSentryUser(
+      session?.user ? { id: session.user.id, email: session.user.email } : null,
+    );
+  }, [session?.user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Notification tap → in-app navigation (data.url is an expo-router path).
   useEffect(() => {
@@ -57,7 +69,12 @@ export default function RootLayout() {
           />
           <Stack.Screen name="onehub" options={{ headerShown: false }} />
         </Stack>
+        <ToastHost />
       </PersistQueryClientProvider>
     </SafeAreaProvider>
   );
 }
+
+// Sentry.wrap installs a top-level error boundary (auto-reports render
+// crashes) and touch/navigation instrumentation.
+export default Sentry.wrap(RootLayout);

--- a/apps/native/app/leads/[id].tsx
+++ b/apps/native/app/leads/[id].tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { useLead } from '@/hooks/use-leads';
 import { useAddNote, useLeadNotes } from '@/hooks/use-notes';
+import { toast } from '@/lib/toast';
 
 function Field({ label, value }: { label: string; value?: string | number | null }) {
   if (value === null || value === undefined || value === '') return null;
@@ -33,7 +34,12 @@ function NotesSection({ leadId }: { leadId: string }) {
   const submit = () => {
     const trimmed = text.trim();
     if (!trimmed || addNote.isPending) return;
-    addNote.mutate(trimmed, { onSuccess: () => setText('') });
+    addNote.mutate(trimmed, {
+      onSuccess: () => {
+        setText('');
+        toast.success('Note added');
+      },
+    });
   };
 
   return (

--- a/apps/native/package-lock.json
+++ b/apps/native/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@maiyuri/shared": "file:../../packages/shared",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@sentry/react-native": "~7.2.0",
         "@supabase/supabase-js": "^2.47.12",
         "@tanstack/query-async-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.62.8",
@@ -3646,6 +3647,336 @@
         "nanoid": "^3.3.11"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.12.0.tgz",
+      "integrity": "sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.12.0.tgz",
+      "integrity": "sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.12.0.tgz",
+      "integrity": "sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.12.0.tgz",
+      "integrity": "sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.3.0.tgz",
+      "integrity": "sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.12.0.tgz",
+      "integrity": "sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.12.0",
+        "@sentry-internal/feedback": "10.12.0",
+        "@sentry-internal/replay": "10.12.0",
+        "@sentry-internal/replay-canvas": "10.12.0",
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.55.0.tgz",
+      "integrity": "sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.55.0",
+        "@sentry/cli-linux-arm": "2.55.0",
+        "@sentry/cli-linux-arm64": "2.55.0",
+        "@sentry/cli-linux-i686": "2.55.0",
+        "@sentry/cli-linux-x64": "2.55.0",
+        "@sentry/cli-win32-arm64": "2.55.0",
+        "@sentry/cli-win32-i686": "2.55.0",
+        "@sentry/cli-win32-x64": "2.55.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.55.0.tgz",
+      "integrity": "sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.55.0.tgz",
+      "integrity": "sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.55.0.tgz",
+      "integrity": "sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.55.0.tgz",
+      "integrity": "sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.55.0.tgz",
+      "integrity": "sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.55.0.tgz",
+      "integrity": "sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.55.0.tgz",
+      "integrity": "sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.55.0.tgz",
+      "integrity": "sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.12.0.tgz",
+      "integrity": "sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.12.0.tgz",
+      "integrity": "sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.12.0",
+        "@sentry/core": "10.12.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.2.0.tgz",
+      "integrity": "sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "4.3.0",
+        "@sentry/browser": "10.12.0",
+        "@sentry/cli": "2.55.0",
+        "@sentry/core": "10.12.0",
+        "@sentry/react": "10.12.0",
+        "@sentry/types": "10.12.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.12.0.tgz",
+      "integrity": "sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.12.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -6404,6 +6735,21 @@
         "hermes-estree": "0.29.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -8161,6 +8507,26 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -8905,6 +9271,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -10772,6 +11144,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -11112,6 +11490,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/whatwg-url-without-unicode": {
       "version": "8.0.0-3",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
@@ -11125,6 +11513,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@maiyuri/shared": "file:../../packages/shared",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/react-native": "~7.2.0",
     "@supabase/supabase-js": "^2.47.12",
     "@tanstack/query-async-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.62.8",

--- a/apps/native/src/components/ToastHost.tsx
+++ b/apps/native/src/components/ToastHost.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Pressable, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useToast, type ToastKind } from '@/lib/toast';
+
+const STYLES: Record<ToastKind, { bg: string; icon: string }> = {
+  success: { bg: 'bg-green-600', icon: '✓' },
+  error: { bg: 'bg-red-600', icon: '⚠️' },
+  info: { bg: 'bg-slate-800', icon: 'ℹ️' },
+};
+
+/** Single toast host — mount once near the root, above the navigator. */
+export function ToastHost() {
+  const { message, kind, seq, clear } = useToast();
+  const insets = useSafeAreaInsets();
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(20)).current;
+
+  useEffect(() => {
+    if (!message) return;
+    opacity.setValue(0);
+    translateY.setValue(20);
+    Animated.parallel([
+      Animated.timing(opacity, { toValue: 1, duration: 180, useNativeDriver: true }),
+      Animated.timing(translateY, { toValue: 0, duration: 180, useNativeDriver: true }),
+    ]).start();
+
+    const timer = setTimeout(() => {
+      Animated.timing(opacity, { toValue: 0, duration: 220, useNativeDriver: true }).start(
+        () => clear(),
+      );
+    }, 2600);
+    return () => clearTimeout(timer);
+    // seq drives re-fire even when message text is unchanged.
+  }, [seq, message]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!message) return null;
+  const style = STYLES[kind];
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={{ position: 'absolute', left: 0, right: 0, bottom: insets.bottom + 70 }}
+      className="items-center px-4"
+    >
+      <Animated.View style={{ opacity, transform: [{ translateY }] }} className="w-full max-w-md">
+        <Pressable
+          onPress={clear}
+          className={`flex-row items-center rounded-xl ${style.bg} px-4 py-3 shadow-lg active:opacity-90`}
+        >
+          <Text className="mr-2 text-base text-white">{style.icon}</Text>
+          <Text className="flex-1 text-sm font-semibold text-white">{message}</Text>
+        </Pressable>
+      </Animated.View>
+    </View>
+  );
+}

--- a/apps/native/src/hooks/use-ops-planning.ts
+++ b/apps/native/src/hooks/use-ops-planning.ts
@@ -203,16 +203,48 @@ export function useProductParams() {
   });
 }
 
+type SaveParamsBody = {
+  finished_good_id: string;
+  daily_capacity_units: number;
+  curing_days: number;
+  min_batch?: number;
+};
+
+type ParamsEnvelope = { data: ProductParams[]; meta?: unknown };
+
 export function useSaveProductParams() {
   const queryClient = useQueryClient();
+  const key = ['ops-planning', 'params'];
   return useMutation({
-    mutationFn: (body: {
-      finished_good_id: string;
-      daily_capacity_units: number;
-      curing_days: number;
-      min_batch?: number;
-    }) => api.put('/api/ops-planning/params', body),
-    onSuccess: () => {
+    mutationFn: (body: SaveParamsBody) => api.put('/api/ops-planning/params', body),
+    // Optimistically patch the cached row so the settings list updates the
+    // instant Save is tapped — don't wait on the refetch (that delay was
+    // what made saves look like they "didn't stick").
+    onMutate: async (body: SaveParamsBody) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<ParamsEnvelope>(key);
+      if (prev?.data) {
+        queryClient.setQueryData<ParamsEnvelope>(key, {
+          ...prev,
+          data: prev.data.map((r) =>
+            r.finished_good_id === body.finished_good_id
+              ? {
+                  ...r,
+                  daily_capacity_units: body.daily_capacity_units,
+                  curing_days: body.curing_days,
+                  min_batch: body.min_batch ?? r.min_batch,
+                }
+              : r,
+          ),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _body, ctx) => {
+      // Roll back the optimistic patch if the server rejected the save.
+      if (ctx?.prev) queryClient.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ['ops-planning'] });
     },
   });

--- a/apps/native/src/lib/api.ts
+++ b/apps/native/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase';
+import { reportError } from './sentry';
 
 /**
  * Typed client for the Maiyuri Next.js API (the 168 routes under
@@ -109,7 +110,16 @@ async function request<T>(
   }
 
   if (!res.ok || (json && json.error)) {
-    throw new ApiError(json?.error ?? `Request failed (${res.status})`, res.status);
+    const apiErr = new ApiError(
+      json?.error ?? `Request failed (${res.status})`,
+      res.status,
+    );
+    // Report server-side failures (5xx) to Sentry — these are real bugs.
+    // Skip 4xx (expected client/validation errors) to avoid noise.
+    if (res.status >= 500) {
+      reportError(apiErr, { path, method, status: res.status });
+    }
+    throw apiErr;
   }
 
   return { data: json.data, meta: json.meta };

--- a/apps/native/src/lib/sentry.ts
+++ b/apps/native/src/lib/sentry.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+/**
+ * Crash + error reporting. Fully no-ops until EXPO_PUBLIC_SENTRY_DSN is set,
+ * so the app behaves identically in local/dev builds without a DSN.
+ *
+ * To enable: create a Sentry project (React Native), then set
+ * EXPO_PUBLIC_SENTRY_DSN in eas.json's build env (and .env for local dev).
+ */
+const DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+export const sentryEnabled = !!DSN;
+
+export function initSentry(): void {
+  if (!DSN) return;
+  Sentry.init({
+    dsn: DSN,
+    // Release/dist tie a crash to a specific build so we can tell which APK
+    // a user is on.
+    release: Constants.expoConfig?.version ?? 'unknown',
+    dist: String(
+      Constants.expoConfig?.android?.versionCode ??
+        Constants.expoConfig?.runtimeVersion ??
+        '1',
+    ),
+    environment: __DEV__ ? 'development' : 'production',
+    // Sample a slice of transactions for performance; full error capture.
+    tracesSampleRate: 0.2,
+    // Don't spam Sentry from local dev runs.
+    enabled: !__DEV__,
+    attachStacktrace: true,
+  });
+}
+
+/**
+ * Report a handled error (e.g. an API failure) with context, without
+ * crashing. Safe to call even when Sentry is disabled.
+ */
+export function reportError(
+  error: unknown,
+  context?: Record<string, unknown>,
+): void {
+  if (!DSN) return;
+  Sentry.captureException(error, context ? { extra: context } : undefined);
+}
+
+/** Tag the current user on the scope so crashes are attributable. */
+export function setSentryUser(user: { id: string; email?: string | null } | null): void {
+  if (!DSN) return;
+  Sentry.setUser(user ? { id: user.id, email: user.email ?? undefined } : null);
+}
+
+export { Sentry };

--- a/apps/native/src/lib/toast.ts
+++ b/apps/native/src/lib/toast.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+export type ToastKind = 'success' | 'error' | 'info';
+
+type ToastState = {
+  message: string | null;
+  kind: ToastKind;
+  /** Monotonic id so re-firing the same message re-triggers the animation. */
+  seq: number;
+  show: (message: string, kind?: ToastKind) => void;
+  clear: () => void;
+};
+
+/**
+ * App-wide lightweight toast. Use for confirming that a write succeeded
+ * (the "did it actually save?" gap) — NOT a substitute for inline field
+ * validation. Rendered by <ToastHost/> mounted once in the root layout.
+ */
+export const useToast = create<ToastState>((set) => ({
+  message: null,
+  kind: 'success',
+  seq: 0,
+  show: (message, kind = 'success') =>
+    set((s) => ({ message, kind, seq: s.seq + 1 })),
+  clear: () => set({ message: null }),
+}));
+
+/** Imperative helpers so non-component code can toast too. */
+export const toast = {
+  success: (m: string) => useToast.getState().show(m, 'success'),
+  error: (m: string) => useToast.getState().show(m, 'error'),
+  info: (m: string) => useToast.getState().show(m, 'info'),
+};


### PR DESCRIPTION
Reported: editing a product's daily quantity on Settings looked like it did not save.

Root cause: the value WAS persisting (DB confirmed), but (a) the list did not visibly refresh after Save and (b) invalid input (stray space/comma from the numeric keypad) silently no-op'd with no error.

Fix:
- Optimistic cache patch so the row updates the instant Save is tapped (rollback on server error)
- Inline validation error instead of silent return; strip stray spaces/commas
- ? Saved confirmation, Cancel button, field hint

Verified: native tsc clean.

Generated with Claude Code