### PR TITLE
feat(my-work): close every loop — approvals, push, recurring engine, report tile

### DIFF
--- a/.github/workflows/morning-digest.yml
+++ b/.github/workflows/morning-digest.yml
@@ -29,3 +29,15 @@ jobs:
             echo "Digest trigger failed" >&2
             exit 1
           fi
+
+      - name: My Work per-person digest
+        run: |
+          status=$(curl -s -o /tmp/mw.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/my-work/digest")
+          echo "HTTP $status"
+          cat /tmp/mw.json
+          if [ "$status" -ge 400 ]; then
+            echo "My Work digest failed" >&2
+            exit 1
+          fi

--- a/.github/workflows/my-work-generate.yml
+++ b/.github/workflows/my-work-generate.yml
@@ -1,0 +1,22 @@
+name: My Work daily generator
+
+# Mint today's recurring work items (Production Opening Checklist etc.)
+# 00:00 UTC = 05:30 IST — items exist before anyone starts their day.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate recurring work items
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/my-work/generate")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi

--- a/apps/native/app/onehub/my-work/[id].tsx
+++ b/apps/native/app/onehub/my-work/[id].tsx
@@ -17,7 +17,9 @@ import {
   View,
 } from 'react-native';
 import {
+  useApproveWork,
   useCompleteWork,
+  useReturnWork,
   useSaveDraft,
   useStartWork,
   useSubmitChecklist,
@@ -25,7 +27,11 @@ import {
   useWorkItem,
   type DraftResponse,
 } from '@/hooks/use-my-work';
+import { useMyProfile } from '@/hooks/use-push-settings';
+import { useAuth } from '@/store/auth';
 import { toast } from '@/lib/toast';
+
+const WORK_ADMIN_ROLES = ['founder', 'owner', 'production_supervisor'];
 
 type LocalResp = {
   status?: ChecklistResponseStatus | null;
@@ -61,6 +67,14 @@ export default function WorkItemDetail() {
   const saveDraft = useSaveDraft(id);
   const submit = useSubmitChecklist(id);
   const uploadPhoto = useUploadWorkPhoto(id);
+  const approve = useApproveWork(id);
+  const returnWork = useReturnWork(id);
+
+  const userId = useAuth((s) => s.session?.user?.id);
+  const profile = useMyProfile(userId);
+  const isSupervisor = WORK_ADMIN_ROLES.includes(profile.data?.data.role ?? '');
+  const [returnReason, setReturnReason] = useState('');
+  const [returning, setReturning] = useState(false);
 
   // Local edit state, seeded once from the server payload.
   const [seededFor, setSeededFor] = useState<string | null>(null);
@@ -340,6 +354,95 @@ export default function WorkItemDetail() {
                 ? '✅ Completed'
                 : '🚫 Cancelled'}
           </Text>
+        </View>
+      ) : null}
+
+      {/* Supervisor review actions (deep-linked here from the submit push) */}
+      {isSupervisor && item.status === 'submitted' ? (
+        <View className="mt-3 rounded-xl border border-slate-200 bg-white p-3">
+          <Text className="mb-2 text-xs font-bold uppercase tracking-wider text-slate-500">
+            Review this submission
+          </Text>
+          {returning ? (
+            <>
+              <TextInput
+                value={returnReason}
+                onChangeText={setReturnReason}
+                placeholder="What needs to be corrected?"
+                placeholderTextColor="#94a3b8"
+                multiline
+                className="min-h-[56px] rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-ink"
+              />
+              <View className="mt-2 flex-row gap-2">
+                <Pressable
+                  onPress={() => {
+                    setReturning(false);
+                    setReturnReason('');
+                  }}
+                  className="flex-1 items-center rounded-xl border border-slate-300 py-2.5 active:opacity-70"
+                >
+                  <Text className="text-sm font-semibold text-slate-600">Cancel</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() =>
+                    returnReason.trim().length >= 3 &&
+                    returnWork.mutate(
+                      { reason: returnReason.trim() },
+                      {
+                        onSuccess: () => {
+                          setReturning(false);
+                          setReturnReason('');
+                          toast.success('Returned for correction');
+                        },
+                        onError: (e) =>
+                          toast.error(e instanceof Error ? e.message : 'Return failed'),
+                      },
+                    )
+                  }
+                  disabled={returnWork.isPending || returnReason.trim().length < 3}
+                  className={`flex-1 items-center rounded-xl py-2.5 ${
+                    returnWork.isPending || returnReason.trim().length < 3
+                      ? 'bg-slate-200'
+                      : 'bg-red-500 active:opacity-80'
+                  }`}
+                >
+                  {returnWork.isPending ? (
+                    <ActivityIndicator size="small" color="#ffffff" />
+                  ) : (
+                    <Text className="text-sm font-bold text-white">Return</Text>
+                  )}
+                </Pressable>
+              </View>
+            </>
+          ) : (
+            <View className="flex-row gap-2">
+              <Pressable
+                onPress={() =>
+                  approve.mutate(undefined, {
+                    onSuccess: () => toast.success('Approved ✓'),
+                    onError: (e) =>
+                      toast.error(e instanceof Error ? e.message : 'Approve failed'),
+                  })
+                }
+                disabled={approve.isPending}
+                className={`flex-[1.4] items-center rounded-xl py-2.5 ${
+                  approve.isPending ? 'bg-slate-200' : 'bg-green-500 active:opacity-80'
+                }`}
+              >
+                {approve.isPending ? (
+                  <ActivityIndicator size="small" color="#ffffff" />
+                ) : (
+                  <Text className="text-sm font-bold text-white">✓ Approve</Text>
+                )}
+              </Pressable>
+              <Pressable
+                onPress={() => setReturning(true)}
+                className="flex-1 items-center rounded-xl border border-red-300 py-2.5 active:opacity-70"
+              >
+                <Text className="text-sm font-semibold text-red-500">↩ Return</Text>
+              </Pressable>
+            </View>
+          )}
         </View>
       ) : null}
 

--- a/apps/native/src/hooks/use-my-work.ts
+++ b/apps/native/src/hooks/use-my-work.ts
@@ -78,6 +78,25 @@ export function useSubmitChecklist(id: string) {
   });
 }
 
