### PR TITLE
fix(security): require auth for /daily-report

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -17,6 +17,7 @@ const publicRoutes = [
 // Routes that require authentication (pages)
 const protectedRoutes = [
   "/dashboard",
+  "/daily-report", // server-rendered with real business data — must never serve anonymously
   "/onehub",
   "/leads",
   "/coaching",


### PR DESCRIPTION
Urgent follow-up to #70: /daily-report is server-rendered with real business data, but middleware only guards routes listed in protectedRoutes — anonymous requests were receiving the full HTML (verified with an unauthenticated curl returning the rendered page). One-line fix: add /daily-report to protectedRoutes so anonymous visitors redirect to /login.

Generated with Claude Code