### PR TITLE
feat(web): R2 Management Console — checklist builder, recurring UI, editors, planning settings, unified approvals

### DIFF
--- a/apps/web/app/(dashboard)/approvals/page.tsx
+++ b/apps/web/app/(dashboard)/approvals/page.tsx
@@ -4,6 +4,11 @@ import { useState } from "react";
 import { Spinner } from "@maiyuri/ui";
 import { useTickets, useApprovalQueue } from "@/hooks/useTickets";
 import {
+  useApproveWorkItem,
+  useReturnWorkItem,
+  useReviewQueue,
+} from "@/hooks/useMyWork";
+import {
   TicketTable,
   TicketDetailPanel,
   TicketStatusBadge,
@@ -63,6 +68,9 @@ export default function ApprovalsPage() {
   return (
     <div className="space-y-6 max-w-[1600px] mx-auto p-6">
       <Toaster position="top-right" />
+
+      {/* My Work submissions — unified into the same inbox (audit #11) */}
+      <WorkSubmissionsSection />
 
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -177,6 +185,106 @@ export default function ApprovalsPage() {
           onActionComplete={handleActionComplete}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * Work submissions awaiting review — the OTHER approval stream (My Work).
+ * Previously only visible inside OneHub; approvers had to know to check two
+ * screens (completeness audit #11). Approve/Return inline, or open OneHub
+ * for the full detail (answers + photos).
+ */
+function WorkSubmissionsSection() {
+  const { data, isLoading } = useReviewQueue();
+  const approve = useApproveWorkItem();
+  const returnItem = useReturnWorkItem();
+  const items = data?.data ?? [];
+
+  if (isLoading || items.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-violet-200 bg-violet-50 p-4 dark:border-violet-800 dark:bg-violet-900/20">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="font-semibold text-violet-900 dark:text-violet-200">
+          📥 Work submissions awaiting review ({items.length})
+        </h2>
+        <a
+          href="/onehub/my-work"
+          className="text-xs font-semibold text-violet-700 underline dark:text-violet-300"
+        >
+          Open in OneHub →
+        </a>
+      </div>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-white p-3 dark:bg-slate-800"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-slate-900 dark:text-white">
+                {item.title}
+              </p>
+              <p className="text-xs text-slate-500">
+                {item.assigned_user?.name ?? "Team member"}
+                {item.submitted_at
+                  ? ` · ${new Date(item.submitted_at).toLocaleString("en-IN", {
+                      day: "numeric",
+                      month: "short",
+                      hour: "numeric",
+                      minute: "2-digit",
+                    })}`
+                  : ""}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <a
+                href={`/onehub/my-work/${item.id}`}
+                className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 dark:border-slate-600 dark:text-slate-300"
+              >
+                Details
+              </a>
+              <button
+                onClick={() =>
+                  approve.mutate(item.id, {
+                    onSuccess: () => toast.success("Approved"),
+                    onError: (e) =>
+                      toast.error(e instanceof Error ? e.message : "Failed"),
+                  })
+                }
+                disabled={approve.isPending}
+                className="rounded-lg bg-green-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                ✓ Approve
+              </button>
+              <button
+                onClick={() => {
+                  const reason = window.prompt(
+                    "What needs to be corrected?",
+                  );
+                  if (reason && reason.trim().length >= 3) {
+                    returnItem.mutate(
+                      { id: item.id, reason: reason.trim() },
+                      {
+                        onSuccess: () => toast.success("Returned for correction"),
+                        onError: (e) =>
+                          toast.error(
+                            e instanceof Error ? e.message : "Failed",
+                          ),
+                      },
+                    );
+                  }
+                }}
+                disabled={returnItem.isPending}
+                className="rounded-lg border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-600 disabled:opacity-50"
+              >
+                ↩ Return
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -318,13 +318,27 @@ function ProfileSettings() {
 }
 
 function NotificationSettings() {
-  const [settings, setSettings] = useState({
-    new_leads: true,
-    follow_ups: true,
-    ai_insights: true,
-    daily_summary: true,
-    telegram: false,
+  // REAL persistence (the previous version faked saves with a setTimeout —
+  // completeness audit): these are the exact keys filterByPushPref reads,
+  // shared with the mobile Settings screen.
+  const queryClient = useQueryClient();
+  const { data: profileData } = useQuery({
+    queryKey: ["me-prefs"],
+    queryFn: async () => {
+      const res = await fetch("/api/users/me");
+      if (!res.ok) throw new Error("Failed to load preferences");
+      return res.json() as Promise<{
+        data: { notification_preferences?: Record<string, boolean> | null };
+      }>;
+    },
   });
+  const prefs = profileData?.data?.notification_preferences ?? {};
+  const settings = {
+    push_leads: prefs.push_leads !== false,
+    push_ops: prefs.push_ops !== false,
+    push_digest: prefs.push_digest !== false,
+    telegram: prefs.telegram === true,
+  };
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
     "idle",
   );
@@ -333,15 +347,27 @@ function NotificationSettings() {
   >("idle");
   const [telegramError, setTelegramError] = useState("");
 
-  const handleToggle = (key: keyof typeof settings) => {
-    setSettings((prev) => ({ ...prev, [key]: !prev[key] }));
-    // Auto-save notification settings
-    setSaveStatus("saving");
-    // Simulate save (in production, call API)
-    setTimeout(() => {
+  const saveMutation = useMutation({
+    mutationFn: async (next: Record<string, boolean>) => {
+      const res = await fetch("/api/users/me", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notification_preferences: next }),
+      });
+      if (!res.ok) throw new Error("Failed to save preferences");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["me-prefs"] });
       setSaveStatus("saved");
       setTimeout(() => setSaveStatus("idle"), 2000);
-    }, 500);
+    },
+    onError: () => setSaveStatus("idle"),
+  });
+
+  const handleToggle = (key: keyof typeof settings) => {
+    setSaveStatus("saving");
+    saveMutation.mutate({ ...prefs, [key]: !settings[key] });
   };
 
   const testTelegram = async () => {
@@ -383,25 +409,20 @@ function NotificationSettings() {
         {(
           [
             {
-              id: "new_leads",
-              title: "New Lead Alerts",
-              description: "Get notified when new leads are added",
+              id: "push_leads",
+              title: "Lead Alerts",
+              description: "New/assigned leads, updates, order won",
             },
             {
-              id: "follow_ups",
-              title: "Follow-up Reminders",
-              description: "Reminders for scheduled follow-ups",
-            },
-            {
-              id: "ai_insights",
-              title: "AI Insights",
+              id: "push_ops",
+              title: "Operations Alerts",
               description:
-                "Notifications about AI-generated insights and recommendations",
+                "Deliveries, production approvals, My Work assignments & reviews",
             },
             {
-              id: "daily_summary",
-              title: "Daily Summary",
-              description: "Daily digest of lead activity and metrics",
+              id: "push_digest",
+              title: "Morning Digest",
+              description: "Daily follow-up + My Work summary each morning",
             },
           ] as const
         ).map((setting) => (

--- a/apps/web/app/api/my-work/digest/route.ts
+++ b/apps/web/app/api/my-work/digest/route.ts
@@ -4,7 +4,11 @@ export const maxDuration = 60;
 import { NextRequest } from "next/server";
 import { success, error } from "@/lib/api-utils";
 import { supabaseAdmin } from "@/lib/supabase-admin";
-import { isFcmConfigured, sendPushToUsers } from "@/lib/push/fcm";
+import {
+  filterByPushPref,
+  isFcmConfigured,
+  sendPushToUsers,
+} from "@/lib/push/fcm";
 
 const CRON_SECRET = process.env.CRON_SECRET;
 
@@ -45,8 +49,14 @@ export async function POST(request: NextRequest) {
       byUser.set(row.assigned_user_id, cur);
     }
 
+    // Respect notification preferences (push_digest, same as the lead digest)
+    const optedIn = new Set(
+      await filterByPushPref([...byUser.keys()], "push_digest"),
+    );
+
     let sent = 0;
     for (const [userId, counts] of byUser) {
+      if (!optedIn.has(userId)) continue;
       const body =
         counts.overdue > 0
           ? `${counts.total} task${counts.total === 1 ? "" : "s"} today — ${counts.overdue} overdue`

--- a/apps/web/app/api/ops-planning/settings/route.ts
+++ b/apps/web/app/api/ops-planning/settings/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const ADMIN_ROLES = ["founder", "owner", "production_supervisor"];
+
+const settingsSchema = z.object({
+  // ISO weekday numbers the factory works (1=Mon … 7=Sun)
+  work_days: z.array(z.number().int().min(1).max(7)).min(1).max(7),
+  max_deliveries_per_day: z.number().int().min(1).max(20),
+  default_constraints_note: z.string().nullable().optional(),
+});
+
+// GET /api/ops-planning/settings — the planner's global knobs
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("planning_settings")
+      .select("*")
+      .eq("id", 1)
+      .maybeSingle();
+    if (dbErr) return error("Failed to load planning settings", 500);
+    return success(
+      data ?? {
+        id: 1,
+        work_days: [1, 2, 3, 4, 5, 6],
+        max_deliveries_per_day: 4,
+        default_constraints_note: null,
+      },
+    );
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("planning settings GET failed:", err);
+    return error("Failed to load planning settings", 500);
+  }
+}
+
+// PUT /api/ops-planning/settings — update (leadership/supervisor only).
+// Previously these knobs were IMPOSSIBLE to change from any surface
+// (completeness audit U6) — hardcoded fallbacks ruled the factory.
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!ADMIN_ROLES.includes(user.role)) {
+      return error("Only leadership can change planning settings", 403);
+    }
+    const parsed = await parseBody(request, settingsSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("planning_settings")
+      .upsert({ id: 1, ...parsed.data })
+      .select("*")
+      .single();
+    if (dbErr || !data) {
+      return error(`Failed to save settings: ${dbErr?.message}`, 500);
+    }
+    return success(data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("planning settings PUT failed:", err);
+    return error("Failed to save planning settings", 500);
+  }
+}

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
 
     const { data: user, error: dbError } = await supabaseAdmin
       .from("users")
-      .select("id, email, name, role, language_preference, created_at")
+      .select("id, email, name, role, language_preference, notification_preferences, created_at")
       .eq("id", authUser.id)
       .single();
 
@@ -47,10 +47,10 @@ export async function PUT(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { name, email, language_preference } = body;
+    const { name, email, language_preference, notification_preferences } = body;
 
     // Only allow updating certain fields
-    const updates: Record<string, string> = {};
+    const updates: Record<string, unknown> = {};
     if (name !== undefined) updates.name = name;
     if (email !== undefined) updates.email = email;
     if (
@@ -58,6 +58,21 @@ export async function PUT(request: NextRequest) {
       ["en", "ta"].includes(language_preference)
     ) {
       updates.language_preference = language_preference;
+    }
+    // Push opt-outs (same JSONB shape the mobile app writes; read by
+    // filterByPushPref). Boolean-only sanitize.
+    if (
+      notification_preferences !== undefined &&
+      typeof notification_preferences === "object" &&
+      notification_preferences !== null
+    ) {
+      const clean: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(
+        notification_preferences as Record<string, unknown>,
+      )) {
+        if (typeof v === "boolean" && k.length <= 40) clean[k] = v;
+      }
+      updates.notification_preferences = clean;
     }
 
     if (Object.keys(updates).length === 0) {
@@ -68,7 +83,7 @@ export async function PUT(request: NextRequest) {
       .from("users")
       .update(updates)
       .eq("id", authUser.id)
-      .select("id, email, name, role, language_preference, created_at")
+      .select("id, email, name, role, language_preference, notification_preferences, created_at")
       .single();
 
     if (dbError) {

--- a/apps/web/app/onehub/admin/page.tsx
+++ b/apps/web/app/onehub/admin/page.tsx
@@ -1,0 +1,1190 @@
+"use client";
+
+/**
+ * OneHub Manage console — the missing management UI for capabilities that
+ * only existed as APIs (completeness audit U1–U10): checklist builder,
+ * recurring work templates, links editor, SOP editor, planning settings.
+ * Server routes enforce roles; the client gate is UX only.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  Calendar,
+  ClipboardList,
+  Link2,
+  ListChecks,
+  Plus,
+  Settings2,
+} from "lucide-react";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  useChecklistTemplates,
+  useCreateChecklistTemplate,
+} from "@/hooks/useMyWork";
+import {
+  useAdminLinks,
+  useAdminSops,
+  usePlanningSettings,
+  useSaveLink,
+  useSavePlanningSettings,
+  useSaveSop,
+  useSaveWorkTemplate,
+  useStaff,
+  useWorkTemplates,
+  type AdminSop,
+  type SopStep,
+} from "@/hooks/useAdminConsole";
+import { onehub } from "../theme";
+
+const ADMIN_ROLES = ["founder", "owner", "production_supervisor"];
+
+type TabKey = "checklists" | "recurring" | "links" | "sops" | "planning";
+
+const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+  { key: "checklists", label: "Checklists", icon: <ListChecks className="h-4 w-4" /> },
+  { key: "recurring", label: "Recurring Work", icon: <Calendar className="h-4 w-4" /> },
+  { key: "links", label: "Links", icon: <Link2 className="h-4 w-4" /> },
+  { key: "sops", label: "SOPs", icon: <ClipboardList className="h-4 w-4" /> },
+  { key: "planning", label: "Planning", icon: <Settings2 className="h-4 w-4" /> },
+];
+
+/* ---------- shared field primitives (onehub theme) ---------- */
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span
+        className="mb-1 block text-xs font-semibold uppercase tracking-wider"
+        style={{ color: onehub.textMuted }}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+const inputCls =
+  "w-full rounded-xl border px-3 py-2 text-sm outline-none focus:ring-2";
+
+function inputStyle(): React.CSSProperties {
+  return { borderColor: onehub.cardBorder, color: onehub.text };
+}
+
+function PrimaryBtn({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-xl px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+      style={{ background: onehub.accent }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function StatusLine({
+  error,
+  success,
+}: {
+  error?: string | null;
+  success?: string | null;
+}) {
+  if (error)
+    return (
+      <p className="mt-2 text-xs" style={{ color: "#c1453e" }}>
+        {error}
+      </p>
+    );
+  if (success)
+    return (
+      <p className="mt-2 text-xs" style={{ color: "#3f7d4d" }}>
+        {success}
+      </p>
+    );
+  return null;
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-2xl border p-4"
+      style={{ background: onehub.card, borderColor: onehub.cardBorder }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* ================= Checklist Builder ================= */
+
+type NewItem = {
+  prompt: string;
+  input_type: "status" | "text" | "number";
+  mandatory: boolean;
+  allow_na: boolean;
+  requires_photo: boolean;
+  requires_photo_on_fail: boolean;
+};
+
+const blankItem = (): NewItem => ({
+  prompt: "",
+  input_type: "status",
+  mandatory: true,
+  allow_na: true,
+  requires_photo: false,
+  requires_photo_on_fail: true,
+});
+
+function ChecklistsTab() {
+  const { data, isLoading } = useChecklistTemplates();
+  const create = useCreateChecklistTemplate();
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [items, setItems] = useState<NewItem[]>([blankItem()]);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const templates = data?.data ?? [];
+
+  const setItem = (i: number, patch: Partial<NewItem>) =>
+    setItems((prev) => prev.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
+
+  const submit = () => {
+    const clean = items.filter((i) => i.prompt.trim());
+    if (!name.trim() || clean.length === 0) return;
+    create.mutate(
+      {
+        name: name.trim(),
+        description: description.trim() || null,
+        items: clean.map((i) => ({
+          prompt: i.prompt.trim(),
+          input_type: i.input_type,
+          mandatory: i.mandatory,
+          allow_na: i.allow_na,
+          requires_photo: i.requires_photo,
+          requires_photo_on_fail: i.requires_photo_on_fail,
+          requires_corrective_action_on_fail: true,
+        })),
+      },
+      {
+        onSuccess: () => {
+          setMsg(`Checklist “${name.trim()}” created`);
+          setCreating(false);
+          setName("");
+          setDescription("");
+          setItems([blankItem()]);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          Checklists define the steps your team runs (assign them via My Work
+          or a recurring template).
+        </p>
+        <PrimaryBtn onClick={() => setCreating((v) => !v)}>
+          <span className="inline-flex items-center gap-1">
+            <Plus className="h-4 w-4" /> New checklist
+          </span>
+        </PrimaryBtn>
+      </div>
+      <StatusLine
+        error={create.isError ? (create.error as Error).message : null}
+        success={msg}
+      />
+
+      {creating && (
+        <Card>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Checklist name">
+              <input
+                className={inputCls}
+                style={inputStyle()}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Evening Shutdown Checklist"
+              />
+            </Field>
+            <Field label="Description (optional)">
+              <input
+                className={inputCls}
+                style={inputStyle()}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="When/why this checklist runs"
+              />
+            </Field>
+          </div>
+
+          <p
+            className="mb-2 mt-4 text-xs font-bold uppercase tracking-wider"
+            style={{ color: onehub.textMuted }}
+          >
+            Items ({items.length})
+          </p>
+          <div className="space-y-3">
+            {items.map((it, i) => (
+              <div
+                key={i}
+                className="rounded-xl border p-3"
+                style={{ borderColor: onehub.cardBorder }}
+              >
+                <div className="flex items-start gap-2">
+                  <input
+                    className={inputCls}
+                    style={inputStyle()}
+                    value={it.prompt}
+                    onChange={(e) => setItem(i, { prompt: e.target.value })}
+                    placeholder={`Item ${i + 1} — e.g. Mixer blades cleaned`}
+                  />
+                  <select
+                    className="rounded-xl border px-2 py-2 text-sm"
+                    style={inputStyle()}
+                    value={it.input_type}
+                    onChange={(e) =>
+                      setItem(i, {
+                        input_type: e.target.value as NewItem["input_type"],
+                      })
+                    }
+                  >
+                    <option value="status">✓ / ✗</option>
+                    <option value="text">Text</option>
+                    <option value="number">Number</option>
+                  </select>
+                  <button
+                    onClick={() =>
+                      setItems((prev) => prev.filter((_, idx) => idx !== i))
+                    }
+                    className="px-2 py-2 text-sm"
+                    style={{ color: "#c1453e" }}
+                  >
+                    ✕
+                  </button>
+                </div>
+                <div
+                  className="mt-2 flex flex-wrap gap-4 text-xs"
+                  style={{ color: onehub.textMuted }}
+                >
+                  {(
+                    [
+                      ["mandatory", "Mandatory"],
+                      ["allow_na", "Allow N/A"],
+                      ["requires_photo", "Photo always"],
+                      ["requires_photo_on_fail", "Photo on fail"],
+                    ] as const
+                  ).map(([key, label]) => (
+                    <label key={key} className="inline-flex items-center gap-1.5">
+                      <input
+                        type="checkbox"
+                        checked={it[key]}
+                        onChange={(e) => setItem(i, { [key]: e.target.checked })}
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button
+              onClick={() => setItems((prev) => [...prev, blankItem()])}
+              className="rounded-xl border px-3 py-2 text-sm font-medium"
+              style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}
+            >
+              + Add item
+            </button>
+            <PrimaryBtn
+              onClick={submit}
+              disabled={
+                create.isPending ||
+                !name.trim() ||
+                items.every((i) => !i.prompt.trim())
+              }
+            >
+              {create.isPending ? "Creating…" : "Create checklist"}
+            </PrimaryBtn>
+          </div>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          Loading…
+        </p>
+      ) : (
+        templates.map((t) => (
+          <Card key={t.id}>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-semibold" style={{ color: onehub.text }}>
+                  {t.name}
+                </p>
+                <p className="text-xs" style={{ color: onehub.textMuted }}>
+                  {t.items?.length ?? 0} items
+                  {t.description ? ` · ${t.description}` : ""}
+                </p>
+              </div>
+            </div>
+            {t.items?.length ? (
+              <ol
+                className="mt-2 list-decimal space-y-0.5 pl-5 text-sm"
+                style={{ color: onehub.text }}
+              >
+                {t.items.map((it) => (
+                  <li key={it.id}>
+                    {it.prompt}
+                    <span className="text-xs" style={{ color: onehub.textMuted }}>
+                      {" "}
+                      ({it.input_type}
+                      {it.requires_photo ? " · 📷" : ""}
+                      {it.requires_photo_on_fail ? " · 📷 on fail" : ""})
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            ) : null}
+          </Card>
+        ))
+      )}
+    </div>
+  );
+}
+
+/* ================= Recurring Work ================= */
+
+const ROLE_OPTIONS = [
+  "production_supervisor",
+  "sales",
+  "driver",
+  "accountant",
+  "engineer",
+  "founder",
+  "owner",
+];
+
+function RecurringTab() {
+  const { data, isLoading } = useWorkTemplates();
+  const save = useSaveWorkTemplate();
+  const staff = useStaff();
+  const checklists = useChecklistTemplates();
+  const [creating, setCreating] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const [form, setForm] = useState({
+    name: "",
+    title: "",
+    activity_type: "checklist" as "simple" | "checklist",
+    checklist_template_id: "",
+    assign_mode: "role" as "role" | "person",
+    default_role: "production_supervisor",
+    default_assigned_user_id: "",
+    recurrence_kind: "daily" as "daily" | "weekly" | "monthly",
+    recurrence_arg: "1",
+    due_time: "08:00",
+    priority: "high" as "low" | "medium" | "high" | "urgent",
+    requires_approval: true,
+    requires_photo: false,
+    requires_note: false,
+  });
+  const set = (patch: Partial<typeof form>) =>
+    setForm((prev) => ({ ...prev, ...patch }));
+
+  const templates = data?.data ?? [];
+  const activeStaff = (staff.data?.data ?? []).filter(
+    (u) => u.is_active !== false,
+  );
+
+  const submit = () => {
+    const rule =
+      form.recurrence_kind === "daily"
+        ? "daily"
+        : `${form.recurrence_kind}:${form.recurrence_arg}`;
+    save.mutate(
+      {
+        name: form.name.trim() || form.title.trim(),
+        title: form.title.trim(),
+        activity_type: form.activity_type,
+        checklist_template_id:
+          form.activity_type === "checklist" ? form.checklist_template_id : null,
+        default_role: form.assign_mode === "role" ? form.default_role : null,
+        default_assigned_user_id:
+          form.assign_mode === "person" ? form.default_assigned_user_id : null,
+        recurrence_rule: rule,
+        due_time: form.due_time,
+        priority: form.priority,
+        requires_approval: form.requires_approval,
+        requires_photo: form.requires_photo,
+        requires_note: form.requires_note,
+        active: true,
+      },
+      {
+        onSuccess: () => {
+          setMsg(`Recurring work “${form.title}” saved — first run tomorrow ~05:30 AM`);
+          setCreating(false);
+        },
+      },
+    );
+  };
+
+  const toggleActive = (id: string, tpl: Record<string, unknown>) =>
+    save.mutate({ ...tpl, id, active: !tpl.active });
+
+  const ruleLabel = (rule: string | null) => {
+    if (!rule) return "—";
+    if (rule === "daily") return "Every day";
+    const [k, a] = rule.split(":");
+    if (k === "weekly")
+      return `Every ${["", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][Number(a)]}`;
+    return `Monthly on day ${a}`;
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          Recurring work auto-appears in people&apos;s My Work each morning
+          (generated ~05:30 AM IST).
+        </p>
+        <PrimaryBtn onClick={() => setCreating((v) => !v)}>
+          <span className="inline-flex items-center gap-1">
+            <Plus className="h-4 w-4" /> New recurring work
+          </span>
+        </PrimaryBtn>
+      </div>
+      <StatusLine
+        error={save.isError ? (save.error as Error).message : null}
+        success={msg}
+      />
+
+      {creating && (
+        <Card>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Task title (what people see)">
+              <input
+                className={inputCls}
+                style={inputStyle()}
+                value={form.title}
+                onChange={(e) => set({ title: e.target.value })}
+                placeholder="e.g. Production Opening Checklist"
+              />
+            </Field>
+            <Field label="Type">
+              <select
+                className={inputCls}
+                style={inputStyle()}
+                value={form.activity_type}
+                onChange={(e) =>
+                  set({ activity_type: e.target.value as "simple" | "checklist" })
+                }
+              >
+                <option value="checklist">Checklist</option>
+                <option value="simple">Simple task</option>
+              </select>
+            </Field>
+            {form.activity_type === "checklist" && (
+              <Field label="Which checklist">
+                <select
+                  className={inputCls}
+                  style={inputStyle()}
+                  value={form.checklist_template_id}
+                  onChange={(e) => set({ checklist_template_id: e.target.value })}
+                >
+                  <option value="">Select…</option>
+                  {(checklists.data?.data ?? []).map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+            )}
+            <Field label="Assign to">
+              <div className="flex gap-2">
+                <select
+                  className={inputCls}
+                  style={inputStyle()}
+                  value={form.assign_mode}
+                  onChange={(e) =>
+                    set({ assign_mode: e.target.value as "role" | "person" })
+                  }
+                >
+                  <option value="role">Everyone with role…</option>
+                  <option value="person">A specific person…</option>
+                </select>
+                {form.assign_mode === "role" ? (
+                  <select
+                    className={inputCls}
+                    style={inputStyle()}
+                    value={form.default_role}
+                    onChange={(e) => set({ default_role: e.target.value })}
+                  >
+                    {ROLE_OPTIONS.map((r) => (
+                      <option key={r} value={r}>
+                        {r.replaceAll("_", " ")}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <select
+                    className={inputCls}
+                    style={inputStyle()}
+                    value={form.default_assigned_user_id}
+                    onChange={(e) =>
+                      set({ default_assigned_user_id: e.target.value })
+                    }
+                  >
+                    <option value="">Select…</option>
+                    {activeStaff.map((u) => (
+                      <option key={u.id} value={u.id}>
+                        {u.name ?? u.email}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            </Field>
+            <Field label="Repeats">
+              <div className="flex gap-2">
+                <select
+                  className={inputCls}
+                  style={inputStyle()}
+                  value={form.recurrence_kind}
+                  onChange={(e) =>
+                    set({
+                      recurrence_kind: e.target
+                        .value as typeof form.recurrence_kind,
+                    })
+                  }
+                >
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                </select>
+                {form.recurrence_kind === "weekly" && (
+                  <select
+                    className={inputCls}
+                    style={inputStyle()}
+                    value={form.recurrence_arg}
+                    onChange={(e) => set({ recurrence_arg: e.target.value })}
+                  >
+                    {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map(
+                      (d, i) => (
+                        <option key={d} value={String(i + 1)}>
+                          {d}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                )}
+                {form.recurrence_kind === "monthly" && (
+                  <input
+                    className={inputCls}
+                    style={inputStyle()}
+                    type="number"
+                    min={1}
+                    max={28}
+                    value={form.recurrence_arg}
+                    onChange={(e) => set({ recurrence_arg: e.target.value })}
+                  />
+                )}
+              </div>
+            </Field>
+            <Field label="Due time (IST)">
+              <input
+                className={inputCls}
+                style={inputStyle()}
+                type="time"
+                value={form.due_time}
+                onChange={(e) => set({ due_time: e.target.value })}
+              />
+            </Field>
+          </div>
+          <div
+            className="mt-3 flex flex-wrap gap-4 text-xs"
+            style={{ color: onehub.textMuted }}
+          >
+            <label className="inline-flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={form.requires_approval}
+                onChange={(e) => set({ requires_approval: e.target.checked })}
+              />
+              Needs supervisor approval
+            </label>
+            <label className="inline-flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={form.requires_photo}
+                onChange={(e) => set({ requires_photo: e.target.checked })}
+              />
+              Photo required
+            </label>
+            <label className="inline-flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={form.requires_note}
+                onChange={(e) => set({ requires_note: e.target.checked })}
+              />
+              Note required
+            </label>
+          </div>
+          <div className="mt-3">
+            <PrimaryBtn
+              onClick={submit}
+              disabled={
+                save.isPending ||
+                !form.title.trim() ||
+                (form.activity_type === "checklist" &&
+                  !form.checklist_template_id) ||
+                (form.assign_mode === "person" && !form.default_assigned_user_id)
+              }
+            >
+              {save.isPending ? "Saving…" : "Save recurring work"}
+            </PrimaryBtn>
+          </div>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          Loading…
+        </p>
+      ) : templates.length === 0 ? (
+        <Card>
+          <p className="text-sm" style={{ color: onehub.textMuted }}>
+            No recurring work yet — create the first one (e.g. the Production
+            Opening Checklist, daily, role: production supervisor).
+          </p>
+        </Card>
+      ) : (
+        templates.map((t) => (
+          <Card key={t.id}>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-semibold" style={{ color: onehub.text }}>
+                  {t.title}
+                  {!t.active && (
+                    <span
+                      className="ml-2 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                      style={{ background: "#f4ece0", color: onehub.textMuted }}
+                    >
+                      paused
+                    </span>
+                  )}
+                </p>
+                <p className="text-xs" style={{ color: onehub.textMuted }}>
+                  {ruleLabel(t.recurrence_rule)}
+                  {t.due_time ? ` · due ${String(t.due_time).slice(0, 5)}` : ""} ·{" "}
+                  {t.default_role
+                    ? `role: ${t.default_role.replaceAll("_", " ")}`
+                    : (t.default_assignee?.name ?? "—")}
+                  {t.checklist_template ? ` · ☑ ${t.checklist_template.name}` : ""}
+                  {t.requires_approval ? " · needs approval" : ""}
+                </p>
+              </div>
+              <button
+                onClick={() => toggleActive(t.id, t as unknown as Record<string, unknown>)}
+                className="flex-shrink-0 rounded-xl border px-3 py-1.5 text-xs font-semibold"
+                style={{
+                  borderColor: onehub.cardBorder,
+                  color: t.active ? "#c1453e" : "#3f7d4d",
+                }}
+              >
+                {t.active ? "Pause" : "Resume"}
+              </button>
+            </div>
+          </Card>
+        ))
+      )}
+    </div>
+  );
+}
+
+/* ================= Links ================= */
+
+function LinksTab() {
+  const { data, isLoading } = useAdminLinks();
+  const save = useSaveLink();
+  const [editing, setEditing] = useState<string | "new" | null>(null);
+  const [form, setForm] = useState({ category: "", name: "", purpose: "", url: "" });
+  const [msg, setMsg] = useState<string | null>(null);
+  const links = data?.data ?? [];
+
+  const startEdit = (l?: (typeof links)[number]) => {
+    setEditing(l?.id ?? "new");
+    setForm({
+      category: l?.category ?? "Operations",
+      name: l?.name ?? "",
+      purpose: l?.purpose ?? "",
+      url: l?.url && l.url !== "https://" ? l.url : "https://",
+    });
+  };
+
+  const submit = () => {
+    save.mutate(
+      {
+        ...(editing !== "new" ? { id: editing! } : {}),
+        category: form.category.trim(),
+        name: form.name.trim(),
+        purpose: form.purpose.trim() || null,
+        url: form.url.trim(),
+        sort_order: 0,
+      },
+      {
+        onSuccess: () => {
+          setMsg(`Link “${form.name}” saved`);
+          setEditing(null);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          These appear in OneHub → Important Links on web and mobile.
+        </p>
+        <PrimaryBtn onClick={() => startEdit()}>
+          <span className="inline-flex items-center gap-1">
+            <Plus className="h-4 w-4" /> Add link
+          </span>
+        </PrimaryBtn>
+      </div>
+      <StatusLine
+        error={save.isError ? (save.error as Error).message : null}
+        success={msg}
+      />
+
+      {editing && (
+        <Card>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Name">
+              <input className={inputCls} style={inputStyle()} value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="e.g. Brochure" />
+            </Field>
+            <Field label="Category">
+              <input className={inputCls} style={inputStyle()} value={form.category} onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))} placeholder="Operations / Sales / Marketing" />
+            </Field>
+            <Field label="URL">
+              <input className={inputCls} style={inputStyle()} value={form.url} onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))} placeholder="https://…" />
+            </Field>
+            <Field label="Purpose (optional)">
+              <input className={inputCls} style={inputStyle()} value={form.purpose} onChange={(e) => setForm((f) => ({ ...f, purpose: e.target.value }))} placeholder="When to use this link" />
+            </Field>
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button onClick={() => setEditing(null)} className="rounded-xl border px-3 py-2 text-sm" style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}>
+              Cancel
+            </button>
+            <PrimaryBtn onClick={submit} disabled={save.isPending || !form.name.trim() || !/^https?:\/\/.+\..+/.test(form.url.trim())}>
+              {save.isPending ? "Saving…" : "Save link"}
+            </PrimaryBtn>
+          </div>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm" style={{ color: onehub.textMuted }}>Loading…</p>
+      ) : (
+        links.map((l) => (
+          <Card key={l.id}>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-semibold" style={{ color: onehub.text }}>
+                  {l.name}
+                  <span className="ml-2 text-xs font-normal" style={{ color: onehub.textMuted }}>
+                    {l.category}
+                  </span>
+                </p>
+                <p className="truncate text-xs" style={{ color: l.url === "https://" ? "#b3781a" : onehub.textMuted }}>
+                  {l.url === "https://" ? "⚠ link not set yet" : l.url}
+                </p>
+              </div>
+              <button onClick={() => startEdit(l)} className="flex-shrink-0 rounded-xl border px-3 py-1.5 text-xs font-semibold" style={{ borderColor: onehub.cardBorder, color: onehub.accent }}>
+                Edit
+              </button>
+            </div>
+          </Card>
+        ))
+      )}
+    </div>
+  );
+}
+
+/* ================= SOPs ================= */
+
+const DEPARTMENTS = ["sales", "production", "dispatch", "accounts", "hr", "safety"];
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60);
+}
+
+function SopsTab() {
+  const { data, isLoading } = useAdminSops();
+  const save = useSaveSop();
+  const [editing, setEditing] = useState<Partial<AdminSop> | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const sops = data?.data ?? [];
+
+  const startNew = () =>
+    setEditing({
+      department: "sales",
+      title_en: "",
+      title_ta: "",
+      purpose_en: "",
+      steps: [{ en: "", ta: "", icon: "" }],
+      warning_en: "",
+      warning_ta: "",
+      video_url: "",
+      status: "draft",
+    });
+
+  const e = editing;
+  const setE = (patch: Partial<AdminSop>) => setEditing((prev) => ({ ...prev!, ...patch }));
+  const steps: SopStep[] = e?.steps ?? [];
+  const setStep = (i: number, patch: Partial<SopStep>) =>
+    setE({ steps: steps.map((s, idx) => (idx === i ? { ...s, ...patch } : s)) });
+
+  const submit = (status: "draft" | "published") => {
+    if (!e?.title_en?.trim()) return;
+    save.mutate(
+      {
+        ...(e.id ? { id: e.id } : {}),
+        department: e.department,
+        slug: e.slug ?? slugify(e.title_en),
+        title_en: e.title_en.trim(),
+        title_ta: e.title_ta?.trim() || null,
+        purpose_en: e.purpose_en?.trim() || null,
+        purpose_ta: e.purpose_ta?.trim() || null,
+        steps: steps
+          .filter((s) => s.en.trim())
+          .map((s) => ({ en: s.en.trim(), ta: s.ta?.trim() || "", icon: s.icon?.trim() || undefined })),
+        warning_en: e.warning_en?.trim() || null,
+        warning_ta: e.warning_ta?.trim() || null,
+        video_url: e.video_url?.trim() || null,
+        status,
+      },
+      {
+        onSuccess: () => {
+          setMsg(
+            status === "published"
+              ? `“${e.title_en}” published — live on web + mobile, Ask Mayur updated`
+              : `Draft saved`,
+          );
+          setEditing(null);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm" style={{ color: onehub.textMuted }}>
+          Publish updates every surface instantly (web, mobile, Ask Mayur).
+        </p>
+        <PrimaryBtn onClick={startNew}>
+          <span className="inline-flex items-center gap-1">
+            <Plus className="h-4 w-4" /> New SOP
+          </span>
+        </PrimaryBtn>
+      </div>
+      <StatusLine error={save.isError ? (save.error as Error).message : null} success={msg} />
+
+      {e && (
+        <Card>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Department">
+              <select className={inputCls} style={inputStyle()} value={e.department} onChange={(ev) => setE({ department: ev.target.value })}>
+                {DEPARTMENTS.map((d) => (
+                  <option key={d} value={d}>{d}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Title (English)">
+              <input className={inputCls} style={inputStyle()} value={e.title_en ?? ""} onChange={(ev) => setE({ title_en: ev.target.value })} />
+            </Field>
+            <Field label="Title (தமிழ்)">
+              <input className={inputCls} style={inputStyle()} value={e.title_ta ?? ""} onChange={(ev) => setE({ title_ta: ev.target.value })} />
+            </Field>
+            <Field label="Purpose (English)">
+              <input className={inputCls} style={inputStyle()} value={e.purpose_en ?? ""} onChange={(ev) => setE({ purpose_en: ev.target.value })} />
+            </Field>
+          </div>
+
+          <p className="mb-2 mt-4 text-xs font-bold uppercase tracking-wider" style={{ color: onehub.textMuted }}>
+            Steps ({steps.length})
+          </p>
+          <div className="space-y-2">
+            {steps.map((s, i) => (
+              <div key={i} className="flex items-start gap-2">
+                <input className="w-14 rounded-xl border px-2 py-2 text-center text-sm" style={inputStyle()} value={s.icon ?? ""} onChange={(ev) => setStep(i, { icon: ev.target.value })} placeholder="🔧" />
+                <div className="flex-1 space-y-1.5">
+                  <input className={inputCls} style={inputStyle()} value={s.en} onChange={(ev) => setStep(i, { en: ev.target.value })} placeholder={`Step ${i + 1} (English)`} />
+                  <input className={inputCls} style={inputStyle()} value={s.ta ?? ""} onChange={(ev) => setStep(i, { ta: ev.target.value })} placeholder="படி (தமிழ்)" />
+                </div>
+                <button onClick={() => setE({ steps: steps.filter((_, idx) => idx !== i) })} className="px-2 py-2 text-sm" style={{ color: "#c1453e" }}>
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+          <button onClick={() => setE({ steps: [...steps, { en: "", ta: "", icon: "" }] })} className="mt-2 rounded-xl border px-3 py-2 text-sm" style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}>
+            + Add step
+          </button>
+
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <Field label="⚠ Warning (English)">
+              <input className={inputCls} style={inputStyle()} value={e.warning_en ?? ""} onChange={(ev) => setE({ warning_en: ev.target.value })} />
+            </Field>
+            <Field label="⚠ Warning (தமிழ்)">
+              <input className={inputCls} style={inputStyle()} value={e.warning_ta ?? ""} onChange={(ev) => setE({ warning_ta: ev.target.value })} />
+            </Field>
+            <Field label="Video URL (optional)">
+              <input className={inputCls} style={inputStyle()} value={e.video_url ?? ""} onChange={(ev) => setE({ video_url: ev.target.value })} />
+            </Field>
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <button onClick={() => setEditing(null)} className="rounded-xl border px-3 py-2 text-sm" style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}>
+              Cancel
+            </button>
+            <button onClick={() => submit("draft")} disabled={save.isPending} className="rounded-xl border px-3 py-2 text-sm font-medium" style={{ borderColor: onehub.cardBorder, color: onehub.text }}>
+              Save draft
+            </button>
+            <PrimaryBtn onClick={() => submit("published")} disabled={save.isPending || !e.title_en?.trim()}>
+              {save.isPending ? "Saving…" : "Publish"}
+            </PrimaryBtn>
+          </div>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm" style={{ color: onehub.textMuted }}>Loading…</p>
+      ) : (
+        sops.map((s) => (
+          <Card key={s.id}>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-semibold" style={{ color: onehub.text }}>
+                  {s.title_en}
+                  {s.status === "draft" && (
+                    <span className="ml-2 rounded-full px-2 py-0.5 text-[10px] font-semibold" style={{ background: "#f4ece0", color: onehub.textMuted }}>
+                      draft
+                    </span>
+                  )}
+                </p>
+                <p className="text-xs" style={{ color: onehub.textMuted }}>
+                  {s.department} · {s.steps.length} steps · v{s.version}
+                </p>
+              </div>
+              <button onClick={() => setEditing(s)} className="flex-shrink-0 rounded-xl border px-3 py-1.5 text-xs font-semibold" style={{ borderColor: onehub.cardBorder, color: onehub.accent }}>
+                Edit
+              </button>
+            </div>
+          </Card>
+        ))
+      )}
+    </div>
+  );
+}
+
+/* ================= Planning settings ================= */
+
+const DAYS = [
+  { n: 1, label: "Mon" },
+  { n: 2, label: "Tue" },
+  { n: 3, label: "Wed" },
+  { n: 4, label: "Thu" },
+  { n: 5, label: "Fri" },
+  { n: 6, label: "Sat" },
+  { n: 7, label: "Sun" },
+];
+
+function PlanningTab() {
+  const { data, isLoading } = usePlanningSettings();
+  const save = useSavePlanningSettings();
+  const [msg, setMsg] = useState<string | null>(null);
+  const [dirty, setDirty] = useState<{
+    work_days: number[];
+    max_deliveries_per_day: number;
+    default_constraints_note: string;
+  } | null>(null);
+
+  const current = data?.data;
+  const form = dirty ?? {
+    work_days: current?.work_days ?? [1, 2, 3, 4, 5, 6],
+    max_deliveries_per_day: current?.max_deliveries_per_day ?? 4,
+    default_constraints_note: current?.default_constraints_note ?? "",
+  };
+
+  const toggleDay = (n: number) =>
+    setDirty({
+      ...form,
+      work_days: form.work_days.includes(n)
+        ? form.work_days.filter((d) => d !== n)
+        : [...form.work_days, n].sort(),
+    });
+
+  if (isLoading)
+    return <p className="text-sm" style={{ color: onehub.textMuted }}>Loading…</p>;
+
+  return (
+    <Card>
+      <p className="text-sm" style={{ color: onehub.textMuted }}>
+        The AI planner&apos;s global rules. Until now these were hardcoded —
+        this is the first surface where they can be changed.
+      </p>
+      <div className="mt-4">
+        <Field label="Factory working days">
+          <div className="flex flex-wrap gap-2">
+            {DAYS.map((d) => (
+              <button
+                key={d.n}
+                onClick={() => toggleDay(d.n)}
+                className="rounded-xl border px-3 py-1.5 text-sm font-medium"
+                style={
+                  form.work_days.includes(d.n)
+                    ? { background: onehub.accent, color: "#fff", borderColor: onehub.accent }
+                    : { borderColor: onehub.cardBorder, color: onehub.textMuted }
+                }
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+        </Field>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Field label="Max deliveries per day">
+          <input
+            className={inputCls}
+            style={inputStyle()}
+            type="number"
+            min={1}
+            max={20}
+            value={form.max_deliveries_per_day}
+            onChange={(e) =>
+              setDirty({ ...form, max_deliveries_per_day: Number(e.target.value) || 1 })
+            }
+          />
+        </Field>
+        <Field label="Standing constraints note (given to the AI)">
+          <input
+            className={inputCls}
+            style={inputStyle()}
+            value={form.default_constraints_note}
+            onChange={(e) =>
+              setDirty({ ...form, default_constraints_note: e.target.value })
+            }
+            placeholder="e.g. Machine service every second Saturday"
+          />
+        </Field>
+      </div>
+      <div className="mt-4">
+        <PrimaryBtn
+          onClick={() =>
+            save.mutate(
+              {
+                work_days: form.work_days,
+                max_deliveries_per_day: form.max_deliveries_per_day,
+                default_constraints_note:
+                  form.default_constraints_note.trim() || null,
+              },
+              { onSuccess: () => { setMsg("Planning settings saved"); setDirty(null); } },
+            )
+          }
+          disabled={save.isPending || form.work_days.length === 0}
+        >
+          {save.isPending ? "Saving…" : "Save settings"}
+        </PrimaryBtn>
+        <StatusLine error={save.isError ? (save.error as Error).message : null} success={msg} />
+      </div>
+    </Card>
+  );
+}
+
+/* ================= Page shell ================= */
+
+export default function OneHubAdminPage() {
+  const { user } = useAuthStore();
+  const [tab, setTab] = useState<TabKey>("checklists");
+  const isAdmin = ADMIN_ROLES.includes(user?.role ?? "");
+
+  const body = useMemo(() => {
+    switch (tab) {
+      case "checklists":
+        return <ChecklistsTab />;
+      case "recurring":
+        return <RecurringTab />;
+      case "links":
+        return <LinksTab />;
+      case "sops":
+        return <SopsTab />;
+      case "planning":
+        return <PlanningTab />;
+    }
+  }, [tab]);
+
+  if (user && !isAdmin) {
+    return (
+      <div className="mx-auto max-w-3xl py-16 text-center">
+        <p className="font-semibold" style={{ color: onehub.text }}>
+          Manage is for supervisors and leadership.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl pb-24">
+      <h2 className="font-serif text-2xl font-bold" style={{ color: onehub.brand }}>
+        Manage
+      </h2>
+      <p className="mt-0.5 text-sm" style={{ color: onehub.textMuted }}>
+        Checklists, recurring work, links, SOPs and planning rules — the
+        controls behind OneHub and My Work.
+      </p>
+
+      <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className="flex min-h-[40px] flex-shrink-0 items-center gap-1.5 rounded-full border px-4 py-1.5 text-sm font-medium"
+            style={
+              tab === t.key
+                ? { background: onehub.brand, color: "#fff", borderColor: onehub.brand }
+                : { background: onehub.card, color: onehub.textMuted, borderColor: onehub.cardBorder }
+            }
+          >
+            {t.icon}
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-5">{body}</div>
+    </div>
+  );
+}

--- a/apps/web/app/onehub/layout.tsx
+++ b/apps/web/app/onehub/layout.tsx
@@ -17,6 +17,7 @@ import {
   MessageSquare,
   Plus,
   Search,
+  Settings2,
   Upload,
 } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
@@ -105,7 +106,13 @@ export default function OneHubLayout({ children }: { children: React.ReactNode }
         </p>
 
         <nav className="flex-1 space-y-1 px-3">
-          {NAV.map((item) => {
+          {[
+            ...NAV,
+            // Manage console — supervisors/leadership only (audit U1–U10)
+            ...(["founder", "owner", "production_supervisor"].includes(user?.role ?? "")
+              ? [{ label: "Manage", icon: Settings2, href: "/onehub/admin" }]
+              : []),
+          ].map((item) => {
             const Icon = item.icon;
             const active =
               item.href === "/onehub"

--- a/apps/web/app/onehub/my-work/[id]/page.tsx
+++ b/apps/web/app/onehub/my-work/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   Trash2,
 } from "lucide-react";
 import {
+  useCancelWorkItem,
   useCompleteWorkItem,
   useRemoveWorkPhoto,
   useSaveDraft,
@@ -22,6 +23,7 @@ import {
   useUploadWorkPhoto,
   useWorkItem,
 } from "@/hooks/useMyWork";
+import { useAuthStore } from "@/stores/authStore";
 import {
   ChecklistRunner,
   type DraftResponse,
@@ -280,6 +282,7 @@ export default function WorkItemDetailPage() {
           >
             {WORK_STATUS_LABELS[item.status]}
           </span>
+          <CancelButton itemId={item.id} status={item.status} />
           {item.priority !== "medium" && item.priority !== "low" && (
             <span
               className="rounded-full px-2 py-0.5 text-[11px] font-semibold"
@@ -501,5 +504,31 @@ export default function WorkItemDetailPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+/** Supervisor-only cancel (audit U7 — the API existed with no button). */
+function CancelButton({ itemId, status }: { itemId: string; status: string }) {
+  const { user } = useAuthStore();
+  const cancel = useCancelWorkItem();
+  const isAdmin = ["founder", "owner", "production_supervisor"].includes(
+    user?.role ?? "",
+  );
+  if (!isAdmin || status === "completed" || status === "cancelled") return null;
+
+  return (
+    <button
+      onClick={() => {
+        const reason = window.prompt("Why is this work being cancelled?");
+        if (reason && reason.trim()) {
+          cancel.mutate({ id: itemId, reason: reason.trim() });
+        }
+      }}
+      disabled={cancel.isPending}
+      className="ml-auto rounded-full border px-2.5 py-0.5 text-[11px] font-semibold disabled:opacity-50"
+      style={{ borderColor: "#e5c8c2", color: "#c1453e" }}
+    >
+      {cancel.isPending ? "Cancelling…" : "Cancel work"}
+    </button>
   );
 }

--- a/apps/web/src/hooks/useAdminConsole.ts
+++ b/apps/web/src/hooks/useAdminConsole.ts
@@ -1,0 +1,206 @@
+/**
+ * Hooks for the OneHub Manage console (/onehub/admin): recurring work
+ * templates, planning settings, OneHub links + SOPs, staff list.
+ * All endpoints already existed — this is the missing client half
+ * (completeness audit U1–U10).
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface ApiResponse<T> {
+  data: T;
+  error?: string;
+}
+
+async function jsonOrThrow<T>(res: Response, fallback: string): Promise<T> {
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || fallback);
+  return body as T;
+}
+
+// ---------- staff ----------
+
+export interface StaffUser {
+  id: string;
+  name: string | null;
+  email: string;
+  role: string;
+  is_active?: boolean;
+}
+
+export function useStaff() {
+  return useQuery({
+    queryKey: ["admin-staff"],
+    queryFn: async () => {
+      const res = await fetch("/api/users");
+      return jsonOrThrow<ApiResponse<StaffUser[]>>(res, "Failed to load staff");
+    },
+  });
+}
+
+// ---------- recurring work templates ----------
+
+export interface WorkTemplate {
+  id: string;
+  name: string;
+  title: string;
+  activity_type: string;
+  default_assigned_user_id: string | null;
+  default_role: string | null;
+  checklist_template_id: string | null;
+  recurrence_rule: string | null;
+  due_time: string | null;
+  priority: string;
+  requires_photo: boolean;
+  requires_note: boolean;
+  requires_approval: boolean;
+  active: boolean;
+  checklist_template?: { id: string; name: string } | null;
+  default_assignee?: { id: string; name: string } | null;
+}
+
+export function useWorkTemplates() {
+  return useQuery({
+    queryKey: ["work-templates"],
+    queryFn: async () => {
+      const res = await fetch("/api/my-work/templates");
+      return jsonOrThrow<ApiResponse<WorkTemplate[]>>(res, "Failed to load templates");
+    },
+  });
+}
+
+export function useSaveWorkTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: Record<string, unknown>) => {
+      const res = await fetch("/api/my-work/templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      return jsonOrThrow<ApiResponse<WorkTemplate>>(res, "Failed to save template");
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["work-templates"] }),
+  });
+}
+
+// ---------- planning settings ----------
+
+export interface PlanningSettings {
+  work_days: number[];
+  max_deliveries_per_day: number;
+  default_constraints_note: string | null;
+}
+
+export function usePlanningSettings() {
+  return useQuery({
+    queryKey: ["planning-settings"],
+    queryFn: async () => {
+      const res = await fetch("/api/ops-planning/settings");
+      return jsonOrThrow<ApiResponse<PlanningSettings>>(res, "Failed to load settings");
+    },
+  });
+}
+
+export function useSavePlanningSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: PlanningSettings) => {
+      const res = await fetch("/api/ops-planning/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      return jsonOrThrow<ApiResponse<PlanningSettings>>(res, "Failed to save settings");
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["planning-settings"] }),
+  });
+}
+
+// ---------- OneHub links ----------
+
+export interface OneHubLink {
+  id: string;
+  category: string;
+  name: string;
+  purpose: string | null;
+  url: string;
+  sort_order: number;
+}
+
+export function useAdminLinks() {
+  return useQuery({
+    queryKey: ["onehub", "links"],
+    queryFn: async () => {
+      const res = await fetch("/api/onehub/links");
+      return jsonOrThrow<ApiResponse<OneHubLink[]>>(res, "Failed to load links");
+    },
+  });
+}
+
+export function useSaveLink() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: Partial<OneHubLink>) => {
+      const res = await fetch("/api/onehub/links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      return jsonOrThrow<ApiResponse<OneHubLink>>(res, "Failed to save link");
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["onehub", "links"] }),
+  });
+}
+
+// ---------- OneHub SOPs ----------
+
+export interface SopStep {
+  en: string;
+  ta?: string;
+  icon?: string;
+}
+
+export interface AdminSop {
+  id: string;
+  department: string;
+  slug: string;
+  title_en: string;
+  title_ta: string | null;
+  purpose_en: string | null;
+  purpose_ta: string | null;
+  steps: SopStep[];
+  warning_en: string | null;
+  warning_ta: string | null;
+  video_url: string | null;
+  status: "draft" | "published";
+  version: number;
+}
+
+export function useAdminSops() {
+  return useQuery({
+    queryKey: ["onehub", "sops", "admin"],
+    queryFn: async () => {
+      const res = await fetch("/api/onehub/sops");
+      return jsonOrThrow<ApiResponse<AdminSop[]>>(res, "Failed to load SOPs");
+    },
+  });
+}
+
+export function useSaveSop() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: Partial<AdminSop>) => {
+      const res = await fetch("/api/onehub/sops", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      return jsonOrThrow<ApiResponse<AdminSop>>(res, "Failed to save SOP");
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["onehub", "sops"] }),
+  });
+}

--- a/apps/web/src/hooks/useMyWork.ts
+++ b/apps/web/src/hooks/useMyWork.ts
@@ -207,6 +207,15 @@ export function useApproveWorkItem() {
   });
 }
 
+export function useCancelWorkItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      postAction(id, "cancel", { reason }),
+    onSuccess: (_, { id }) => invalidateReview(queryClient, id),
+  });
+}
+
 export function useReturnWorkItem() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/web/src/lib/my-work-notify.ts
+++ b/apps/web/src/lib/my-work-notify.ts
@@ -8,6 +8,7 @@
  */
 import type { WorkItem } from "@maiyuri/shared";
 import {
+  filterByPushPref,
   getUserIdsByRoles,
   isFcmConfigured,
   sendPushToUsers,
@@ -23,7 +24,11 @@ async function safeSend(
 ): Promise<void> {
   try {
     if (!isFcmConfigured() || userIds.length === 0) return;
-    await sendPushToUsers(userIds, payload);
+    // Respect each user's notification_preferences like every other flow
+    // (completeness audit #7 — My Work previously bypassed prefs).
+    const recipients = await filterByPushPref(userIds, "push_ops");
+    if (!recipients.length) return;
+    await sendPushToUsers(recipients, payload);
   } catch (err) {
     console.error("[MyWork] push failed (ignored):", err);
   }


### PR DESCRIPTION
Phase R2 of the enterprise-readiness plan: every capability that existed only as an API gets its operating surface.

New /onehub/admin (Manage, supervisor/leadership-gated) with 5 tabs: Checklists (full builder with item types + photo rules), Recurring Work (daily/weekly/monthly, person or role fan-out, pause/resume), Links editor, SOP editor (EN/TA, draft/publish→RAG), Planning settings (work days, max deliveries/day, AI constraints — first editable surface ever; new GET/PUT /api/ops-planning/settings).

Also: My Work submissions unified into /approvals with inline Approve/Return; Cancel-work button on the web detail page; web notification preferences were FAKE (setTimeout simulate) — now real and shared with mobile + push engine; My Work pushes/digest now respect notification_preferences.

Verified: web tsc clean, lint 0 errors on touched files. Web-only (no APK rebuild needed).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a role-restricted OneHub Manage console for checklists, recurring work, links, SOPs, and planning settings.
  - Added work submission review tools with approve and return-for-correction actions.
  - Added supervisor/admin cancellation for active work items.
  - Added planning settings management for working days, delivery limits, and constraints.

- **Improvements**
  - Notification preferences now persist across sessions.
  - Operational and digest notifications respect individual push preferences.
  - Added a Manage link for authorized roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->