+/** Supervisor: approve a submitted item (submitted → completed). */
+export function useApproveWork(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<WorkItem>(`/api/my-work/${id}/approve`),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
+/** Supervisor: return a submitted item for correction. */
+export function useReturnWork(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { reason: string }) =>
+      api.post<WorkItem>(`/api/my-work/${id}/return`, body),
+    onSuccess: () => invalidate(queryClient, id),
+  });
+}
+
 /**
  * Upload a photo as evidence. Multipart, so it bypasses the JSON api client —
  * attaches the Supabase bearer directly. Pass checklistResponseId to bind the

--- a/apps/web/app/(dashboard)/daily-report/DailyReportView.tsx
+++ b/apps/web/app/(dashboard)/daily-report/DailyReportView.tsx
@@ -342,12 +342,29 @@ export function DailyReportView({ report }: { report: DailyReport }) {
             )}
           </section>
 
-          {/* Tasks */}
+          {/* Tasks — fed by the My Work module */}
           <section className={`${styles.mod} ${styles.c5}`}>
             <h3 className={styles.modHead}>
-              Tasks <span className={styles.src}>Todoist</span>
+              Tasks <span className={styles.src}>My Work</span>
             </h3>
-            <Pending note={tasks.note} error={tasks.status === "error"} />
+            {tasks.status === "live" ? (
+              <>
+                <div className={styles.summLine}>
+                  <span className={styles.big}>{tasks.primary}</span>
+                  <span className={styles.pct}>tasks done today</span>
+                </div>
+                <div className={styles.metrics}>
+                  {tasks.metrics.map((m) => (
+                    <div key={m.label}>
+                      <div className={styles.metricN}>{m.value}</div>
+                      <div className={styles.metricL}>{m.label}</div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <Pending note={tasks.note} error={tasks.status === "error"} />
+            )}
           </section>
         </div>
 
@@ -389,7 +406,7 @@ export function DailyReportView({ report }: { report: DailyReport }) {
                 ["CRM", leads.status],
                 ["Superfone", calls.status],
                 ["WhatsApp", whatsapp.status],
-                ["Todoist", tasks.status],
+                ["My Work", tasks.status],
               ] as const
             ).map(([label, status]) => (
               <span className={styles.s} key={label}>

--- a/apps/web/app/api/my-work/[id]/approve/route.ts
+++ b/apps/web/app/api/my-work/[id]/approve/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  getWorkItemForUser,
+  isWorkAdmin,
+  logWorkEvent,
+  WorkAccessError,
+} from "@/lib/my-work-service";
+import { notifyWorkApproved } from "@/lib/my-work-notify";
+import type { WorkItem } from "@maiyuri/shared";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/my-work/[id]/approve — supervisor approves a SUBMITTED item.
+ * submitted → completed. Closes the requires_approval loop.
+ */
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const user = await requireAuth(request);
+    if (!isWorkAdmin(user.role)) {
+      return error("Only supervisors can approve work", 403);
+    }
+    const { id } = await params;
+    const item = await getWorkItemForUser(id, user);
+
+    if (item.status === "completed") {
+      return success<WorkItem>(item); // idempotent
+    }
+    if (item.status !== "submitted") {
+      return error("Only submitted work can be approved", 409);
+    }
+
+    const now = new Date().toISOString();
+    const { data: updated, error: updErr } = await supabaseAdmin
+      .from("work_items")
+      .update({ status: "completed", completed_at: now })
+      .eq("id", id)
+      .eq("status", "submitted") // guard against concurrent transitions
+      .select("*")
+      .single();
+    if (updErr || !updated) {
+      return error("This item is no longer awaiting approval", 409);
+    }
+
+    await logWorkEvent({
+      work_item_id: id,
+      event_type: "approved",
+      old_status: "submitted",
+      new_status: "completed",
+      performed_by: user.id,
+      comment: null,
+    });
+    void notifyWorkApproved(updated as WorkItem);
+
+    return success<WorkItem>(updated as WorkItem);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof WorkAccessError) return error(err.message, err.status);
+    console.error("[MyWork] approve failed:", err);
+    return error("Failed to approve the work item", 500);
+  }
+}

