### PR TITLE
fix(health): schema probe checked leads.status, real column is lead_status

### DIFF
--- a/apps/api/src/cloudcore/routes/health.ts
+++ b/apps/api/src/cloudcore/routes/health.ts
@@ -133,7 +133,7 @@ const REQUIRED_LEAD_COLUMNS = [
   "contact",
   "source",
   "lead_type",
-  "status",
+  "lead_status",
   "assigned_staff",
   // Issue #3, #4, #5 - Classification and location fields
   "classification",


### PR DESCRIPTION
/api/health has been reporting 'unhealthy / column leads.status does not exist' — a stale probe, not a real outage. REQUIRED_LEAD_COLUMNS listed 'status' but the actual column is 'lead_status'.

Verified the entire probe list against production information_schema: every other column exists; only this one entry was wrong. One-word fix.

Verified: web tsc clean.

Generated with Claude Code