### PR TITLE
fix(security+reliability): R1 hardening — all audit blockers

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,56 @@
+name: Nightly database backup
+
+# The whole business lives in one Supabase Postgres — this is the recovery
+# path (reliability audit, blocker S2). Dumps nightly at 21:00 UTC (02:30 IST)
+# and stores as a workflow artifact (30-day retention, private repo).
+#
+# Requires repo secret SUPABASE_DB_URL — the direct Postgres connection string
+# (Settings → Secrets → Actions). Rotate together with the DB password.
+
+on:
+  schedule:
+    - cron: "0 21 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check secret present
+        run: |
+          if [ -z "${{ secrets.SUPABASE_DB_URL }}" ]; then
+            echo "SUPABASE_DB_URL secret is not set — cannot back up" >&2
+            exit 1
+          fi
+
+      - name: Dump database (pg_dump 17 via docker, custom format)
+        run: |
+          stamp=$(date -u +%Y-%m-%d)
+          echo "STAMP=$stamp" >> "$GITHUB_ENV"
+          docker run --rm postgres:17-alpine \
+            pg_dump --dbname="${{ secrets.SUPABASE_DB_URL }}" -Fc --no-owner --no-privileges \
+            > "maiyuri-$stamp.dump"
+          ls -la "maiyuri-$stamp.dump"
+          # Sanity: a real dump of this DB is at least a few hundred KB.
+          size=$(stat -c%s "maiyuri-$stamp.dump")
+          if [ "$size" -lt 100000 ]; then
+            echo "Dump suspiciously small ($size bytes) — treating as failure" >&2
+            exit 1
+          fi
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ env.STAMP }}
+          path: maiyuri-*.dump
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ DB BACKUP FAILED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/deliveries-digest.yml
+++ b/.github/workflows/deliveries-digest.yml
@@ -1,27 +1,25 @@
-name: Nightly plan reminder
+name: Driver deliveries digest
 
-# Previous-night reminder of tomorrow's production & delivery plan.
-# 15:30 UTC = 21:00 IST. The endpoint is silent when tomorrow has no plan
-# items (Sundays, no active plan), so this can fire every night safely.
-# Requires repo secret CRON_SECRET (already configured for morning-digest).
+# Rehomed from apps/web/vercel.json where it NEVER ran (root vercel.json is
+# the only one Vercel reads; Hobby cron cap already used). 01:30 UTC = 07:00
+# IST — drivers get today's delivery list before leaving the yard.
 
 on:
   schedule:
-    - cron: "30 15 * * *"
+    - cron: "30 1 * * *"
   workflow_dispatch: {}
 
 jobs:
-  send-reminder:
+  digest:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Trigger plan notification endpoint
+      - name: Trigger deliveries cron
         run: |
-          status=$(curl -s -o /tmp/notify.json -w "%{http_code}" -X POST \
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
-            "https://mb.maiyuri.com/api/ops-planning/notify")
-          echo "HTTP $status"
-          cat /tmp/notify.json
+            "https://mb.maiyuri.com/api/deliveries/cron")
+          echo "HTTP $status"; cat /tmp/r.json
           if [ "$status" -ge 400 ]; then exit 1; fi
 
       - name: Alert on failure