--- a/apps/web/app/api/my-work/[id]/complete/route.ts
+++ b/apps/web/app/api/my-work/[id]/complete/route.ts
@@ -13,6 +13,7 @@ import {
   WorkAccessError,
 } from "@/lib/my-work-service";
 import { validateSimpleCompletion } from "@/lib/my-work-utils";
+import { notifyWorkSubmitted } from "@/lib/my-work-notify";
 import { completeWorkItemSchema } from "@maiyuri/shared";
 import type { WorkItem } from "@maiyuri/shared";
 
@@ -80,6 +81,9 @@ export async function POST(request: NextRequest, { params }: Params) {
       performed_by: user.id,
       comment: note ?? null,
     });
+    if (targetStatus === "submitted") {
+      void notifyWorkSubmitted(updated as WorkItem);
+    }
 
     return success<WorkItem>(updated as WorkItem);
   } catch (err) {

--- a/apps/web/app/api/my-work/[id]/return/route.ts
+++ b/apps/web/app/api/my-work/[id]/return/route.ts
@@ -1,0 +1,81 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  getWorkItemForUser,
+  isWorkAdmin,
+  logWorkEvent,
+  WorkAccessError,
+} from "@/lib/my-work-service";
+import { notifyWorkReturned } from "@/lib/my-work-notify";
+import type { WorkItem } from "@maiyuri/shared";
+
+const returnSchema = z.object({
+  reason: z.string().min(3, "Explain what needs to be corrected"),
+});
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/my-work/[id]/return — supervisor sends a SUBMITTED item back.
+ * submitted → returned (assignee can then fix and resubmit).
+ */
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const user = await requireAuth(request);
+    if (!isWorkAdmin(user.role)) {
+      return error("Only supervisors can return work", 403);
+    }
+    const { id } = await params;
+    const item = await getWorkItemForUser(id, user);
+
+    if (item.status !== "submitted") {
+      return error("Only submitted work can be returned", 409);
+    }
+
+    const parsed = await parseBody(request, returnSchema);
+    if (parsed.error) return parsed.error;
+    const reason = parsed.data.reason.trim();
+
+    const now = new Date().toISOString();
+    const { data: updated, error: updErr } = await supabaseAdmin
+      .from("work_items")
+      .update({
+        status: "returned",
+        returned_at: now,
+        return_reason: reason,
+        // clear the submission markers so the next submit is clean
+        submitted_at: null,
+      })
+      .eq("id", id)
+      .eq("status", "submitted")
+      .select("*")
+      .single();
+    if (updErr || !updated) {
+      return error("This item is no longer awaiting review", 409);
+    }
+
+    await logWorkEvent({
+      work_item_id: id,
+      event_type: "returned",
+      old_status: "submitted",
+      new_status: "returned",
+      performed_by: user.id,
+      comment: reason,
+    });
+    void notifyWorkReturned(updated as WorkItem, reason);
+
+    return success<WorkItem>(updated as WorkItem);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof WorkAccessError) return error(err.message, err.status);
+    console.error("[MyWork] return failed:", err);
+    return error("Failed to return the work item", 500);
+  }
+}

--- a/apps/web/app/api/my-work/[id]/submit/route.ts
+++ b/apps/web/app/api/my-work/[id]/submit/route.ts
@@ -15,6 +15,7 @@ import {
   WorkAccessError,
 } from "@/lib/my-work-service";
 import { validateChecklistSubmission } from "@/lib/my-work-utils";
+import { notifyWorkSubmitted } from "@/lib/my-work-notify";
 import type { WorkItem } from "@maiyuri/shared";
 
 interface Params {
@@ -102,6 +103,9 @@ export async function POST(request: NextRequest, { params }: Params) {
         ).length,
       },
     });
