### PR TITLE
feat(web): Daily Operations Briefing — one-page print-to-PDF snapshot

### DIFF
--- a/apps/web/app/(dashboard)/daily-report/DailyReportView.tsx
+++ b/apps/web/app/(dashboard)/daily-report/DailyReportView.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import Link from "next/link";
+import type {
+  DailyReport,
+  PlanActualSection,
+  WebsiteSection,
+} from "@/lib/daily-report/aggregate";
+import styles from "./daily-report.module.css";
+
+/* ---------- formatting ---------- */
+const inr = (n: number) => n.toLocaleString("en-IN", { maximumFractionDigits: 0 });
+const compact = (n: number) =>
+  n >= 100000 ? `${(n / 100000).toFixed(1)}L` : n.toLocaleString("en-IN");
+
+function shiftDate(dateISO: string, days: number): string {
+  const d = new Date(`${dateISO}T00:00:00+05:30`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function prettyDate(dateISO: string): string {
+  return new Date(`${dateISO}T00:00:00+05:30`).toLocaleDateString("en-IN", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "Asia/Kolkata",
+  });
+}
+
+function pctClass(pct: number): "chipGood" | "chipWarn" | "chipBad" {
+  if (pct >= 95) return "chipGood";
+  if (pct >= 80) return "chipWarn";
+  return "chipBad";
+}
+function fillClass(pct: number): "fillGood" | "fillWarn" | "fillBad" {
+  if (pct >= 95) return "fillGood";
+  if (pct >= 80) return "fillWarn";
+  return "fillBad";
+}
+
+/* ---------- small building blocks ---------- */
+function Pending({ note, error }: { note?: string; error?: boolean }) {
+  return (
+    <div className={styles.pending}>
+      <span className={`${styles.pendingDot} ${error ? styles.errorDot : ""}`} />
+      {note ?? (error ? "Could not load" : "Not connected yet")}
+    </div>
+  );
+}
+
+function Sparkline({ series }: { series: WebsiteSection["timeseries"] }) {
+  if (!series.length) return null;
+  const w = 260;
+  const h = 56;
+  const max = Math.max(...series.map((p) => p.users), 1);
+  const step = series.length > 1 ? w / (series.length - 1) : w;
+  const pts = series.map((p, i) => {
+    const x = Math.round(i * step);
+    const y = Math.round(h - 6 - (p.users / max) * (h - 12));
+    return `${x},${y}`;
+  });
+  const line = pts.map((p, i) => (i === 0 ? `M${p}` : `L${p}`)).join(" ");
+  const [lastX, lastY] = pts[pts.length - 1].split(",");
+  return (
+    <svg className={styles.spark} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-label="Visitor trend">
+      <defs>
+        <linearGradient id="drSpark" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#a83a24" stopOpacity="0.28" />
+          <stop offset="1" stopColor="#a83a24" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={`${line} L${w},${h} L0,${h} Z`} fill="url(#drSpark)" />
+      <path d={line} fill="none" stroke="#a83a24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={lastX} cy={lastY} r="3.2" fill="#a83a24" />
+    </svg>
+  );
+}
+
+/* ---------- main ---------- */
+export function DailyReportView({ report }: { report: DailyReport }) {
+  const { date, finance, production, deliveries, website, leads, calls, whatsapp, tasks } = report;
+  const prev = shiftDate(date, -1);
+  const next = shiftDate(date, 1);
+  const today = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+  const genTime = new Date(report.generatedAt).toLocaleTimeString("en-IN", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "Asia/Kolkata",
+  });
+
+  return (
+    <div className={styles.desk}>
+      {/* Controls (hidden in print) */}
+      <div className={styles.toolbar}>
+        <div className={styles.dateNav}>
+          <Link href={`/daily-report?date=${prev}`}>← Prev</Link>
+          <span className={`${styles.today} ${styles.cur}`}>{date}</span>
+          <Link href={`/daily-report?date=${next}`}>Next →</Link>
+          {date !== today ? <Link href="/daily-report">Today</Link> : null}
+        </div>
+        <div className={styles.actions}>
+          <button className={styles.btn} onClick={() => window.print()}>
+            ⤓ Export PDF
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.sheet}>
+        {/* Masthead */}
+        <header className={styles.masthead}>
+          <div className={styles.brand}>
+            <div className={styles.mark}>M</div>
+            <div>
+              <div className={styles.name}>MAIYURI</div>
+              <span className={styles.tag}>Bricks · Daily Operations</span>
+            </div>
+          </div>
+          <div className={styles.meta}>
+            <div className={styles.kicker}>Daily Operations Briefing</div>
+            <div className={styles.date}>{prettyDate(date)}</div>
+            <div className={styles.gen}>Generated {genTime} IST</div>
+          </div>
+        </header>
+
+        {/* Hero KPIs */}
+        <section className={styles.hero}>
+          <div className={`${styles.kpi} ${styles.kpiAccent}`}>
+            <div className={styles.kpiLab}>Invoiced</div>
+            <div className={styles.kpiVal}>
+              <span className={styles.cur}>₹</span>
+              {finance.status === "live" ? inr(finance.invoiced) : "—"}
+            </div>
+            <div className={styles.kpiSub}>
+              {finance.status === "live" ? `${finance.invoiceCount} invoices` : finance.note}
+            </div>
+          </div>
+          <div className={styles.kpi}>
+            <div className={styles.kpiLab}>Expenses</div>
+            <div className={styles.kpiVal}>
+              <span className={styles.cur}>₹</span>
+              {finance.status === "live" ? inr(finance.expenses) : "—"}
+            </div>
+            <div className={styles.kpiSub}>
+              {finance.status === "live" ? `${finance.expenseCount} entries` : ""}
+            </div>
+          </div>
+          <div className={`${styles.kpi} ${styles.kpiAccent}`}>
+            <div className={styles.kpiLab}>Net Movement</div>
+            <div className={styles.kpiVal}>
+              <span className={styles.cur}>₹</span>
+              {finance.status === "live" ? inr(finance.net) : "—"}
+            </div>
+            <div className={styles.kpiSub}>
+              {finance.status === "live" ? (
+                <span className={finance.net >= 0 ? styles.up : styles.down}>
+                  {finance.net >= 0 ? "positive day" : "negative day"}
+                </span>
+              ) : (
+                ""
+              )}
+            </div>
+          </div>
+          <div className={styles.kpi}>
+            <div className={styles.kpiLab}>Production</div>
+            <div className={styles.kpiVal}>
+              {production.status === "live" ? inr(production.actualUnits) : "—"}
+            </div>
+            <div className={styles.kpiSub}>
+              {production.status === "live" ? (
+                <>
+                  of {inr(production.plannedUnits)} planned ·{" "}
+                  <span className={`${styles.chip} ${styles[pctClass(production.pct)]}`}>
+                    {production.pct}%
+                  </span>
+                </>
+              ) : (
+                production.note
+              )}
+            </div>
+          </div>
+          <div className={styles.kpi}>
+            <div className={styles.kpiLab}>Deliveries</div>
+            <div className={styles.kpiVal}>
+              {deliveries.status === "live" ? deliveries.completed : "—"}
+              {deliveries.status === "live" ? (
+                <span className={styles.cur}> / {deliveries.planned}</span>
+              ) : null}
+            </div>
+            <div className={styles.kpiSub}>
+              {deliveries.status === "live"
+                ? deliveries.rolledOver
+                  ? `${deliveries.rolledOver} rolled over`
+                  : "all on schedule"
+                : deliveries.note}
+            </div>
+          </div>
+        </section>
+
+        {/* Row 1 */}
+        <div className={styles.grid}>
+          {/* Finance */}
+          <section className={`${styles.mod} ${styles.c6}`}>
+            <h3 className={styles.modHead}>
+              Finance <span className={styles.src}>Odoo</span>
+            </h3>
+            {finance.status === "live" ? (
+              <>
+                <div className={styles.fin}>
+                  <div>
+                    <div className={styles.amt}>
+                      <span className={styles.cur}>₹</span>
+                      {inr(finance.invoiced)}
+                    </div>
+                    <div className={styles.cap}>Revenue invoiced · {finance.invoiceCount} invoices</div>
+                  </div>
+                  <div>
+                    <div className={`${styles.amt} ${styles.amtExp}`}>
+                      <span className={styles.cur}>₹</span>
+                      {inr(finance.expenses)}
+                    </div>
+                    <div className={styles.cap}>Expenses booked · {finance.expenseCount} entries</div>
+                  </div>
+                </div>
+                {finance.topInvoices.length || finance.topExpenses.length ? (
+                  <div className={styles.ledger}>
+                    {finance.topInvoices.map((i) => (
+                      <div className={styles.ledRow} key={i.ref}>
+                        <span className={styles.who}>
+                          {i.ref} · {i.party}
+                        </span>
+                        <span className={styles.ledNum}>₹{inr(i.amount)}</span>
+                      </div>
+                    ))}
+                    {finance.topExpenses.map((e, idx) => (
+                      <div className={styles.ledRow} key={`e${idx}`}>
+                        <span className={styles.who}>{e.label}</span>
+                        <span className={`${styles.ledNum} ${styles.neg}`}>−₹{inr(e.amount)}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <Pending note={finance.note} error={finance.status === "error"} />
+            )}
+          </section>
+
+          {/* Production plan vs actual */}
+          <section className={`${styles.mod} ${styles.c6}`}>
+            <h3 className={styles.modHead}>
+              Production · Plan vs Actual <span className={styles.src}>Planner</span>
+            </h3>
+            {production.status === "live" ? (
+              <ProductionBody production={production} />
+            ) : (
+              <Pending note={production.note} error={production.status === "error"} />
+            )}
+          </section>
+        </div>
+
+        {/* Row 2 */}
+        <div className={styles.grid}>
+          {/* Deliveries */}
+          <section className={`${styles.mod} ${styles.c4}`}>
+            <h3 className={styles.modHead}>
+              Deliveries <span className={styles.src}>Planner</span>
+            </h3>
+            {deliveries.status === "live" ? (
+              <>
+                <div className={styles.summLine}>
+                  <span className={styles.big}>{deliveries.completed}</span>
+                  <span className={styles.pct}>/ {deliveries.planned} completed</span>
+                </div>
+                <div className={styles.dots}>
+                  {Array.from({ length: deliveries.planned }).map((_, i) => (
+                    <span
+                      key={i}
+                      className={`${styles.dot} ${i < deliveries.completed ? styles.dotDone : styles.dotPending}`}
+                    >
+                      {i < deliveries.completed ? "✓" : "…"}
+                    </span>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <Pending note={deliveries.note} error={deliveries.status === "error"} />
+            )}
+          </section>
+
+          {/* Calls */}
+          <section className={`${styles.mod} ${styles.c4}`}>
+            <h3 className={styles.modHead}>
+              Calls <span className={styles.src}>Superfone</span>
+            </h3>
+            <Pending note={calls.note} error={calls.status === "error"} />
+          </section>
+
+          {/* WhatsApp */}
+          <section className={`${styles.mod} ${styles.c4}`}>
+            <h3 className={styles.modHead}>
+              WhatsApp <span className={styles.src}>Meta API</span>
+            </h3>
+            <Pending note={whatsapp.note} error={whatsapp.status === "error"} />
+          </section>
+        </div>
+
+        {/* Row 3 */}
+        <div className={styles.grid}>
+          {/* Website */}
+          <section className={`${styles.mod} ${styles.c7}`}>
+            <h3 className={styles.modHead}>
+              Website · maiyuri.com <span className={styles.src}>GA4</span>
+            </h3>
+            {website.status === "live" ? (
+              <div className={styles.webWrap}>
+                <div>
+                  <div className={styles.metrics} style={{ marginBottom: 8 }}>
+                    <div>
+                      <div className={styles.metricN}>{inr(website.visitors)}</div>
+                      <div className={styles.metricL}>Visitors</div>
+                    </div>
+                    <div>
+                      <div className={styles.metricN}>{inr(website.pageViews)}</div>
+                      <div className={styles.metricL}>Pageviews</div>
+                    </div>
+                  </div>
+                  <Sparkline series={website.timeseries} />
+                </div>
+                <div>
+                  {website.keyEvents.slice(0, 5).map((e) => (
+                    <div className={styles.ev} key={e.event}>
+                      <span className={styles.evCta}>{e.event.replace(/_/g, " ")}</span>
+                      <span className={styles.evN}>{e.count}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <Pending note={website.note} error={website.status === "error"} />
+            )}
+          </section>
+
+          {/* Tasks */}
+          <section className={`${styles.mod} ${styles.c5}`}>
+            <h3 className={styles.modHead}>
+              Tasks <span className={styles.src}>Todoist</span>
+            </h3>
+            <Pending note={tasks.note} error={tasks.status === "error"} />
+          </section>
+        </div>
+
+        {/* Leads strip */}
+        <div className={styles.grid}>
+          <section className={`${styles.mod} ${styles.c12}`}>
+            <h3 className={styles.modHead}>
+              Leads &amp; Enquiries <span className={styles.src}>CRM</span>
+            </h3>
+            {leads.status !== "error" ? (
+              <div className={styles.leadsRow}>
+                <div className={styles.leadCard}>
+                  <div className={styles.leadN}>{leads.newLeads}</div>
+                  <div className={styles.leadL}>New leads</div>
+                </div>
+                <div className={styles.leadCard}>
+                  <div className={`${styles.leadN} ${styles.leadHot}`}>{leads.hot}</div>
+                  <div className={styles.leadL}>Hot</div>
+                </div>
+                <div className={styles.leadCard}>
+                  <div className={styles.leadN}>{leads.followupsDue}</div>
+                  <div className={styles.leadL}>Follow-ups due</div>
+                </div>
+              </div>
+            ) : (
+              <Pending note={leads.note} error />
+            )}
+          </section>
+        </div>
+
+        {/* Footer: data-source legend */}
+        <footer className={styles.foot}>
+          <div className={styles.sources}>
+            {(
+              [
+                ["Odoo", finance.status],
+                ["Planner", production.status],
+                ["GA4", website.status],
+                ["CRM", leads.status],
+                ["Superfone", calls.status],
+                ["WhatsApp", whatsapp.status],
+                ["Todoist", tasks.status],
+              ] as const
+            ).map(([label, status]) => (
+              <span className={styles.s} key={label}>
+                <span
+                  className={`${styles.sdot} ${
+                    status === "live" ? styles.live : status === "error" ? styles.err : styles.pend
+                  }`}
+                />
+                {label}
+              </span>
+            ))}
+          </div>
+          <div className={styles.sig}>
+            நம் மண். நம் வீடு. நம் அறிவு. · <b>MAIYURI</b>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function ProductionBody({ production }: { production: PlanActualSection }) {
+  return (
+    <>
+      <div className={styles.summLine}>
+        <span className={styles.big}>{inr(production.actualUnits)}</span>
+        <span className={styles.pct}>/ {inr(production.plannedUnits)} units planned</span>
+        <span className={`${styles.chip} ${styles[pctClass(production.pct)]} ${styles.mlAuto}`}>
+          {production.pct}% met
+        </span>
+      </div>
+      <div className={styles.pva}>
+        {production.byProduct.map((p) => {
+          const pct = p.planned ? Math.round((p.actual / p.planned) * 100) : 0;
+          return (
+            <div key={p.name}>
+              <div className={styles.barTop}>
+                <span className={styles.barName}>{p.name}</span>
+                <span className={styles.barFig}>
+                  <b>{compact(p.actual)}</b> / {compact(p.planned)}
+                </span>
+              </div>
+              <div className={styles.track}>
+                <span
+                  className={`${styles.fill} ${styles[fillClass(pct)]}`}
+                  style={{ width: `${Math.min(100, pct)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/(dashboard)/daily-report/daily-report.module.css
+++ b/apps/web/app/(dashboard)/daily-report/daily-report.module.css
@@ -1,0 +1,329 @@
+/* Daily Operations Briefing — bespoke print-first report styling.
+   Scoped via CSS module so it never collides with the app's Tailwind. */
+
+.desk {
+  --paper: #ffffff;
+  --ink: #211a15;
+  --muted: #6f645c;
+  --faint: #9a8f86;
+  --line: #e6ded5;
+  --wash: #f8f4ef;
+  --clay: #a83a24;
+  --clayDeep: #7c2a1a;
+  --good: #2f7d5b;
+  --goodBg: #e7f1eb;
+  --warn: #b9781f;
+  --warnBg: #f6ecda;
+  --bad: #c0392b;
+  --badBg: #f7e4e1;
+
+  background: radial-gradient(120% 80% at 50% 0%, #efeae3 0%, #e9e3db 70%);
+  min-height: 100%;
+  padding: 24px 16px 56px;
+  color: var(--ink);
+  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.toolbar {
+  max-width: 840px;
+  margin: 0 auto 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.dateNav { display: flex; align-items: center; gap: 8px; }
+.dateNav a,
+.dateNav .today {
+  font-size: 13px;
+  color: var(--ink);
+  text-decoration: none;
+  padding: 7px 11px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  font-weight: 600;
+}
+.dateNav a:hover { border-color: var(--clay); color: var(--clay); }
+.dateNav .cur { font-weight: 750; font-variant-numeric: tabular-nums; }
+.actions { display: flex; gap: 8px; align-items: center; }
+.btn {
+  appearance: none;
+  border: none;
+  background: var(--ink);
+  color: #fff;
+  font: inherit;
+  font-weight: 650;
+  font-size: 13px;
+  padding: 9px 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.btn:hover { background: var(--clayDeep); }
+.btn:focus-visible { outline: 3px solid var(--clay); outline-offset: 2px; }
+
+.sheet {
+  width: 840px;
+  max-width: 100%;
+  margin: 0 auto;
+  background: var(--paper);
+  box-shadow: 0 1px 2px rgba(40, 25, 15, 0.1), 0 24px 60px -24px rgba(40, 25, 15, 0.35);
+  padding: 32px 36px 24px;
+  border-radius: 3px;
+}
+
+.masthead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  padding-bottom: 13px;
+  border-bottom: 2.5px solid var(--clay);
+}
+.brand { display: flex; align-items: center; gap: 12px; }
+.mark {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  background: linear-gradient(150deg, var(--clay), var(--clayDeep));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+  font-size: 19px;
+}
+.name { font-size: 21px; font-weight: 800; letter-spacing: 0.14em; line-height: 1; }
+.tag {
+  display: block;
+  margin-top: 4px;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.meta { text-align: right; line-height: 1.25; }
+.kicker {
+  font-size: 10.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--clay);
+  font-weight: 700;
+}
+.date { font-size: 17px; font-weight: 750; margin-top: 3px; }
+.gen { font-size: 10.5px; color: var(--faint); margin-top: 2px; }
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin: 16px 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.kpi { padding: 12px 14px 13px; border-right: 1px solid var(--line); background: #fff; }
+.kpi:last-child { border-right: none; }
+.kpiAccent { background: var(--wash); }
+.kpiLab {
+  font-size: 9.5px;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 650;
+}
+.kpiVal {
+  font-size: 24px;
+  font-weight: 800;
+  margin-top: 6px;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.cur { font-size: 14px; font-weight: 700; color: var(--muted); }
+.kpiSub { font-size: 10.5px; margin-top: 6px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.up { color: var(--good); font-weight: 700; }
+.down { color: var(--bad); font-weight: 700; }
+
+.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 12px; }
+.grid + .grid { margin-top: 12px; }
+.mod {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px 13px;
+  background: #fff;
+  min-width: 0;
+}
+.modHead {
+  margin: 0 0 10px;
+  font-size: 11px;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  font-weight: 750;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.src {
+  font-size: 8.5px;
+  letter-spacing: 0.09em;
+  color: var(--faint);
+  font-weight: 600;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  white-space: nowrap;
+}
+.c4 { grid-column: span 4; }
+.c5 { grid-column: span 5; }
+.c6 { grid-column: span 6; }
+.c7 { grid-column: span 7; }
+.c12 { grid-column: span 12; }
+
+.pending {
+  font-size: 11px;
+  color: var(--faint);
+  padding: 10px 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.pendingDot { width: 7px; height: 7px; border-radius: 50%; background: var(--warn); display: inline-block; }
+.errorDot { background: var(--bad); }
+
+.fin { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.amt { font-size: 21px; font-weight: 800; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+.amtExp { color: var(--clayDeep); }
+.cap { font-size: 10px; color: var(--muted); margin-top: 2px; }
+.ledger { margin-top: 11px; border-top: 1px dashed var(--line); padding-top: 8px; }
+.ledRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  padding: 3px 0;
+  gap: 10px;
+}
+.who { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ledNum { font-variant-numeric: tabular-nums; font-weight: 650; white-space: nowrap; }
+.neg { color: var(--clayDeep); }
+
+.summLine { display: flex; align-items: baseline; gap: 8px; margin-bottom: 11px; }
+.big { font-size: 24px; font-weight: 800; font-variant-numeric: tabular-nums; }
+.pct { font-size: 12px; color: var(--muted); }
+
+.chip {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 20px;
+  text-transform: uppercase;
+}
+.chipGood { color: var(--good); background: var(--goodBg); }
+.chipWarn { color: var(--warn); background: var(--warnBg); }
+.chipBad { color: var(--bad); background: var(--badBg); }
+.mlAuto { margin-left: auto; }
+
+.pva { display: flex; flex-direction: column; gap: 10px; }
+.barTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.barName { font-weight: 650; }
+.barFig { font-variant-numeric: tabular-nums; color: var(--muted); }
+.barFig b { color: var(--ink); }
+.track {
+  position: relative;
+  height: 14px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(90deg, #f0eae3 0 6px, #f5f0ea 6px 12px);
+  overflow: hidden;
+}
+.fill { position: absolute; top: 0; bottom: 0; left: 0; border-radius: 4px 0 0 4px; }
+.fillGood { background: linear-gradient(180deg, #37946b, var(--good)); }
+.fillWarn { background: linear-gradient(180deg, #cf8b2b, var(--warn)); }
+.fillBad { background: linear-gradient(180deg, #d0493a, var(--bad)); }
+
+.dots { display: flex; gap: 6px; flex-wrap: wrap; margin: 2px 0 10px; }
+.dot { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; font-size: 11px; }
+.dotDone { background: var(--goodBg); color: var(--good); border: 1px solid #c4e0d1; }
+.dotPending { background: #f4f0ea; color: var(--faint); border: 1px dashed var(--line); }
+
+.metrics { display: grid; grid-template-columns: repeat(2, 1fr); gap: 9px 14px; }
+.metricN { font-size: 19px; font-weight: 800; font-variant-numeric: tabular-nums; }
+.metricN small { font-size: 11px; color: var(--muted); font-weight: 600; }
+.metricL {
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-top: 1px;
+}
+
+.webWrap { display: grid; grid-template-columns: 1.1fr 1fr; gap: 14px; align-items: start; }
+.spark { width: 100%; height: 56px; display: block; }
+.ev {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  padding: 3.5px 0;
+  border-bottom: 1px dotted var(--line);
+}
+.ev:last-child { border-bottom: none; }
+.evN { font-variant-numeric: tabular-nums; font-weight: 700; }
+.evCta { color: var(--muted); text-transform: capitalize; }
+
+.leadsRow { display: flex; gap: 10px; flex-wrap: wrap; }
+.leadCard { flex: 1; min-width: 90px; text-align: center; padding: 9px 6px; background: var(--wash); border-radius: 8px; }
+.leadN { font-size: 20px; font-weight: 800; font-variant-numeric: tabular-nums; }
+.leadHot { color: var(--clay); }
+.leadL {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.foot {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.sources { display: flex; gap: 12px; flex-wrap: wrap; font-size: 9.5px; color: var(--muted); }
+.s { display: inline-flex; align-items: center; gap: 5px; }
+.sdot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+.live { background: var(--good); }
+.pend { background: var(--warn); }
+.err { background: var(--bad); }
+.sig { font-size: 10px; color: var(--faint); letter-spacing: 0.04em; }
+.sig b { color: var(--clay); letter-spacing: 0.1em; }
+
+@media (max-width: 720px) {
+  .hero { grid-template-columns: repeat(2, 1fr); }
+  .kpi { border-bottom: 1px solid var(--line); }
+  .grid > [class*="c"] { grid-column: span 12; }
+  .webWrap { grid-template-columns: 1fr; }
+  .sheet { padding: 22px 18px; }
+}
+
+@media print {
+  .desk { background: #fff; padding: 0; }
+  .toolbar { display: none; }
+  .sheet { box-shadow: none; width: 100%; padding: 0; border-radius: 0; }
+}

--- a/apps/web/app/(dashboard)/daily-report/page.tsx
+++ b/apps/web/app/(dashboard)/daily-report/page.tsx
@@ -1,0 +1,26 @@
+import { getDailyReport } from "@/lib/daily-report/aggregate";
+import { DailyReportView } from "./DailyReportView";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // Odoo + GA4 round-trips
+
+// Today in IST as YYYY-MM-DD.
+function istToday(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export default async function DailyReportPage({
+  searchParams,
+}: {
+  searchParams: { date?: string };
+}) {
+  const date =
+    searchParams.date && DATE_RE.test(searchParams.date)
+      ? searchParams.date
+      : istToday();
+
+  const report = await getDailyReport(date);
+  return <DailyReportView report={report} />;
+}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -40,6 +40,7 @@ function OneHubIcon({ className }: { className?: string }) {
 const navigation: NavItem[] = [
   { name: "Dashboard", href: "/dashboard", icon: HomeIcon, key: "dashboard" },
   { name: "OneHub", href: "/onehub", icon: OneHubIcon, key: "onehub" },
+  { name: "Daily Report", href: "/daily-report", icon: KPIIcon, key: "daily-report" },
   { name: "Business", href: "/business-health", icon: HealthIcon, key: "business-health" },
   { name: "Leads", href: "/leads", icon: UsersIcon, key: "leads" },
   {
@@ -79,6 +80,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
   accountant: [
     "dashboard",
     "onehub",
+    "daily-report",
     "leads",
     "tasks",
     "approvals",

--- a/apps/web/src/lib/daily-report/aggregate.ts
+++ b/apps/web/src/lib/daily-report/aggregate.ts
@@ -1,0 +1,334 @@
+/**
+ * Daily Operations Snapshot aggregator.
+ *
+ * Pulls a single day's activity from every connected system. Each source is
+ * isolated: a failure or a not-yet-connected integration degrades that ONE
+ * tile to a "pending"/"error" state with a reason, never breaking the page.
+ * Times are anchored to IST (Asia/Kolkata, UTC+5:30) — the factory's clock.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { odooExecute } from "@/lib/odoo-service";
+import {
+  getWebsiteAnalytics,
+  isGa4Configured,
+  type WebsiteAnalytics,
+} from "@/lib/ga4/client";
+
+export type SourceStatus = "live" | "pending" | "error";
+
+type Base = { status: SourceStatus; note?: string };
+
+export interface FinanceSection extends Base {
+  invoiced: number;
+  invoiceCount: number;
+  expenses: number;
+  expenseCount: number;
+  net: number;
+  topInvoices: { ref: string; party: string; amount: number }[];
+  topExpenses: { label: string; amount: number }[];
+}
+
+export interface PlanActualSection extends Base {
+  plannedUnits: number;
+  actualUnits: number;
+  pct: number;
+  byProduct: { name: string; planned: number; actual: number }[];
+}
+
+export interface DeliverySection extends Base {
+  planned: number;
+  completed: number;
+  rolledOver: number;
+}
+
+export interface WebsiteSection extends Base {
+  visitors: number;
+  pageViews: number;
+  sessions: number;
+  timeseries: { date: string; users: number }[];
+  keyEvents: { event: string; count: number }[];
+}
+
+export interface LeadsSection extends Base {
+  newLeads: number;
+  hot: number;
+  followupsDue: number;
+}
+
+export interface CountSection extends Base {
+  primary: number;
+  metrics: { label: string; value: string }[];
+}
+
+export interface DailyReport {
+  date: string; // YYYY-MM-DD (IST day)
+  generatedAt: string; // ISO
+  finance: FinanceSection;
+  production: PlanActualSection;
+  deliveries: DeliverySection;
+  website: WebsiteSection;
+  leads: LeadsSection;
+  calls: CountSection;
+  whatsapp: CountSection;
+  tasks: CountSection;
+}
+
+const IST_OFFSET = "+05:30";
+
+function istBounds(dateISO: string): { startUtc: string; endUtc: string } {
+  return {
+    startUtc: new Date(`${dateISO}T00:00:00${IST_OFFSET}`).toISOString(),
+    endUtc: new Date(`${dateISO}T23:59:59.999${IST_OFFSET}`).toISOString(),
+  };
+}
+
+const num = (v: unknown): number => (typeof v === "number" ? v : Number(v) || 0);
+
+/** Today's revenue + expenses from Odoo (account.move). */
+async function financeFromOdoo(dateISO: string): Promise<FinanceSection> {
+  if (!process.env.ODOO_PASSWORD) {
+    return emptyFinance("pending", "Odoo not configured");
+  }
+  try {
+    const [invoices, bills] = await Promise.all([
+      odooExecute("account.move", "search_read", [
+        [
+          ["move_type", "=", "out_invoice"],
+          ["state", "=", "posted"],
+          ["invoice_date", "=", dateISO],
+        ],
+      ], { fields: ["name", "partner_id", "amount_total"], limit: 200 }) as Promise<
+        { name: string; partner_id: [number, string] | false; amount_total: number }[]
+      >,
+      odooExecute("account.move", "search_read", [
+        [
+          ["move_type", "=", "in_invoice"],
+          ["state", "=", "posted"],
+          ["invoice_date", "=", dateISO],
+        ],
+      ], { fields: ["name", "partner_id", "amount_total"], limit: 200 }) as Promise<
+        { name: string; partner_id: [number, string] | false; amount_total: number }[]
+      >,
+    ]);
+
+    const invoiced = invoices.reduce((s, i) => s + num(i.amount_total), 0);
+    const expenses = bills.reduce((s, b) => s + num(b.amount_total), 0);
+    return {
+      status: "live",
+      invoiced,
+      invoiceCount: invoices.length,
+      expenses,
+      expenseCount: bills.length,
+      net: invoiced - expenses,
+      topInvoices: invoices
+        .sort((a, b) => num(b.amount_total) - num(a.amount_total))
+        .slice(0, 4)
+        .map((i) => ({
+          ref: i.name,
+          party: Array.isArray(i.partner_id) ? i.partner_id[1] : "—",
+          amount: num(i.amount_total),
+        })),
+      topExpenses: bills
+        .sort((a, b) => num(b.amount_total) - num(a.amount_total))
+        .slice(0, 3)
+        .map((b) => ({
+          label: Array.isArray(b.partner_id) ? b.partner_id[1] : b.name,
+          amount: num(b.amount_total),
+        })),
+    };
+  } catch (err) {
+    return emptyFinance("error", err instanceof Error ? err.message : "Odoo error");
+  }
+}
+
+function emptyFinance(status: SourceStatus, note: string): FinanceSection {
+  return {
+    status,
+    note,
+    invoiced: 0,
+    invoiceCount: 0,
+    expenses: 0,
+    expenseCount: 0,
+    net: 0,
+    topInvoices: [],
+    topExpenses: [],
+  };
+}
+
+/** Production planned vs actual from our own plan items (no Odoo needed). */
+async function productionFromPlan(dateISO: string): Promise<PlanActualSection> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("ops_plan_items")
+      .select("product_name, quantity, actual_quantity")
+      .eq("item_type", "production")
+      .eq("item_date", dateISO);
+    if (error) throw new Error(error.message);
+    const rows = data ?? [];
+    const byName = new Map<string, { planned: number; actual: number }>();
+    for (const r of rows) {
+      const cur = byName.get(r.product_name) ?? { planned: 0, actual: 0 };
+      cur.planned += num(r.quantity);
+      cur.actual += num(r.actual_quantity);
+      byName.set(r.product_name, cur);
+    }
+    const planned = rows.reduce((s, r) => s + num(r.quantity), 0);
+    const actual = rows.reduce((s, r) => s + num(r.actual_quantity), 0);
+    return {
+      status: rows.length ? "live" : "pending",
+      note: rows.length ? undefined : "No production planned for this day",
+      plannedUnits: planned,
+      actualUnits: actual,
+      pct: planned ? Math.round((actual / planned) * 100) : 0,
+      byProduct: [...byName.entries()].map(([name, v]) => ({ name, ...v })),
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      note: err instanceof Error ? err.message : "DB error",
+      plannedUnits: 0,
+      actualUnits: 0,
+      pct: 0,
+      byProduct: [],
+    };
+  }
+}
+
+/** Delivery planned vs actual from plan items. */
+async function deliveriesFromPlan(dateISO: string): Promise<DeliverySection> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("ops_plan_items")
+      .select("status")
+      .eq("item_type", "delivery")
+      .eq("item_date", dateISO);
+    if (error) throw new Error(error.message);
+    const rows = data ?? [];
+    const completed = rows.filter((r) => r.status === "done").length;
+    const rolledOver = rows.filter((r) => r.status === "moved" || r.status === "missed").length;
+    return {
+      status: rows.length ? "live" : "pending",
+      note: rows.length ? undefined : "No deliveries planned for this day",
+      planned: rows.length,
+      completed,
+      rolledOver,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      note: err instanceof Error ? err.message : "DB error",
+      planned: 0,
+      completed: 0,
+      rolledOver: 0,
+    };
+  }
+}
+
+/** Website activity from GA4 (single-day window). */
+async function websiteFromGa4(): Promise<WebsiteSection> {
+  if (!isGa4Configured()) {
+    return {
+      status: "pending",
+      note: "GA4 not configured",
+      visitors: 0,
+      pageViews: 0,
+      sessions: 0,
+      timeseries: [],
+      keyEvents: [],
+    };
+  }
+  try {
+    const a = (await getWebsiteAnalytics(1)) as WebsiteAnalytics;
+    return {
+      status: "live",
+      visitors: a.totals.activeUsers,
+      pageViews: a.totals.pageViews,
+      sessions: a.totals.sessions,
+      timeseries: a.timeseries,
+      keyEvents: a.keyEvents,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      note: err instanceof Error ? err.message : "GA4 error",
+      visitors: 0,
+      pageViews: 0,
+      sessions: 0,
+      timeseries: [],
+      keyEvents: [],
+    };
+  }
+}
+
+/** New / hot leads and follow-ups due, from the CRM tables. */
+async function leadsFromDb(dateISO: string): Promise<LeadsSection> {
+  const { startUtc, endUtc } = istBounds(dateISO);
+  try {
+    const [created, hot, followups] = await Promise.all([
+      supabaseAdmin
+        .from("leads")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", startUtc)
+        .lte("created_at", endUtc),
+      supabaseAdmin
+        .from("leads")
+        .select("id", { count: "exact", head: true })
+        .eq("lead_temperature", "hot")
+        .gte("created_at", startUtc)
+        .lte("created_at", endUtc),
+      supabaseAdmin
+        .from("leads")
+        .select("id", { count: "exact", head: true })
+        .eq("follow_up_date", dateISO),
+    ]);
+    return {
+      status: "live",
+      newLeads: created.count ?? 0,
+      hot: hot.count ?? 0,
+      followupsDue: followups.count ?? 0,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      note: err instanceof Error ? err.message : "DB error",
+      newLeads: 0,
+      hot: 0,
+      followupsDue: 0,
+    };
+  }
+}
+
+const notConnected = (note: string): CountSection => ({
+  status: "pending",
+  note,
+  primary: 0,
+  metrics: [],
+});
+
+/**
+ * Assemble the full report. Every source runs concurrently and independently;
+ * a rejected source becomes an error tile rather than failing the whole report.
+ */
+export async function getDailyReport(dateISO: string): Promise<DailyReport> {
+  const [finance, production, deliveries, website, leads] = await Promise.all([
+    financeFromOdoo(dateISO),
+    productionFromPlan(dateISO),
+    deliveriesFromPlan(dateISO),
+    websiteFromGa4(),
+    leadsFromDb(dateISO),
+  ]);
+
+  return {
+    date: dateISO,
+    generatedAt: new Date().toISOString(),
+    finance,
+    production,
+    deliveries,
+    website,
+    leads,
+    // Awaiting integration + credentials (see daily-report page footer):
+    calls: notConnected("Superfone API not connected"),
+    whatsapp: notConnected("WhatsApp Cloud API not connected"),
+    tasks: notConnected("Todoist not connected"),
+  };
+}


### PR DESCRIPTION
A /daily-report page: the whole day across every connected system on one A4 sheet, with an Export PDF (browser print) button and prev/next/today navigation.

Architecture: getDailyReport(date) runs every source concurrently and isolates failures — each tile degrades to a pending/error state with a reason rather than breaking the page. IST day boundaries.

Live now (no new credentials):
- Production plan-vs-actual and Deliveries (from our ops_plan_items)
- Leads / CRM (new, hot, follow-ups due)
- Website (GA4) when GA4 env vars are set

Lights up when credentials land:
- Odoo Finance (invoices + expenses via account.move) — once ODOO_PASSWORD is fixed
- Superfone / WhatsApp (Meta) / Todoist — show 'not connected' until wired

Design: bespoke print-first CSS module (clay/brick palette, tabular figures, plan-vs-actual bars, GA4 sparkline). Footer legend shows each source's live/pending/error status. Nav access for founder/owner/accountant.

Verified: web tsc clean.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Daily Report dashboard with date navigation, live status indicators, KPI tiles, and sectioned operational summaries.
  * Added print-friendly “Export PDF” support for the report.
  * Enabled the Daily Report page in dashboard navigation for permitted roles.

* **Bug Fixes**
  * Improved date handling so the report defaults reliably to today in local time when no valid date is provided.
  * Added graceful fallback states when some report sections are unavailable or delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->