### PR TITLE
feat(my-work): checklist editing — rename, edit items, safe add/remove

### DIFF
--- a/apps/web/app/api/my-work/checklist-templates/[id]/route.ts
+++ b/apps/web/app/api/my-work/checklist-templates/[id]/route.ts
@@ -1,0 +1,139 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { isWorkAdmin } from "@/lib/my-work-service";
+
+const itemPatchSchema = z.object({
+  /** present = update this existing item; absent = insert a new one */
+  id: z.string().uuid().optional(),
+  prompt: z.string().min(1),
+  input_type: z.enum(["status", "text", "number"]).default("status"),
+  mandatory: z.boolean().default(true),
+  allow_na: z.boolean().default(true),
+  requires_photo: z.boolean().default(false),
+  requires_photo_on_fail: z.boolean().default(false),
+  requires_corrective_action_on_fail: z.boolean().default(true),
+});
+
+const patchSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+  active: z.boolean().optional(),
+  /** Full desired item list, in display order (existing carry their id). */
+  items: z.array(itemPatchSchema).min(1).optional(),
+  /** Item ids the user removed in the editor. */
+  remove_item_ids: z.array(z.string().uuid()).optional(),
+});
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PATCH /api/my-work/checklist-templates/[id] — edit a checklist (audit R4).
+ * Safe-edit rules:
+ * - rename / description / active toggle: always allowed
+ * - item prompt/flags edits + new items: always allowed
+ * - item REMOVAL: only when the item has never been referenced by a run —
+ *   the responses FK RESTRICTs deletion, so used items are reported back as
+ *   `kept_in_use` instead of failing the whole save (history stays intact).
+ */
+export async function PATCH(request: NextRequest, { params }: Params) {
+  try {
+    const user = await requireAuth(request);
+    if (!isWorkAdmin(user.role)) {
+      return error("You do not have permission to edit templates", 403);
+    }
+    const { id } = await params;
+
+    const { data: template } = await supabaseAdmin
+      .from("work_checklist_templates")
+      .select("id")
+      .eq("id", id)
+      .single();
+    if (!template) return error("Checklist template not found", 404);
+
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const input = parsed.data;
+
+    // 1. Template fields
+    const tplPatch: Record<string, unknown> = {};
+    if (input.name !== undefined) tplPatch.name = input.name;
+    if (input.description !== undefined) tplPatch.description = input.description;
+    if (input.active !== undefined) tplPatch.active = input.active;
+    if (Object.keys(tplPatch).length) {
+      const { error: updErr } = await supabaseAdmin
+        .from("work_checklist_templates")
+        .update(tplPatch)
+        .eq("id", id);
+      if (updErr) return error(`Failed to update template: ${updErr.message}`, 500);
+    }
+
+    // 2. Removals — only items never referenced by any run
+    const keptInUse: string[] = [];
+    for (const itemId of input.remove_item_ids ?? []) {
+      const { count } = await supabaseAdmin
+        .from("work_checklist_responses")
+        .select("id", { count: "exact", head: true })
+        .eq("template_item_id", itemId);
+      if ((count ?? 0) > 0) {
+        keptInUse.push(itemId);
+        continue;
+      }
+      const { error: delErr } = await supabaseAdmin
+        .from("work_checklist_template_items")
+        .delete()
+        .eq("id", itemId)
+        .eq("template_id", id);
+      if (delErr) keptInUse.push(itemId); // FK raced us — keep it
+    }
+
+    // 3. Item updates + inserts, re-sequenced in the submitted order
+    if (input.items) {
+      for (let i = 0; i < input.items.length; i++) {
+        const item = input.items[i];
+        const fields = {
+          prompt: item.prompt,
+          sort_order: i + 1,
+          input_type: item.input_type,
+          mandatory: item.mandatory,
+          allow_na: item.allow_na,
+          requires_photo: item.requires_photo,
+          requires_photo_on_fail: item.requires_photo_on_fail,
+          requires_corrective_action_on_fail:
+            item.requires_corrective_action_on_fail,
+        };
+        if (item.id) {
+          const { error: uErr } = await supabaseAdmin
+            .from("work_checklist_template_items")
+            .update(fields)
+            .eq("id", item.id)
+            .eq("template_id", id);
+          if (uErr) return error(`Failed to update an item: ${uErr.message}`, 500);
+        } else {
+          const { error: iErr } = await supabaseAdmin
+            .from("work_checklist_template_items")
+            .insert({ ...fields, template_id: id });
+          if (iErr) return error(`Failed to add an item: ${iErr.message}`, 500);
+        }
+      }
+    }
+
+    const { data: fresh } = await supabaseAdmin
+      .from("work_checklist_templates")
+      .select("*, items:work_checklist_template_items(*)")
+      .eq("id", id)
+      .single();
+
+    return success({ template: fresh, kept_in_use: keptInUse });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[MyWork] template PATCH failed:", err);
+    return error("Failed to update the checklist template", 500);
+  }
+}