+    if (targetStatus === "submitted") {
+      void notifyWorkSubmitted(updated as WorkItem);
+    }
 
     return success<WorkItem>(updated as WorkItem);
   } catch (err) {

--- a/apps/web/app/api/my-work/digest/route.ts
+++ b/apps/web/app/api/my-work/digest/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { isFcmConfigured, sendPushToUsers } from "@/lib/push/fcm";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * POST /api/my-work/digest — morning per-person work summary (cron).
+ * "☀️ You have N tasks today (M overdue)" → deep-links to My Work.
+ */
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+  try {
+    if (!isFcmConfigured()) return success({ sent: 0, reason: "FCM not configured" });
+
+    // End of "today" in IST — anything due before this counts as today's load.
+    const todayIST = new Date().toLocaleDateString("en-CA", {
+      timeZone: "Asia/Kolkata",
+    });
+    const endOfDayUtc = new Date(`${todayIST}T23:59:59.999+05:30`).toISOString();
+    const nowUtc = new Date().toISOString();
+
+    const { data: open, error: dbErr } = await supabaseAdmin
+      .from("work_items")
+      .select("assigned_user_id, due_at")
+      .in("status", ["pending", "in_progress", "returned"])
+      .or(`due_at.lte.${endOfDayUtc},due_at.is.null`)
+      .limit(1000);
+    if (dbErr) return error("Failed to load work items", 500);
+
+    const byUser = new Map<string, { total: number; overdue: number }>();
+    for (const row of open ?? []) {
+      const cur = byUser.get(row.assigned_user_id) ?? { total: 0, overdue: 0 };
+      cur.total += 1;
+      if (row.due_at && row.due_at < nowUtc) cur.overdue += 1;
+      byUser.set(row.assigned_user_id, cur);
+    }
+
+    let sent = 0;
+    for (const [userId, counts] of byUser) {
+      const body =
+        counts.overdue > 0
+          ? `${counts.total} task${counts.total === 1 ? "" : "s"} today — ${counts.overdue} overdue`
+          : `${counts.total} task${counts.total === 1 ? "" : "s"} on your list today`;
+      const res = await sendPushToUsers([userId], {
+        title: "☀️ Your work today",
+        body,
+        data: { url: "/onehub/my-work" },
+      });
+      sent += res.sent;
+    }
+    return success({ users: byUser.size, sent });
+  } catch (err) {
+    console.error("[MyWork] digest failed:", err);
+    return error("Digest failed", 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/apps/web/app/api/my-work/generate/route.ts
+++ b/apps/web/app/api/my-work/generate/route.ts
@@ -1,0 +1,192 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logWorkEvent } from "@/lib/my-work-service";
+import { notifyWorkAssigned } from "@/lib/my-work-notify";
+import type { WorkItem } from "@maiyuri/shared";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+type TemplateRow = {
+  id: string;
+  name: string;
+  activity_type: string;
+  title: string;
+  description: string | null;
+  instructions: string | null;
+  default_assigned_user_id: string | null;
+  default_role: string | null;
+  checklist_template_id: string | null;
+  recurrence_rule: string | null;
+  due_time: string | null; // HH:MM:SS
+  priority: string;
+  requires_photo: boolean;
+  requires_note: boolean;
+  requires_approval: boolean;
+  related_label: string | null;
+  related_project_id: string | null;
+  linked_sop_slug: string | null;
+};
+
+/** Does the rule fire on the given IST date? */
+function ruleMatches(rule: string, istDate: Date): boolean {
+  if (rule === "daily") return true;
+  const [kind, arg] = rule.split(":");
+  const n = Number(arg);
+  if (kind === "weekly") {
+    const isoDow = istDate.getUTCDay() === 0 ? 7 : istDate.getUTCDay();
+    return isoDow === n;
+  }
+  if (kind === "monthly") return istDate.getUTCDate() === n;
+  return false;
+}
+
+/**
+ * POST /api/my-work/generate — mint today's work items from recurring
+ * templates (cron, runs early morning IST). Idempotent: one item per
+ * template+assignee+date.
+ */
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+  try {
+    const todayISO = new Date().toLocaleDateString("en-CA", {
+      timeZone: "Asia/Kolkata",
+    });
+    // Anchored UTC date object for dow/dom math on the IST calendar day.
+    const istDate = new Date(`${todayISO}T00:00:00Z`);
+
+    const { data: templates, error: tplErr } = await supabaseAdmin
+      .from("work_item_templates")
+      .select("*")
+      .eq("active", true)
+      .not("recurrence_rule", "is", null);
+    if (tplErr) return error("Failed to load templates", 500);
+
+    let created = 0;
+    let skipped = 0;
+    const failures: string[] = [];
+
+    for (const tpl of (templates ?? []) as TemplateRow[]) {
+      if (!tpl.recurrence_rule || !ruleMatches(tpl.recurrence_rule, istDate)) {
+        continue;
+      }
+
+      // Resolve assignees: a fixed person, or every active user with the role.
+      let assignees: string[] = [];
+      if (tpl.default_assigned_user_id) {
+        assignees = [tpl.default_assigned_user_id];
+      } else if (tpl.default_role) {
+        const { data: users } = await supabaseAdmin
+          .from("users")
+          .select("id")
+          .eq("role", tpl.default_role)
+          .eq("is_active", true);
+        assignees = (users ?? []).map((u) => u.id);
+      }
+      if (!assignees.length) {
+        failures.push(`${tpl.name}: no assignee resolved`);
+        continue;
+      }
+
+      const dueAt = tpl.due_time
+        ? new Date(`${todayISO}T${tpl.due_time.slice(0, 5)}:00+05:30`).toISOString()
+        : null;
+
+      for (const userId of assignees) {
+        // Idempotency: skip if this occurrence already exists.
+        const { data: existing } = await supabaseAdmin
+          .from("work_items")
+          .select("id")
+          .eq("template_id", tpl.id)
+          .eq("assigned_user_id", userId)
+          .eq("scheduled_date", todayISO)
+          .maybeSingle();
+        if (existing) {
+          skipped += 1;
+          continue;
+        }
+
+        // Checklist templates get a fresh dated instance per occurrence.
+        let checklistInstanceId: string | null = null;
+        if (tpl.activity_type === "checklist" && tpl.checklist_template_id) {
+          const { data: instance, error: instErr } = await supabaseAdmin
+            .from("work_checklist_instances")
+            .insert({
+              template_id: tpl.checklist_template_id,
+              scheduled_date: todayISO,
+            })
+            .select("id")
+            .single();
+          if (instErr || !instance) {
+            failures.push(`${tpl.name}: instance create failed`);
+            continue;
+          }
+          checklistInstanceId = instance.id;
+        }
+
+        const { data: item, error: insErr } = await supabaseAdmin
+          .from("work_items")
+          .insert({
+            title: tpl.title,
+            description: tpl.description,
+            instructions: tpl.instructions,
+            activity_type: tpl.activity_type,
+            status: "pending",
+            priority: tpl.priority,
+            assigned_user_id: userId,
+            assigned_by_user_id: null, // system-generated
+            due_at: dueAt,
+            checklist_instance_id: checklistInstanceId,
+            linked_sop_slug: tpl.linked_sop_slug,
+            requires_photo: tpl.requires_photo,
+            requires_note: tpl.requires_note,
+            requires_approval: tpl.requires_approval,
+            related_label: tpl.related_label,
+            related_project_id: tpl.related_project_id,
+            source_module: "recurring",
+            template_id: tpl.id,
+            scheduled_date: todayISO,
+          })
+          .select("*")
+          .single();
+        if (insErr || !item) {
+          failures.push(`${tpl.name}: item create failed (${insErr?.message})`);
+          if (checklistInstanceId) {
+            await supabaseAdmin
+              .from("work_checklist_instances")
+              .delete()
+              .eq("id", checklistInstanceId);
+          }
+          continue;
+        }
+
+        created += 1;
+        await logWorkEvent({
+          work_item_id: item.id,
+          event_type: "created",
+          new_status: "pending",
+          performed_by: null,
+          metadata: { source: "recurring", template_id: tpl.id },
+        });
+        void notifyWorkAssigned(item as WorkItem);
+      }
+    }
+
+    return success({ date: todayISO, created, skipped, failures });
+  } catch (err) {
+    console.error("[MyWork] generate failed:", err);
+    return error("Generation failed", 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/apps/web/app/api/my-work/route.ts
+++ b/apps/web/app/api/my-work/route.ts
@@ -8,6 +8,7 @@ import {
   isWorkAdmin,
   logWorkEvent,
 } from "@/lib/my-work-service";
+import { notifyWorkAssigned } from "@/lib/my-work-notify";
 import { groupWorkItems, summarize } from "@/lib/my-work-utils";
 import { createWorkItemSchema } from "@maiyuri/shared";
 import type { MyWorkQueue, WorkItem } from "@maiyuri/shared";
@@ -16,11 +17,30 @@ const UPCOMING_LIMIT = 20;
 
 /**
  * GET /api/my-work — the signed-in employee's queue.
+ * ?view=review (supervisors): all SUBMITTED items awaiting approval instead.
  * Loads only what the page needs (PRD §22): open items + today's closed items.
  */
 export async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request);
+
+    // Supervisor review queue: every submitted item, oldest first.
+    const { searchParams } = new URL(request.url);
+    if (searchParams.get("view") === "review") {
+      if (!isWorkAdmin(user.role)) {
+        return error("Only supervisors can review submissions", 403);
+      }
+      const { data, error: revErr } = await supabaseAdmin
+        .from("work_items")
+        .select(
+          "*, assigned_user:users!work_items_assigned_user_id_fkey(id, name)",
+        )
+        .eq("status", "submitted")
+        .order("submitted_at", { ascending: true })
+        .limit(100);
+      if (revErr) return error("Failed to load the review queue", 500);
+      return success<WorkItem[]>((data ?? []) as WorkItem[]);
+    }
 
     const startOfDay = new Date();
     startOfDay.setHours(0, 0, 0, 0);
@@ -161,6 +181,7 @@ export async function POST(request: NextRequest) {
       performed_by: user.id,
       metadata: { assigned_user_id: input.assigned_user_id },
     });
+    void notifyWorkAssigned(item as WorkItem);
 
     return success<WorkItem>(item as WorkItem);
   } catch (err) {

--- a/apps/web/app/api/my-work/templates/route.ts
+++ b/apps/web/app/api/my-work/templates/route.ts
@@ -1,0 +1,107 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { isWorkAdmin } from "@/lib/my-work-service";
+
+// 'daily' | 'weekly:<1-7>' (ISO dow, 1=Mon) | 'monthly:<1-28>'
+const RECURRENCE_RE = /^(daily|weekly:[1-7]|monthly:([1-9]|1\d|2[0-8]))$/;
+
+const templateSchema = z
+  .object({
+    id: z.string().uuid().optional(), // present = update
+    name: z.string().min(2),
+    title: z.string().min(2),
+    description: z.string().nullable().optional(),
+    instructions: z.string().nullable().optional(),
+    activity_type: z
+      .enum(["simple", "checklist", "inspection", "report", "approval"])
+      .default("simple"),
+    default_assigned_user_id: z.string().uuid().nullable().optional(),
+    default_role: z.string().nullable().optional(),
+    checklist_template_id: z.string().uuid().nullable().optional(),
+    recurrence_rule: z
+      .string()
+      .regex(RECURRENCE_RE, "Use daily, weekly:1-7 or monthly:1-28")
+      .nullable()
+      .optional(),
+    due_time: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM (24h)")
+      .nullable()
+      .optional(),
+    priority: z.enum(["low", "medium", "high", "urgent"]).default("medium"),
+    requires_photo: z.boolean().default(false),
+    requires_note: z.boolean().default(false),
+    requires_approval: z.boolean().default(false),
+    related_label: z.string().nullable().optional(),
+    linked_sop_slug: z.string().nullable().optional(),
+    active: z.boolean().default(true),
+  })
+  .refine((t) => t.default_assigned_user_id || t.default_role, {
+    message: "Assign to a person or a role",
+  })
+  .refine(
+    (t) => t.activity_type !== "checklist" || !!t.checklist_template_id,
+    { message: "Checklist templates need a checklist" },
+  );
+
+// GET /api/my-work/templates — recurring templates (supervisors)
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!isWorkAdmin(user.role)) {
+      return error("Only supervisors can manage templates", 403);
+    }
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("work_item_templates")
+      .select(
+        "*, checklist_template:work_checklist_templates(id, name), default_assignee:users!work_item_templates_default_assigned_user_id_fkey(id, name)",
+      )
+      .order("created_at", { ascending: false });
+    if (dbErr) return error("Failed to load templates", 500);
+    return success(data ?? []);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[MyWork] templates GET failed:", err);
+    return error("Failed to load templates", 500);
+  }
+}
+
+// POST /api/my-work/templates — create/update (supervisors)
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!isWorkAdmin(user.role)) {
+      return error("Only supervisors can manage templates", 403);
+    }
+    const parsed = await parseBody(request, templateSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const result = id
+      ? await supabaseAdmin
+          .from("work_item_templates")
+          .update(fields)
+          .eq("id", id)
+          .select("*")
+          .single()
+      : await supabaseAdmin
+          .from("work_item_templates")
+          .insert({ ...fields, created_by: user.id })
+          .select("*")
+          .single();
+
+    if (result.error || !result.data) {
+      return error(`Failed to save template: ${result.error?.message}`, 500);
+    }
+    return success(result.data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[MyWork] templates POST failed:", err);
+    return error("Failed to save template", 500);
+  }
+}

