### PR TITLE
feat(mobile): My Work port — personal task queue + checklist engine

### DIFF
--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -10,6 +10,8 @@ export default function OneHubLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ title: '🧭 Maiyuri OneHub' }} />
+      <Stack.Screen name="my-work/index" options={{ title: '✅ My Work' }} />
+      <Stack.Screen name="my-work/[id]" options={{ title: 'Work Item' }} />
       <Stack.Screen name="department/[dept]" options={{ title: 'SOPs' }} />
       <Stack.Screen name="sop/[slug]" options={{ title: 'SOP' }} />
       <Stack.Screen name="edit/[slug]" options={{ title: 'Edit SOP', presentation: 'modal' }} />

--- a/apps/native/app/onehub/index.tsx
+++ b/apps/native/app/onehub/index.tsx
@@ -39,6 +39,20 @@ export default function OneHubHome() {
         />
       </View>
 
+      {/* My Work — the personal daily queue */}
+      <Link href={"/onehub/my-work" as import("expo-router").Href} asChild>
+        <Pressable className="mt-3 flex-row items-center rounded-2xl bg-ink p-4 active:opacity-70">
+          <Text className="mr-3 text-3xl">✅</Text>
+          <View className="flex-1">
+            <Text className="text-base font-bold text-white">My Work</Text>
+            <Text className="text-xs text-slate-300">
+              Your tasks, checklists and daily jobs — do them here
+            </Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
+
       {/* Ask Mayur */}
       <Link href={"/onehub/ask" as import("expo-router").Href} asChild>
         <Pressable className="mt-3 flex-row items-center rounded-2xl border-2 border-brand bg-orange-50 p-4 active:opacity-70">

--- a/apps/native/app/onehub/my-work/[id].tsx
+++ b/apps/native/app/onehub/my-work/[id].tsx
@@ -1,0 +1,438 @@
+import { useLocalSearchParams } from 'expo-router';
+import type {
+  ChecklistResponseStatus,
+  WorkChecklistTemplateItem,
+  WorkItem,
+} from '@maiyuri/shared';
+import * as ImagePicker from 'expo-image-picker';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  useCompleteWork,
+  useSaveDraft,
+  useStartWork,
+  useSubmitChecklist,
+  useUploadWorkPhoto,
+  useWorkItem,
+  type DraftResponse,
+} from '@/hooks/use-my-work';
+import { toast } from '@/lib/toast';
+
+type LocalResp = {
+  status?: ChecklistResponseStatus | null;
+  text_value?: string | null;
+  number_value?: number | null;
+  note?: string | null;
+};
+
+const STATUS_CHIPS: { key: ChecklistResponseStatus; label: string; on: string }[] = [
+  { key: 'completed', label: '✓ Done', on: 'bg-green-500' },
+  { key: 'not_completed', label: '✗ Not done', on: 'bg-red-500' },
+  { key: 'not_applicable', label: 'N/A', on: 'bg-slate-400' },
+];
+
+async function takePhoto(): Promise<string | null> {
+  const perm = await ImagePicker.requestCameraPermissionsAsync();
+  if (!perm.granted) {
+    toast.error('Camera permission denied');
+    return null;
+  }
+  const res = await ImagePicker.launchCameraAsync({ quality: 0.4 });
+  if (res.canceled || !res.assets?.[0]?.uri) return null;
+  return res.assets[0].uri;
+}
+
+export default function WorkItemDetail() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { data, isLoading } = useWorkItem(id);
+  const item = data?.data;
+
+  const start = useStartWork(id);
+  const complete = useCompleteWork(id);
+  const saveDraft = useSaveDraft(id);
+  const submit = useSubmitChecklist(id);
+  const uploadPhoto = useUploadWorkPhoto(id);
+
+  // Local edit state, seeded once from the server payload.
+  const [seededFor, setSeededFor] = useState<string | null>(null);
+  const [note, setNote] = useState('');
+  const [responses, setResponses] = useState<Record<string, LocalResp>>({});
+
+  if (item && seededFor !== `${item.id}:${item.updated_at}`) {
+    setSeededFor(`${item.id}:${item.updated_at}`);
+    setNote(item.note ?? '');
+    const seed: Record<string, LocalResp> = {};
+    for (const r of item.checklist_instance?.responses ?? []) {
+      seed[r.template_item_id] = {
+        status: r.status,
+        text_value: r.text_value,
+        number_value: r.number_value,
+        note: r.note,
+      };
+    }
+    setResponses(seed);
+  }
+
+  if (isLoading || !item) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        {isLoading ? (
+          <ActivityIndicator size="large" color="#f97316" />
+        ) : (
+          <Text className="text-slate-400">Work item not found</Text>
+        )}
+      </View>
+    );
+  }
+
+  const templateItems = item.checklist_instance?.template?.items ?? [];
+  const respIdByTemplateItem = new Map(
+    (item.checklist_instance?.responses ?? []).map((r) => [r.template_item_id, r.id]),
+  );
+  const isChecklist = item.activity_type === 'checklist';
+  const canAct = item.status === 'pending' || item.status === 'in_progress' || item.status === 'returned';
+  const started = item.status === 'in_progress';
+  const closed = ['submitted', 'completed', 'cancelled'].includes(item.status);
+  const busy = start.isPending || complete.isPending || saveDraft.isPending || submit.isPending;
+
+  const setResp = (tid: string, patch: LocalResp) =>
+    setResponses((prev) => ({ ...prev, [tid]: { ...prev[tid], ...patch } }));
+
+  const draftPayload = (): { note: string | null; responses: DraftResponse[] } => ({
+    note: note.trim() || null,
+    responses: templateItems.map((ti) => ({
+      template_item_id: ti.id,
+      status: responses[ti.id]?.status ?? null,
+      text_value: responses[ti.id]?.text_value ?? null,
+      number_value: responses[ti.id]?.number_value ?? null,
+      note: responses[ti.id]?.note ?? null,
+    })),
+  });
+
+  const onSaveProgress = () =>
+    saveDraft.mutate(draftPayload(), {
+      onSuccess: () => toast.success('Progress saved'),
+      onError: (e) => toast.error(e instanceof Error ? e.message : 'Save failed'),
+    });
+
+  const onSubmit = () => {
+    // Persist answers first (mints response ids, satisfies server validation),
+    // then submit for validation.
+    saveDraft.mutate(draftPayload(), {
+      onSuccess: () =>
+        submit.mutate(undefined, {
+          onSuccess: () => toast.success('Checklist submitted'),
+          onError: (e) => toast.error(e instanceof Error ? e.message : 'Submit failed'),
+        }),
+      onError: (e) => toast.error(e instanceof Error ? e.message : 'Save failed'),
+    });
+  };
+
+  const onCompleteSimple = () =>
+    complete.mutate(
+      { note: note.trim() || null },
+      {
+        onSuccess: () =>
+          toast.success(item.requires_approval ? 'Sent for approval' : 'Completed'),
+        onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not complete'),
+      },
+    );
+
+  const onItemPhoto = async (tid: string) => {
+    const responseId = respIdByTemplateItem.get(tid);
+    if (!responseId) {
+      toast.info('Tap “Save progress” first, then add the photo');
+      return;
+    }
+    const uri = await takePhoto();
+    if (uri) {
+      uploadPhoto.mutate(
+        { uri, checklistResponseId: responseId },
+        {
+          onSuccess: () => toast.success('Photo added'),
+          onError: (e) => toast.error(e instanceof Error ? e.message : 'Upload failed'),
+        },
+      );
+    }
+  };
+
+  const onSimplePhoto = async () => {
+    const uri = await takePhoto();
+    if (uri) {
+      uploadPhoto.mutate(
+        { uri },
+        {
+          onSuccess: () => toast.success('Photo added'),
+          onError: (e) => toast.error(e instanceof Error ? e.message : 'Upload failed'),
+        },
+      );
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-16">
+      {/* header */}
+      <Text className="text-lg font-bold text-ink">{item.title}</Text>
+      {item.description ? (
+        <Text className="mt-1 text-sm text-slate-600">{item.description}</Text>
+      ) : null}
+      {item.instructions ? (
+        <View className="mt-2 rounded-xl bg-slate-100 p-3">
+          <Text className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Instructions
+          </Text>
+          <Text className="mt-1 text-sm leading-5 text-ink">{item.instructions}</Text>
+        </View>
+      ) : null}
+      {item.linked_sop_slug ? (
+        <Pressable
+          onPress={() => Linking.openURL(`https://mb.maiyuri.com/onehub`)}
+          className="mt-2"
+        >
+          <Text className="text-xs font-semibold text-brand">📖 Related SOP</Text>
+        </Pressable>
+      ) : null}
+
+      {item.status === 'returned' && item.return_reason ? (
+        <View className="mt-3 rounded-xl border border-red-200 bg-red-50 p-3">
+          <Text className="text-xs font-bold uppercase tracking-wider text-red-500">
+            Returned for correction
+          </Text>
+          <Text className="mt-1 text-sm text-red-700">{item.return_reason}</Text>
+        </View>
+      ) : null}
+
+      {/* Start gate */}
+      {(item.status === 'pending' || item.status === 'returned') ? (
+        <Pressable
+          onPress={() => start.mutate()}
+          disabled={busy}
+          className={`mt-4 items-center rounded-xl py-3 ${busy ? 'bg-slate-200' : 'bg-brand active:opacity-80'}`}
+        >
+          {start.isPending ? (
+            <ActivityIndicator color="#0f172a" />
+          ) : (
+            <Text className="font-bold text-ink">▶️ Start work</Text>
+          )}
+        </Pressable>
+      ) : null}
+
+      {/* Checklist body */}
+      {isChecklist && started ? (
+        <View className="mt-4">
+          <Text className="mb-2 text-sm font-bold text-ink">
+            {item.checklist_instance?.template?.name ?? 'Checklist'}
+          </Text>
+          {templateItems.map((ti, idx) => (
+            <ChecklistRow
+              key={ti.id}
+              index={idx + 1}
+              ti={ti}
+              value={responses[ti.id] ?? {}}
+              onChange={(patch) => setResp(ti.id, patch)}
+              onPhoto={() => onItemPhoto(ti.id)}
+              photoPending={uploadPhoto.isPending}
+            />
+          ))}
+        </View>
+      ) : null}
+
+      {/* Simple-task body */}
+      {!isChecklist && started ? (
+        <View className="mt-4">
+          <Text className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Note {item.requires_note ? '(required)' : ''}
+          </Text>
+          <TextInput
+            value={note}
+            onChangeText={setNote}
+            placeholder="What did you do?"
+            placeholderTextColor="#94a3b8"
+            multiline
+            className="min-h-[70px] rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-ink"
+          />
+          {item.requires_photo ? (
+            <Pressable
+              onPress={onSimplePhoto}
+              disabled={uploadPhoto.isPending}
+              className="mt-3 flex-row items-center justify-center rounded-xl border-2 border-dashed border-slate-300 py-3 active:opacity-70"
+            >
+              {uploadPhoto.isPending ? (
+                <ActivityIndicator color="#f97316" />
+              ) : (
+                <Text className="font-semibold text-slate-600">
+                  📷 Add proof photo{item.attachments?.length ? ` (${item.attachments.length})` : ''}
+                </Text>
+              )}
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+
+      {/* existing attachments preview */}
+      {item.attachments?.length ? (
+        <View className="mt-3 flex-row flex-wrap gap-2">
+          {item.attachments.map((a) =>
+            a.url ? (
+              <Image key={a.id} source={{ uri: a.url }} style={{ width: 64, height: 64, borderRadius: 8 }} />
+            ) : null,
+          )}
+        </View>
+      ) : null}
+
+      {/* action bar */}
+      {started ? (
+        <View className="mt-5 flex-row gap-2">
+          {isChecklist ? (
+            <>
+              <Pressable
+                onPress={onSaveProgress}
+                disabled={busy}
+                className="flex-1 items-center rounded-xl border border-slate-300 py-3 active:opacity-70"
+              >
+                <Text className="font-semibold text-slate-600">Save progress</Text>
+              </Pressable>
+              <Pressable
+                onPress={onSubmit}
+                disabled={busy}
+                className={`flex-[1.4] items-center rounded-xl py-3 ${busy ? 'bg-slate-200' : 'bg-green-500 active:opacity-80'}`}
+              >
+                {submit.isPending || saveDraft.isPending ? (
+                  <ActivityIndicator color="#ffffff" />
+                ) : (
+                  <Text className="font-bold text-white">Submit</Text>
+                )}
+              </Pressable>
+            </>
+          ) : (
+            <Pressable
+              onPress={onCompleteSimple}
+              disabled={busy}
+              className={`flex-1 items-center rounded-xl py-3 ${busy ? 'bg-slate-200' : 'bg-green-500 active:opacity-80'}`}
+            >
+              {complete.isPending ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <Text className="font-bold text-white">
+                  {item.requires_approval ? 'Submit for approval' : 'Mark complete'}
+                </Text>
+              )}
+            </Pressable>
+          )}
+        </View>
+      ) : null}
+
+      {closed ? (
+        <View className="mt-4 items-center rounded-xl border border-green-200 bg-green-50 p-4">
+          <Text className="text-sm font-semibold text-green-700">
+            {item.status === 'submitted'
+              ? '⏳ Submitted — awaiting approval'
+              : item.status === 'completed'
+                ? '✅ Completed'
+                : '🚫 Cancelled'}
+          </Text>
+        </View>
+      ) : null}
+
+      {!canAct && !closed ? (
+        <Text className="mt-4 text-center text-sm text-slate-400">
+          This item is {item.status}.
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function ChecklistRow({
+  index,
+  ti,
+  value,
+  onChange,
+  onPhoto,
+  photoPending,
+}: {
+  index: number;
+  ti: WorkChecklistTemplateItem;
+  value: { status?: ChecklistResponseStatus | null; text_value?: string | null; number_value?: number | null; note?: string | null };
+  onChange: (patch: {
+    status?: ChecklistResponseStatus | null;
+    text_value?: string | null;
+    number_value?: number | null;
+    note?: string | null;
+  }) => void;
+  onPhoto: () => void;
+  photoPending: boolean;
+}) {
+  const failed = value.status === 'not_completed';
+  const needsPhoto = ti.requires_photo || (ti.requires_photo_on_fail && failed);
+  return (
+    <View className="mb-2 rounded-xl border border-slate-200 bg-white p-3">
+      <Text className="text-sm font-medium text-ink">
+        {index}. {ti.prompt}
+        {ti.mandatory ? <Text className="text-red-400"> *</Text> : null}
+      </Text>
+
+      {ti.input_type === 'status' ? (
+        <View className="mt-2 flex-row gap-2">
+          {STATUS_CHIPS.filter((c) => c.key !== 'not_applicable' || ti.allow_na).map((c) => {
+            const active = value.status === c.key;
+            return (
+              <Pressable
+                key={c.key}
+                onPress={() => onChange({ status: active ? null : c.key })}
+                className={`rounded-lg px-3 py-1.5 ${active ? c.on : 'bg-slate-100'}`}
+              >
+                <Text className={`text-xs font-semibold ${active ? 'text-white' : 'text-slate-600'}`}>
+                  {c.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+
+      {ti.input_type === 'text' ? (
+        <TextInput
+          value={value.text_value ?? ''}
+          onChangeText={(t) => onChange({ text_value: t })}
+          placeholder="Enter value"
+          placeholderTextColor="#94a3b8"
+          className="mt-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-ink"
+        />
+      ) : null}
+
+      {ti.input_type === 'number' ? (
+        <TextInput
+          value={value.number_value != null ? String(value.number_value) : ''}
+          onChangeText={(t) => {
+            const n = Number(t.replace(/[^0-9.]/g, ''));
+            onChange({ number_value: t === '' || Number.isNaN(n) ? null : n });
+          }}
+          keyboardType="numeric"
+          placeholder="Enter number"
+          placeholderTextColor="#94a3b8"
+          className="mt-2 w-28 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-ink"
+        />
+      ) : null}
+
+      {needsPhoto ? (
+        <Pressable
+          onPress={onPhoto}
+          disabled={photoPending}
+          className="mt-2 flex-row items-center self-start rounded-lg bg-slate-100 px-3 py-1.5 active:opacity-70"
+        >
+          <Text className="text-xs font-semibold text-slate-600">📷 Photo required</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/native/app/onehub/my-work/index.tsx
+++ b/apps/native/app/onehub/my-work/index.tsx
@@ -1,0 +1,157 @@
+import { Link } from 'expo-router';
+import type { WorkItem, WorkItemStatus, WorkPriority } from '@maiyuri/shared';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { useMyWork } from '@/hooks/use-my-work';
+
+const STATUS_STYLE: Record<WorkItemStatus, { bg: string; text: string; label: string }> = {
+  pending: { bg: 'bg-slate-100', text: 'text-slate-600', label: 'Pending' },
+  in_progress: { bg: 'bg-blue-100', text: 'text-blue-700', label: 'In progress' },
+  returned: { bg: 'bg-red-100', text: 'text-red-700', label: 'Returned' },
+  submitted: { bg: 'bg-violet-100', text: 'text-violet-700', label: 'Submitted' },
+  completed: { bg: 'bg-green-100', text: 'text-green-700', label: 'Completed' },
+  cancelled: { bg: 'bg-slate-100', text: 'text-slate-400', label: 'Cancelled' },
+};
+
+const PRIORITY_DOT: Record<WorkPriority, string> = {
+  urgent: 'bg-red-500',
+  high: 'bg-orange-500',
+  medium: 'bg-slate-300',
+  low: 'bg-slate-200',
+};
+
+function fmtDue(iso: string | null): string | null {
+  if (!iso) return null;
+  return new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+}
+
+function WorkCard({ item, overdue }: { item: WorkItem; overdue?: boolean }) {
+  const s = STATUS_STYLE[item.status];
+  const due = fmtDue(item.due_at);
+  const progress = item.checklist_progress;
+  return (
+    <Link href={`/onehub/my-work/${item.id}` as import('expo-router').Href} asChild>
+      <Pressable className="mb-2 rounded-xl border border-slate-200 bg-white p-3.5 active:opacity-70">
+        <View className="flex-row items-start">
+          <View className={`mt-1.5 mr-2.5 h-2.5 w-2.5 rounded-full ${PRIORITY_DOT[item.priority]}`} />
+          <View className="min-w-0 flex-1">
+            <Text className="text-sm font-semibold text-ink" numberOfLines={2}>
+              {item.title}
+            </Text>
+            <View className="mt-1.5 flex-row flex-wrap items-center gap-2">
+              <View className={`rounded-full px-2 py-0.5 ${s.bg}`}>
+                <Text className={`text-[10px] font-semibold ${s.text}`}>{s.label}</Text>
+              </View>
+              {item.activity_type === 'checklist' && progress ? (
+                <Text className="text-[11px] text-slate-400">
+                  ☑️ {progress.answered}/{progress.total}
+                </Text>
+              ) : null}
+              {due ? (
+                <Text className={`text-[11px] ${overdue ? 'font-semibold text-red-500' : 'text-slate-400'}`}>
+                  {overdue ? '⚠️ due ' : 'due '}
+                  {due}
+                </Text>
+              ) : null}
+              {item.related_label ? (
+                <Text className="text-[11px] text-slate-400" numberOfLines={1}>
+                  · {item.related_label}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+          <Text className="ml-2 text-slate-300">›</Text>
+        </View>
+      </Pressable>
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  items,
+  overdue,
+}: {
+  title: string;
+  items: WorkItem[];
+  overdue?: boolean;
+}) {
+  if (!items.length) return null;
+  return (
+    <View className="mb-4">
+      <Text className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">
+        {title} ({items.length})
+      </Text>
+      {items.map((it) => (
+        <WorkCard key={it.id} item={it} overdue={overdue} />
+      ))}
+    </View>
+  );
+}
+
+export default function MyWorkQueueScreen() {
+  const { data, isLoading, isRefetching, refetch } = useMyWork();
+  const q = data?.data;
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-slate-50">
+        <ActivityIndicator size="large" color="#f97316" />
+      </View>
+    );
+  }
+
+  const summary = q?.summary;
+  const empty =
+    !q ||
+    (!q.attention.length &&
+      !q.today.length &&
+      !q.upcoming.length &&
+      !q.completed_today.length);
+
+  return (
+    <ScrollView
+      className="flex-1 bg-slate-50"
+      contentContainerClassName="p-4 pb-10"
+      refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />}
+    >
+      {/* summary strip */}
+      {summary ? (
+        <View className="mb-4 flex-row gap-2">
+          {[
+            { n: summary.overdue, l: 'Overdue', c: 'text-red-600' },
+            { n: summary.due_today, l: 'Today', c: 'text-ink' },
+            { n: summary.in_progress, l: 'Doing', c: 'text-blue-600' },
+            { n: summary.completed_today, l: 'Done', c: 'text-green-600' },
+          ].map((s) => (
+            <View key={s.l} className="flex-1 items-center rounded-xl border border-slate-200 bg-white py-2.5">
+              <Text className={`text-xl font-bold ${s.c}`}>{s.n}</Text>
+              <Text className="text-[10px] uppercase tracking-wider text-slate-400">{s.l}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {empty ? (
+        <View className="mt-16 items-center">
+          <Text className="text-4xl">🎉</Text>
+          <Text className="mt-2 text-base font-semibold text-ink">All clear</Text>
+          <Text className="mt-1 text-sm text-slate-400">No work assigned to you right now.</Text>
+        </View>
+      ) : (
+        <>
+          <Section title="⚠️ Needs attention" items={q!.attention} overdue />
+          <Section title="📌 Today" items={q!.today} />
+          <Section title="🗓️ Upcoming" items={q!.upcoming} />
+          <Section title="✅ Completed today" items={q!.completed_today} />
+        </>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/src/hooks/use-my-work.ts
+++ b/apps/native/src/hooks/use-my-work.ts
@@ -1,0 +1,118 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  ChecklistResponseStatus,
+  MyWorkQueue,
+  WorkItem,
+} from '@maiyuri/shared';
+import { api } from '@/lib/api';
+import { supabase } from '@/lib/supabase';
+
+const BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://mb.maiyuri.com';
+
+/** The signed-in employee's grouped work queue. */
+export function useMyWork() {
+  return useQuery({
+    queryKey: ['my-work'],
+    queryFn: () => api.get<MyWorkQueue>('/api/my-work'),
+  });
+}
+
+/** Full detail for one work item (checklist, attachments, history). */
+export function useWorkItem(id: string | undefined) {
+  return useQuery({
+    queryKey: ['my-work', id],
+    queryFn: () => api.get<WorkItem>(`/api/my-work/${id}`),
+    enabled: !!id,
+  });
+}
+
+function invalidate(queryClient: ReturnType<typeof useQueryClient>, id: string) {
+  void queryClient.invalidateQueries({ queryKey: ['my-work'] });
+  void queryClient.invalidateQueries({ queryKey: ['my-work', id] });
+}
+
+/** Move pending/returned → in_progress (idempotent). */
+export function useStartWork(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<WorkItem>(`/api/my-work/${id}/start`),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
+/** Complete a SIMPLE task (server validates note/photo requirements → 422). */
+export function useCompleteWork(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { note?: string | null }) =>
+      api.post<WorkItem>(`/api/my-work/${id}/complete`, body),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
+export type DraftResponse = {
+  template_item_id: string;
+  status?: ChecklistResponseStatus | null;
+  text_value?: string | null;
+  number_value?: number | null;
+  note?: string | null;
+};
+
+/** Persist checklist answers + note (also mints response ids for photos). */
+export function useSaveDraft(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { note?: string | null; responses?: DraftResponse[] }) =>
+      api.put<{ saved_at: string }>(`/api/my-work/${id}/draft`, body),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
+/** Submit a checklist task (server validates all mandatory answers → 422). */
+export function useSubmitChecklist(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<WorkItem>(`/api/my-work/${id}/submit`),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
+/**
+ * Upload a photo as evidence. Multipart, so it bypasses the JSON api client —
+ * attaches the Supabase bearer directly. Pass checklistResponseId to bind the
+ * photo to a specific checklist answer (that answer must be saved first).
+ */
+export function useUploadWorkPhoto(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (opts: {
+      uri: string;
+      checklistResponseId?: string;
+    }): Promise<{ id: string }> => {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      const form = new FormData();
+      // React Native FormData file shape.
+      form.append('file', {
+        uri: opts.uri,
+        name: `photo-${Date.now()}.jpg`,
+        type: 'image/jpeg',
+      } as unknown as Blob);
+      if (opts.checklistResponseId) {
+        form.append('checklist_response_id', opts.checklistResponseId);
+      }
+      const res = await fetch(`${BASE_URL}/api/my-work/${id}/attachments`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        body: form,
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(json?.error ?? `Upload failed (${res.status})`);
+      }
+      return json.data;
+    },
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}


### PR DESCRIPTION
Ports the My Work module to the mobile app (thin client over the existing /api/my-work routes — same backend as web, so data stays in sync).

Added under OneHub:
- Queue: summary strip + grouped sections (needs attention / today / upcoming / completed today), status + priority chips, checklist progress
- Detail: Start gate; SIMPLE tasks = note + proof-photo + Mark complete (or Submit for approval); CHECKLIST tasks = per-item status/text/number inputs + notes, Save progress + Submit, per-item photo bound to the saved response; returned-for-correction banner; attachment thumbnails
- Multipart photo upload (Supabase bearer) for /attachments
- OneHub home entry card + routes

Verified: native tsc clean + expo export bundles.

Generated with Claude Code