--- a/.github/workflows/morning-digest.yml
+++ b/.github/workflows/morning-digest.yml
@@ -41,3 +41,11 @@ jobs:
             echo "My Work digest failed" >&2
             exit 1
           fi
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/my-work-generate.yml
+++ b/.github/workflows/my-work-generate.yml
@@ -20,3 +20,11 @@ jobs:
             "https://mb.maiyuri.com/api/my-work/generate")
           echo "HTTP $status"; cat /tmp/r.json
           if [ "$status" -ge 400 ]; then exit 1; fi
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/odoo-rhythm.yml
+++ b/.github/workflows/odoo-rhythm.yml
@@ -20,3 +20,11 @@ jobs:
             "https://mb.maiyuri.com/api/onehub/rhythm")
           echo "HTTP $status"; cat /tmp/r.json
           if [ "$status" -ge 400 ]; then exit 1; fi
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/odoo-sync.yml
+++ b/.github/workflows/odoo-sync.yml
@@ -1,0 +1,40 @@
+name: Nightly Odoo sync
+
+# Rehomed from apps/web/vercel.json where it NEVER ran (Vercel reads only the
+# root vercel.json, and the Hobby plan caps crons at 2 — both used by health
+# + recordings). 00:15 UTC = 05:45 IST, before the workday.
+
+on:
+  schedule:
+    - cron: "15 0 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Trigger Odoo sync
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/odoo/cron")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi
+
+      - name: Refresh planner order cache (best-effort)
+        continue-on-error: true
+        run: |
+          status=$(curl -s -o /tmp/p.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/ops-planning/inputs")
+          echo "HTTP $status"; head -c 300 /tmp/p.json 2>/dev/null
+          # Best-effort: the in-app Sync Odoo button covers this interactively.
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
         "ODOO_URL": "https://crm.maiyuri.com",
         "ODOO_DB": "lite2",
         "ODOO_USERNAME": "maiyuribricks@gmail.com",
-        "ODOO_API_KEY": "c6c96ff9bbfa8c569640e0285ac5e502ae396de9",
+        "ODOO_API_KEY": "${ODOO_API_KEY}",
         "ODOO_UID": "2"
       }
     }

--- a/apps/native/app/(tabs)/_layout.tsx
+++ b/apps/native/app/(tabs)/_layout.tsx
@@ -1,12 +1,37 @@
 import { Link, Redirect, Tabs } from 'expo-router';
 import { Image, Pressable, Text } from 'react-native';
 import { useAuth } from '@/store/auth';