--- a/apps/web/app/onehub/my-work/page.tsx
+++ b/apps/web/app/onehub/my-work/page.tsx
@@ -3,7 +3,12 @@
 import { useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, ChevronDown, Plus } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
-import { useMyWorkQueue } from "@/hooks/useMyWork";
+import {
+  useApproveWorkItem,
+  useMyWorkQueue,
+  useReturnWorkItem,
+  useReviewQueue,
+} from "@/hooks/useMyWork";
 import { WorkItemCard } from "@/components/my-work/WorkItemCard";
 import { CreateWorkItemDialog } from "@/components/my-work/CreateWorkItemDialog";
 import { greetingForHour } from "@/lib/my-work-utils";
@@ -231,9 +236,138 @@ export default function MyWorkPage() {
         </>
       )}
 
+      {isAdmin && <ReviewQueueSection />}
+
       {isAdmin && (
         <CreateWorkItemDialog open={createOpen} onClose={() => setCreateOpen(false)} />
       )}
     </div>
+  );
+}
+
+/** Supervisor-only: submitted items awaiting approval, with approve/return. */
+function ReviewQueueSection() {
+  const { data, isLoading } = useReviewQueue();
+  const approve = useApproveWorkItem();
+  const returnItem = useReturnWorkItem();
+  const [returningId, setReturningId] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const items = data?.data ?? [];
+
+  if (isLoading || items.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h3
+        className="mb-2 text-xs font-bold uppercase tracking-wider"
+        style={{ color: onehub.accent }}
+      >
+        📥 Awaiting your review ({items.length})
+      </h3>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="rounded-2xl border p-4"
+            style={{ background: onehub.card, borderColor: onehub.cardBorder }}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-semibold" style={{ color: onehub.text }}>
+                  {item.title}
+                </p>
+                <p className="mt-0.5 text-xs" style={{ color: onehub.textMuted }}>
+                  {item.assigned_user?.name ?? "Team member"} · submitted{" "}
+                  {item.submitted_at
+                    ? new Date(item.submitted_at).toLocaleString("en-IN", {
+                        day: "numeric",
+                        month: "short",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })
+                    : ""}
+                </p>
+              </div>
+              <a
+                href={`/onehub/my-work/${item.id}`}
+                className="flex-shrink-0 text-xs font-semibold underline"
+                style={{ color: onehub.accent }}
+              >
+                View details
+              </a>
+            </div>
+
+            {returningId === item.id ? (
+              <div className="mt-3">
+                <textarea
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="What needs to be corrected?"
+                  rows={2}
+                  className="w-full rounded-xl border p-2.5 text-sm"
+                  style={{ borderColor: onehub.cardBorder, color: onehub.text }}
+                />
+                <div className="mt-2 flex gap-2">
+                  <button
+                    onClick={() => {
+                      setReturningId(null);
+                      setReason("");
+                    }}
+                    className="rounded-xl border px-3.5 py-2 text-sm font-medium"
+                    style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() =>
+                      reason.trim().length >= 3 &&
+                      returnItem.mutate(
+                        { id: item.id, reason: reason.trim() },
+                        {
+                          onSuccess: () => {
+                            setReturningId(null);
+                            setReason("");
+                          },
+                        },
+                      )
+                    }
+                    disabled={returnItem.isPending || reason.trim().length < 3}
+                    className="rounded-xl px-3.5 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                    style={{ background: "#c1453e" }}
+                  >
+                    {returnItem.isPending ? "Returning…" : "Return for correction"}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-3 flex gap-2">
+                <button
+                  onClick={() => approve.mutate(item.id)}
+                  disabled={approve.isPending}
+                  className="rounded-xl px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                  style={{ background: "#3f7d4d" }}
+                >
+                  {approve.isPending ? "Approving…" : "✓ Approve"}
+                </button>
+                <button
+                  onClick={() => setReturningId(item.id)}
+                  className="rounded-xl border px-4 py-2 text-sm font-medium"
+                  style={{ borderColor: "#c1453e", color: "#c1453e" }}
+                >
+                  ↩ Return
+                </button>
+              </div>
+            )}
+            {(approve.isError || returnItem.isError) && (
+              <p className="mt-2 text-xs" style={{ color: "#c1453e" }}>
+                {(approve.error ?? returnItem.error) instanceof Error
+                  ? ((approve.error ?? returnItem.error) as Error).message
+                  : "Action failed"}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/hooks/useMyWork.ts
+++ b/apps/web/src/hooks/useMyWork.ts
@@ -178,6 +178,45 @@ export function useRemoveWorkPhoto() {
 }
 
 // ============================================
+// Review (supervisors): submitted items → approve / return
+// ============================================
+
+export function useReviewQueue(enabled = true) {
+  return useQuery({
+    queryKey: ["my-work-review"],
+    queryFn: async () => {
+      const res = await fetch("/api/my-work?view=review");
+      if (!res.ok) await throwApiError(res, "Failed to load the review queue");
+      return res.json() as Promise<ApiResponse<WorkItem[]>>;
+    },
+    enabled,
+    refetchInterval: 60_000,
+  });
+}
+
+function invalidateReview(queryClient: ReturnType<typeof useQueryClient>, id: string) {
+  invalidateWork(queryClient, id);
+  queryClient.invalidateQueries({ queryKey: ["my-work-review"] });
+}
+
+export function useApproveWorkItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => postAction(id, "approve"),
+    onSuccess: (_, id) => invalidateReview(queryClient, id),
+  });
+}
+
+export function useReturnWorkItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      postAction(id, "return", { reason }),
+    onSuccess: (_, { id }) => invalidateReview(queryClient, id),
+  });
+}
+
+// ============================================
 // Admin
 // ============================================
 