--- a/apps/web/app/onehub/admin/page.tsx
+++ b/apps/web/app/onehub/admin/page.tsx
@@ -20,6 +20,7 @@ import { useAuthStore } from "@/stores/authStore";
 import {
   useChecklistTemplates,
   useCreateChecklistTemplate,
+  useUpdateChecklistTemplate,
 } from "@/hooks/useMyWork";
 import {
   useAdminLinks,
@@ -134,6 +135,8 @@ function Card({ children }: { children: React.ReactNode }) {
 /* ================= Checklist Builder ================= */
 
 type NewItem = {
+  /** present = existing template item (may be edited); absent = new */
+  id?: string;
   prompt: string;
   input_type: "status" | "text" | "number";
   mandatory: boolean;
@@ -154,44 +157,108 @@ const blankItem = (): NewItem => ({
 function ChecklistsTab() {
   const { data, isLoading } = useChecklistTemplates();
   const create = useCreateChecklistTemplate();
+  const update = useUpdateChecklistTemplate();
   const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [items, setItems] = useState<NewItem[]>([blankItem()]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
   const [msg, setMsg] = useState<string | null>(null);
 
   const templates = data?.data ?? [];
+  const formOpen = creating || editingId !== null;
 
   const setItem = (i: number, patch: Partial<NewItem>) =>
     setItems((prev) => prev.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
 
+  const resetForm = () => {
+    setCreating(false);
+    setEditingId(null);
+    setName("");
+    setDescription("");
+    setItems([blankItem()]);
+    setRemovedIds([]);
+  };
+
+  const startEdit = (t: (typeof templates)[number]) => {
+    setMsg(null);
+    setCreating(false);
+    setEditingId(t.id);
+    setName(t.name);
+    setDescription(t.description ?? "");
+    setRemovedIds([]);
+    setItems(
+      (t.items ?? []).map((it) => ({
+        id: it.id,
+        prompt: it.prompt,
+        input_type: it.input_type,
+        mandatory: it.mandatory,
+        allow_na: it.allow_na,
+        requires_photo: it.requires_photo,
+        requires_photo_on_fail: it.requires_photo_on_fail,
+      })),
+    );
+  };
+
+  const removeItemAt = (i: number) => {
+    const it = items[i];
+    if (it.id) setRemovedIds((prev) => [...prev, it.id!]);
+    setItems((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const busy = create.isPending || update.isPending;
+
   const submit = () => {
     const clean = items.filter((i) => i.prompt.trim());
     if (!name.trim() || clean.length === 0) return;
-    create.mutate(
-      {
-        name: name.trim(),
-        description: description.trim() || null,
-        items: clean.map((i) => ({
-          prompt: i.prompt.trim(),
-          input_type: i.input_type,
-          mandatory: i.mandatory,
-          allow_na: i.allow_na,
-          requires_photo: i.requires_photo,
-          requires_photo_on_fail: i.requires_photo_on_fail,
-          requires_corrective_action_on_fail: true,
-        })),
-      },
-      {
-        onSuccess: () => {
-          setMsg(`Checklist “${name.trim()}” created`);
-          setCreating(false);
-          setName("");
-          setDescription("");
-          setItems([blankItem()]);
+    const payloadItems = clean.map((i) => ({
+      ...(i.id ? { id: i.id } : {}),
+      prompt: i.prompt.trim(),
+      input_type: i.input_type,
+      mandatory: i.mandatory,
+      allow_na: i.allow_na,
+      requires_photo: i.requires_photo,
+      requires_photo_on_fail: i.requires_photo_on_fail,
+      requires_corrective_action_on_fail: true,
+    }));
+
+    if (editingId) {
+      update.mutate(
+        {
+          id: editingId,
+          name: name.trim(),
+          description: description.trim() || null,
+          items: payloadItems,
+          remove_item_ids: removedIds,
         },
-      },
-    );
+        {
+          onSuccess: (res) => {
+            const kept = res.data?.kept_in_use?.length ?? 0;
+            setMsg(
+              kept > 0
+                ? `“${name.trim()}” updated — ${kept} item${kept === 1 ? "" : "s"} kept (already answered in past runs)`
+                : `“${name.trim()}” updated`,
+            );
+            resetForm();
+          },
+        },
+      );
+    } else {
+      create.mutate(
+        {
+          name: name.trim(),
+          description: description.trim() || null,
+          items: payloadItems,
+        },
+        {
+          onSuccess: () => {
+            setMsg(`Checklist “${name.trim()}” created`);
+            resetForm();
+          },
+        },
+      );
+    }
   };
 
   return (
@@ -201,18 +268,30 @@ function ChecklistsTab() {
           Checklists define the steps your team runs (assign them via My Work
           or a recurring template).
         </p>
-        <PrimaryBtn onClick={() => setCreating((v) => !v)}>
+        <PrimaryBtn
+          onClick={() => {
+            resetForm();
+            setCreating(true);
+            setMsg(null);
+          }}
+        >
           <span className="inline-flex items-center gap-1">
             <Plus className="h-4 w-4" /> New checklist
           </span>
         </PrimaryBtn>
       </div>
       <StatusLine
-        error={create.isError ? (create.error as Error).message : null}
+        error={
+          create.isError
+            ? (create.error as Error).message
+            : update.isError
+              ? (update.error as Error).message
+              : null
+        }
         success={msg}
       />
 
-      {creating && (
+      {formOpen && (
         <Card>
           <div className="grid gap-3 sm:grid-cols-2">
             <Field label="Checklist name">
@@ -271,11 +350,14 @@ function ChecklistsTab() {
                     <option value="number">Number</option>
                   </select>
                   <button
-                    onClick={() =>
-                      setItems((prev) => prev.filter((_, idx) => idx !== i))
-                    }
+                    onClick={() => removeItemAt(i)}
                     className="px-2 py-2 text-sm"
                     style={{ color: "#c1453e" }}
+                    title={
+                      it.id
+                        ? "Remove (kept in past runs if already answered)"
+                        : "Remove"
+                    }
                   >
                     ✕
                   </button>
@@ -313,15 +395,24 @@ function ChecklistsTab() {
             >
               + Add item
             </button>
+            <button
+              onClick={resetForm}
+              className="rounded-xl border px-3 py-2 text-sm font-medium"
+              style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}
+            >
+              Cancel
+            </button>
             <PrimaryBtn
               onClick={submit}
               disabled={
-                create.isPending ||
-                !name.trim() ||
-                items.every((i) => !i.prompt.trim())
+                busy || !name.trim() || items.every((i) => !i.prompt.trim())
               }
             >
-              {create.isPending ? "Creating…" : "Create checklist"}
+              {busy
+                ? "Saving…"
+                : editingId
+                  ? "Save changes"
+                  : "Create checklist"}
             </PrimaryBtn>
           </div>
         </Card>
@@ -334,8 +425,8 @@ function ChecklistsTab() {
       ) : (
         templates.map((t) => (
           <Card key={t.id}>
-            <div className="flex items-center justify-between">
-              <div>
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
                 <p className="font-semibold" style={{ color: onehub.text }}>
                   {t.name}
                 </p>
@@ -344,6 +435,13 @@ function ChecklistsTab() {
                   {t.description ? ` · ${t.description}` : ""}
                 </p>
               </div>
+              <button
+                onClick={() => startEdit(t)}
+                className="flex-shrink-0 rounded-xl border px-3 py-1.5 text-xs font-semibold"
+                style={{ borderColor: onehub.cardBorder, color: onehub.accent }}
+              >
+                ✏️ Edit
+              </button>
             </div>
             {t.items?.length ? (
               <ol

--- a/apps/web/src/hooks/useMyWork.ts
+++ b/apps/web/src/hooks/useMyWork.ts
@@ -273,3 +273,40 @@ export function useCreateChecklistTemplate() {
       queryClient.invalidateQueries({ queryKey: ["work-checklist-templates"] }),
   });
 }
+
+export interface UpdateChecklistTemplateInput {
+  id: string;
+  name?: string;
+  description?: string | null;
+  active?: boolean;
+  items?: Array<{
+    id?: string;
+    prompt: string;
+    input_type: "status" | "text" | "number";
+    mandatory: boolean;
+    allow_na: boolean;
+    requires_photo: boolean;
+    requires_photo_on_fail: boolean;
+    requires_corrective_action_on_fail: boolean;
+  }>;
+  remove_item_ids?: string[];
+}
+
+export function useUpdateChecklistTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...body }: UpdateChecklistTemplateInput) => {
+      const res = await fetch(`/api/my-work/checklist-templates/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) await throwApiError(res, "Failed to update the template");
+      return res.json() as Promise<
+        ApiResponse<{ template: WorkChecklistTemplate; kept_in_use: string[] }>
+      >;
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["work-checklist-templates"] }),
+  });
+}


### PR DESCRIPTION
Closes the R4-backlog gap the founder hit: checklists were create-only.

- PATCH /api/my-work/checklist-templates/[id]: rename/description/active; edit item prompts+flags; add items; re-sequence. Item removal only when never answered — answered items come back as kept_in_use (responses FK RESTRICTs deletion, so run history is never orphaned).
- Manage console → Checklists: ✏️ Edit opens the builder prefilled; safe-removal messaging; Cancel.

Web-only. Verified: tsc clean, lint 0 errors.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editing for existing checklist templates in the admin Checklists Builder.
  - Update template names, descriptions, active status, item details, and ordering.
  - Add or remove checklist items while preserving items referenced by past runs.
  - Added clear edit, cancel, save, and new-checklist actions with improved status feedback.
  - Updated templates refresh automatically after successful edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->