### PR TITLE
fix(build): disable Sentry sourcemap auto-upload until org exists

### DIFF
--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -16,7 +16,8 @@
       "env": {
         "EXPO_PUBLIC_SUPABASE_URL": "https://pailepomvvwjkrhkwdqt.supabase.co",
         "EXPO_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBhaWxlcG9tdnZ3amtyaGt3ZHF0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc1MzkzNzksImV4cCI6MjA4MzExNTM3OX0.LPqNxVCbBYIpsIeg5lGMro-Ubj8JPmHrDFLT8X0XVVc",
-        "EXPO_PUBLIC_API_BASE_URL": "https://mb.maiyuri.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://mb.maiyuri.com",
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
       }
     },
     "production": {


### PR DESCRIPTION
Required for the APK build: the @sentry/react-native gradle step fails EAS builds with 'An organization ID or slug is required' because no Sentry org/project is configured yet. SENTRY_DISABLE_AUTO_UPLOAD=true skips the sourcemap upload; runtime crash reporting still activates once EXPO_PUBLIC_SENTRY_DSN is set. Re-enable upload when the Sentry auth token + org are added.

Generated with Claude Code