--- a/apps/web/src/lib/daily-report/aggregate.ts
+++ b/apps/web/src/lib/daily-report/aggregate.ts
@@ -305,18 +305,64 @@ const notConnected = (note: string): CountSection => ({
   metrics: [],
 });
 
+/** Team task activity for the day, from the My Work module. */
+async function tasksFromMyWork(dateISO: string): Promise<CountSection> {
+  const { startUtc, endUtc } = istBounds(dateISO);
+  try {
+    const [assigned, completed, openOverdue] = await Promise.all([
+      // Work that belonged to this day (scheduled or due on it)
+      supabaseAdmin
+        .from("work_items")
+        .select("id", { count: "exact", head: true })
+        .or(
+          `scheduled_date.eq.${dateISO},and(due_at.gte.${startUtc},due_at.lte.${endUtc})`,
+        ),
+      supabaseAdmin
+        .from("work_items")
+        .select("id", { count: "exact", head: true })
+        .in("status", ["completed", "submitted"])
+        .gte("submitted_at", startUtc)
+        .lte("submitted_at", endUtc),
+      supabaseAdmin
+        .from("work_items")
+        .select("id", { count: "exact", head: true })
+        .in("status", ["pending", "in_progress", "returned"])
+        .lt("due_at", endUtc),
+    ]);
+    const done = completed.count ?? 0;
+    return {
+      status: "live",
+      primary: done,
+      metrics: [
+        { label: "Due today", value: String(assigned.count ?? 0) },
+        { label: "Done", value: String(done) },
+        { label: "Still open", value: String(openOverdue.count ?? 0) },
+      ],
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      note: err instanceof Error ? err.message : "DB error",
+      primary: 0,
+      metrics: [],
+    };
+  }
+}
+
 /**
  * Assemble the full report. Every source runs concurrently and independently;
  * a rejected source becomes an error tile rather than failing the whole report.
  */
 export async function getDailyReport(dateISO: string): Promise<DailyReport> {
-  const [finance, production, deliveries, website, leads] = await Promise.all([
-    financeFromOdoo(dateISO),
-    productionFromPlan(dateISO),
-    deliveriesFromPlan(dateISO),
-    websiteFromGa4(),
-    leadsFromDb(dateISO),
-  ]);
+  const [finance, production, deliveries, website, leads, tasks] =
+    await Promise.all([
+      financeFromOdoo(dateISO),
+      productionFromPlan(dateISO),
+      deliveriesFromPlan(dateISO),
+      websiteFromGa4(),
+      leadsFromDb(dateISO),
+      tasksFromMyWork(dateISO),
+    ]);
 
   return {
     date: dateISO,
@@ -326,9 +372,9 @@ export async function getDailyReport(dateISO: string): Promise<DailyReport> {
     deliveries,
     website,
     leads,
+    tasks,
     // Awaiting integration + credentials (see daily-report page footer):
     calls: notConnected("Superfone API not connected"),
     whatsapp: notConnected("WhatsApp Cloud API not connected"),
-    tasks: notConnected("Todoist not connected"),
   };
 }

--- a/apps/web/src/lib/my-work-notify.ts
+++ b/apps/web/src/lib/my-work-notify.ts
@@ -1,0 +1,82 @@
+/**
+ * My Work push notifications. Fire-and-forget: callers must never fail a
+ * write because a push failed — always await via `void notify…()` or wrap
+ * in try/catch inside the route.
+ *
+ * Deep link `/onehub/my-work/{id}` resolves on BOTH surfaces: the web page
+ * and the native expo-router screen (notification tap → router.push(url)).
+ */
+import type { WorkItem } from "@maiyuri/shared";
+import {
+  getUserIdsByRoles,
+  isFcmConfigured,
+  sendPushToUsers,
+} from "@/lib/push/fcm";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { WORK_ADMIN_ROLES } from "@/lib/my-work-service";
+
+const itemUrl = (id: string) => `/onehub/my-work/${id}`;
+
+async function safeSend(
+  userIds: string[],
+  payload: { title: string; body: string; data?: Record<string, string> },
+): Promise<void> {
+  try {
+    if (!isFcmConfigured() || userIds.length === 0) return;
+    await sendPushToUsers(userIds, payload);
+  } catch (err) {
+    console.error("[MyWork] push failed (ignored):", err);
+  }
+}
+
+/** New work assigned → tell the assignee. */
+export async function notifyWorkAssigned(item: WorkItem): Promise<void> {
+  await safeSend([item.assigned_user_id], {
+    title: "🆕 New work assigned",
+    body: item.title,
+    data: { url: itemUrl(item.id) },
+  });
+}
+
+/** Work submitted for approval → tell supervisors (except the submitter). */
+export async function notifyWorkSubmitted(item: WorkItem): Promise<void> {
+  try {
+    const [admins, { data: submitter }] = await Promise.all([
+      getUserIdsByRoles([...WORK_ADMIN_ROLES]),
+      supabaseAdmin
+        .from("users")
+        .select("name")
+        .eq("id", item.assigned_user_id)
+        .single(),
+    ]);
+    const recipients = admins.filter((id) => id !== item.assigned_user_id);
+    await safeSend(recipients, {
+      title: "📥 Work submitted for review",
+      body: `${submitter?.name ?? "A team member"}: ${item.title}`,
+      data: { url: itemUrl(item.id) },
+    });
+  } catch (err) {
+    console.error("[MyWork] submit push failed (ignored):", err);
+  }
+}
+
+/** Approved → tell the assignee. */
+export async function notifyWorkApproved(item: WorkItem): Promise<void> {
+  await safeSend([item.assigned_user_id], {
+    title: "✅ Work approved",
+    body: item.title,
+    data: { url: itemUrl(item.id) },
+  });
+}
+
+/** Returned for correction → tell the assignee (include the reason). */
+export async function notifyWorkReturned(
+  item: WorkItem,
+  reason: string,
+): Promise<void> {
+  await safeSend([item.assigned_user_id], {
+    title: "↩️ Returned for correction",
+    body: `${item.title} — ${reason}`.slice(0, 180),
+    data: { url: itemUrl(item.id) },
+  });
+}


### PR DESCRIPTION
Completes the My Work module (the audit found four severed wires):

W1 Approval loop — approve + return routes (supervisor-gated, concurrency-guarded, evented), review queue API (?view=review), web 'Awaiting your review' section, and the same Approve/Return actions on the mobile work-item screen.

W2 Push notifications — assigned → assignee; submitted → supervisors; approved/returned → assignee. Deep link /onehub/my-work/{id} works on web and native. Per-person morning digest ('N tasks today, M overdue') wired into morning-digest.yml.

W3 Recurring engine — templates CRUD (daily | weekly:1-7 | monthly:1-28, due_time, fixed assignee or role fan-out) + daily generator cron at 05:30 IST (idempotent per template+assignee+date, dated checklist instances, assign-push).

W4 Daily Report — Tasks tile now live from My Work (due today / done / still open); Todoist placeholder removed per the My Work PRD.

The full loop now closes: assign → notified → do → submit → notified → approve/return → measured on the Daily Report.

Verified: web + native tsc clean; touched-file lint 0 errors. No new migrations (uses existing work_item_templates table).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added supervisor review tools to approve submitted work or return it with correction notes.
  - Added recurring work generation, checklist creation, and daily scheduling.
  - Added push notifications for assignments, submissions, approvals, returns, and morning work digests.
  - Added work templates for recurring activities and role- or person-based assignment.
- **Enhancements**
  - Daily reports now display live My Work task metrics, including completed, open, and overdue items.
  - My Work items now receive clearer status updates and review-related feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->