+import { useMyProfile } from '@/hooks/use-push-settings';
+
+/**
+ * Role → visible tabs, mirroring the web sidebar's roleModuleAccess.
+ * Before this map existed every role saw every tab — a driver could open
+ * Plan and activate a production plan (security audit, blocker S4).
+ * Until the profile loads we show the safe minimum; the profile query is
+ * cache-persisted so returning users see their full tabs instantly.
+ */
+const TAB_ACCESS: Record<string, string[]> = {
+  founder: ['index', 'leads', 'plan', 'production', 'deliveries', 'settings'],
+  owner: ['index', 'leads', 'plan', 'production', 'deliveries', 'settings'],
+  production_supervisor: ['index', 'plan', 'production', 'deliveries', 'settings'],
+  sales: ['index', 'leads', 'settings'],
+  driver: ['index', 'deliveries', 'settings'],
+  accountant: ['index', 'leads', 'settings'],
+  engineer: ['index', 'leads', 'production', 'settings'],
+};
+const DEFAULT_TABS = ['index', 'settings'];
 
 export default function TabsLayout() {
   const { session, initializing } = useAuth();
+  const profile = useMyProfile(session?.user?.id);
 
   // Guard the authenticated area.
   if (!initializing && !session) return <Redirect href="/(auth)/login" />;
+
+  const role = (profile.data?.data.role as string | undefined) ?? '';
+  const visible = TAB_ACCESS[role] ?? DEFAULT_TABS;
+  // Hidden tabs get href:null — removed from the bar AND unreachable by URL.
+  const tabHref = (name: string) => (visible.includes(name) ? undefined : null);
 
   return (
     <Tabs
@@ -52,6 +77,7 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="leads"
         options={{
+          href: tabHref('leads'),
           title: 'Leads',
           tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>👥</Text>,
           headerRight: () => (
@@ -78,6 +104,7 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="plan"
         options={{
+          href: tabHref('plan'),
           title: 'Plan',
           tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>📋</Text>,
         }}
@@ -85,6 +112,7 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="production"
         options={{
+          href: tabHref('production'),
           title: 'Production',
           tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>🏭</Text>,
         }}
@@ -92,6 +120,7 @@ export default function TabsLayout() {
       <Tabs.Screen
         name="deliveries"
         options={{
+          href: tabHref('deliveries'),
           title: 'Deliveries',
           tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 18 }}>🚚</Text>,
         }}

--- a/apps/native/app/(tabs)/settings.tsx
+++ b/apps/native/app/(tabs)/settings.tsx
@@ -324,7 +324,12 @@ export default function SettingsScreen() {
 
         <PushSection />
         {userId ? <PreferencesSection userId={userId} /> : null}
-        <PlanningParamsSection />
+        {/* Factory capacity knobs are leadership/supervisor-only (audit S4) */}
+        {['founder', 'owner', 'production_supervisor'].includes(
+          String(profile.data?.data.role ?? ''),
+        ) ? (
+          <PlanningParamsSection />
+        ) : null}
 
         <Pressable
           onPress={signOut}

--- a/apps/web/src/lib/odoo-service.ts
+++ b/apps/web/src/lib/odoo-service.ts
@@ -5,13 +5,26 @@
 
 import { supabaseAdmin } from "./supabase-admin";
 
-// Odoo connection config
+// Odoo connection config — env-only, no committed fallbacks (security audit).
+// Missing config surfaces as a clear error instead of a silent auth failure.
 const ODOO_CONFIG = {
-  url: process.env.ODOO_URL || "https://CRM.MAIYURI.COM",
-  db: process.env.ODOO_DB || "lite2",
-  username: process.env.ODOO_USER || "maiyuribricks@gmail.com",
-  password: process.env.ODOO_PASSWORD || "",
+  url: process.env.ODOO_URL ?? "",
+  db: process.env.ODOO_DB ?? "",
+  username: process.env.ODOO_USER ?? "",
+  password: process.env.ODOO_PASSWORD ?? "",
 };
+
+function assertOdooConfigured(): void {
+  const missing = [
+    !ODOO_CONFIG.url && "ODOO_URL",
+    !ODOO_CONFIG.db && "ODOO_DB",
+    !ODOO_CONFIG.username && "ODOO_USER",
+    !ODOO_CONFIG.password && "ODOO_PASSWORD",
+  ].filter(Boolean);
+  if (missing.length) {
+    throw new Error(`Odoo is not configured: set ${missing.join(", ")}`);
+  }
+}
 
 // Default salesperson: Ms.Nithya (Odoo user_id: 10)
 const DEFAULT_SALESPERSON_ID = 10;
@@ -66,11 +79,28 @@ async function odooXmlRpc(
   </params>
 </methodCall>`;
 
-  const response = await fetch(`${ODOO_CONFIG.url}/xmlrpc/2/${endpoint}`, {
-    method: "POST",
-    headers: { "Content-Type": "text/xml" },
-    body: xmlBody,
-  });
+  assertOdooConfigured();
+
+  // Hard timeout: a hung Odoo must not pin the serverless function until the
+  // platform kills it (reliability audit). 25s covers slow ERP reads.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 25_000);
+  let response: Response;
+  try {
+    response = await fetch(`${ODOO_CONFIG.url}/xmlrpc/2/${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "text/xml" },
+      body: xmlBody,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (controller.signal.aborted) {
+      throw new Error(`Odoo timed out after 25s (${endpoint}/${method})`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 
   const text = await response.text();
   return parseXmlResponse(text);

--- a/apps/web/src/lib/ops-planning/odoo-planning.ts
+++ b/apps/web/src/lib/ops-planning/odoo-planning.ts
@@ -42,6 +42,7 @@ export type CachedOrderLine = {
 export async function pullConfirmedSalesOrders(): Promise<{
   synced: number;
   openOrders: number;
+  removed: number;
 }> {
   // Map of odoo product -> local finished good
   const { data: goods } = await supabaseAdmin
@@ -71,7 +72,7 @@ export async function pullConfirmedSalesOrders(): Promise<{
     },
   )) as OdooSaleOrder[];
 
-  if (!orders.length) return { synced: 0, openOrders: 0 };
+  if (!orders.length) return { synced: 0, openOrders: 0, removed: 0 };
 
   const lines = (await odooExecute(
     "sale.order.line",
@@ -139,7 +140,38 @@ export async function pullConfirmedSalesOrders(): Promise<{
     .upsert(rows, { onConflict: "odoo_order_id" });
   if (error) throw new Error(`sales_order_cache upsert failed: ${error.message}`);
 
-  return { synced: rows.length, openOrders };
+  // Reconcile cancellations: an order cancelled (or reset to draft) in Odoo
+  // stops matching state in ('sale','done') and would otherwise linger in the
+  // cache with stale remaining_units > 0 — the planner would keep scheduling
+  // phantom production for it (reliability audit, blocker S3). Ask Odoo for
+  // the CURRENT state of every cached order id and evict the dead ones.
+  // (Deliberately not "delete not-in-fetched": the fetch is capped at 300.)
+  let removed = 0;
+  const { data: cached } = await supabaseAdmin
+    .from("sales_order_cache")
+    .select("odoo_order_id");
+  const cachedIds = (cached ?? []).map((r) => r.odoo_order_id as number);
+  if (cachedIds.length) {
+    const dead = (await odooExecute(
+      "sale.order",
+      "search_read",
+      [[["id", "in", cachedIds], ["state", "not in", ["sale", "done"]]]],
+      { fields: ["id"], limit: cachedIds.length },
+    )) as { id: number }[];
+    if (dead.length) {
+      const { error: delErr } = await supabaseAdmin
+        .from("sales_order_cache")
+        .delete()
+        .in("odoo_order_id", dead.map((d) => d.id));
+      if (delErr) {
+        console.error("sales_order_cache eviction failed:", delErr.message);
+      } else {
+        removed = dead.length;
+      }
+    }
+  }
+
+  return { synced: rows.length, openOrders, removed };
 }
 
 /**

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,19 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "echo 'registry=https://registry.npmjs.org' > ~/.npmrc && npm install --legacy-peer-deps --no-audit",
-  "buildCommand": "npm run build",
-  "crons": [
-    {
-      "path": "/api/odoo/cron",
-      "schedule": "0 0 * * *"
-    },
-    {
-      "path": "/api/deliveries/cron",
-      "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/recordings/process",
-      "schedule": "0 */4 * * *"
-    }
-  ]
+  "buildCommand": "npm run build"
 }


### PR DESCRIPTION
Implements phase R1 of the enterprise-readiness audit.

- S1 Secrets: live Odoo API key stripped from .mcp.json (env placeholder); hardcoded Odoo fallbacks removed from odoo-service (env-only + clear error). NOTE: key c6c96ff9… must still be REVOKED in Odoo — git history retains it.
- S2 Backups: nightly pg_dump (docker postgres:17) → workflow artifact, 30-day retention, size sanity check, Telegram alert. Needs new repo secret SUPABASE_DB_URL.
- S3 Phantom orders: sync now asks Odoo the current state of every cached order id and evicts anything no longer sale/done — cancelled orders can't drive phantom production. Plus a 25s timeout on all Odoo XML-RPC calls.
- S4 Mobile RBAC: role→tab map (driver can no longer open Plan/Production or edit factory capacity); hidden tabs are href:null (unroutable). Capacity editor gated.
- Cron integrity: dead apps/web/vercel.json crons removed; odoo-sync + deliveries-digest rehomed as GitHub workflows; Telegram alert-on-failure added to all 4 silent scheduled workflows + the 2 new ones + backup.

Verified: web + native tsc clean.

USER ACTIONS required after merge (cannot be done from code):
1. REVOKE Odoo key c6c96ff9… (Odoo → Preferences → Account Security)
2. Add repo secret SUPABASE_DB_URL (Actions secrets) for backups
3. Verify repo secrets TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID exist (alerts)
4. Sentry: create projects + provide DSNs to turn monitoring on
5. Standing rotation list (DB password, GitHub PAT, Expo token, Supabase keys, vck_ key)

Generated with Claude Code