### PR TITLE
feat(onehub): Renewals & Compliance register — insurance/tax/license dates that cannot slip

### DIFF
--- a/apps/web/app/api/my-work/generate/route.ts
+++ b/apps/web/app/api/my-work/generate/route.ts
@@ -180,7 +180,128 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    return success({ date: todayISO, created, skipped, failures });
+    // ---- Renewals & Compliance register ------------------------------------
+    // Two passes: (a) roll forward entries whose renewal task was completed,
+    // (b) create a task for entries entering their reminder window.
+    let renewalsCreated = 0;
+    let renewalsRolled = 0;
+    const { data: renewals } = await supabaseAdmin
+      .from("compliance_renewals")
+      .select("*")
+      .eq("status", "active");
+
+    for (const rn of renewals ?? []) {
+      // (a) roll-forward: the generated task was completed → advance one cycle
+      if (rn.last_work_item_id) {
+        const { data: wi } = await supabaseAdmin
+          .from("work_items")
+          .select("status")
+          .eq("id", rn.last_work_item_id)
+          .maybeSingle();
+        if (wi?.status === "completed") {
+          if (rn.cycle === "one_time") {
+            await supabaseAdmin
+              .from("compliance_renewals")
+              .update({ status: "done", last_work_item_id: null })
+              .eq("id", rn.id);
+            renewalsRolled += 1;
+            continue;
+          }
+          const months =
+            rn.cycle === "yearly" ? 12 : rn.cycle === "half_yearly" ? 6 : rn.cycle === "quarterly" ? 3 : 1;
+          const next = new Date(`${rn.due_date}T00:00:00Z`);
+          next.setUTCMonth(next.getUTCMonth() + months);
+          await supabaseAdmin
+            .from("compliance_renewals")
+            .update({
+              due_date: next.toISOString().slice(0, 10),
+              last_generated_for: null,
+              last_work_item_id: null,
+            })
+            .eq("id", rn.id);
+          renewalsRolled += 1;
+          continue;
+        }
+      }
+
+      // (b) inside the reminder window and not yet generated for this due date
+      const windowStart = new Date(`${rn.due_date}T00:00:00Z`);
+      windowStart.setUTCDate(windowStart.getUTCDate() - rn.remind_days_before);
+      const inWindow = istDate.getTime() >= windowStart.getTime();
+      if (!inWindow || rn.last_generated_for === rn.due_date) continue;
+
+      // Assignee: the entry's owner, else every founder/owner
+      let assignees: string[] = [];
+      if (rn.owner_user_id) {
+        assignees = [rn.owner_user_id];
+      } else {
+        const { data: bosses } = await supabaseAdmin
+          .from("users")
+          .select("id")
+          .in("role", ["founder", "owner"])
+          .eq("is_active", true);
+        assignees = (bosses ?? []).map((u) => u.id);
+      }
+      if (!assignees.length) {
+        failures.push(`renewal ${rn.name}: no assignee`);
+        continue;
+      }
+
+      const overdue = rn.due_date < todayISO;
+      const dueLabel = new Date(`${rn.due_date}T00:00:00Z`).toLocaleDateString("en-IN", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+        timeZone: "UTC",
+      });
+      const { data: item, error: insErr } = await supabaseAdmin
+        .from("work_items")
+        .insert({
+          title: `Renew: ${rn.name} — due ${dueLabel}`,
+          description: rn.notes,
+          instructions: rn.document_url ? `Document: ${rn.document_url}` : null,
+          activity_type: "simple",
+          status: "pending",
+          priority: overdue ? "urgent" : "high",
+          assigned_user_id: assignees[0],
+          assigned_by_user_id: null,
+          due_at: new Date(`${rn.due_date}T18:00:00+05:30`).toISOString(),
+          requires_photo: false,
+          requires_note: true, // record policy no. / receipt reference
+          requires_approval: true,
+          related_label: `renewal · ${rn.category}`,
+          source_module: "renewal",
+          source_record_id: rn.id,
+          scheduled_date: todayISO,
+        })
+        .select("*")
+        .single();
+      if (insErr || !item) {
+        failures.push(`renewal ${rn.name}: item create failed`);
+        continue;
+      }
+      await supabaseAdmin
+        .from("compliance_renewals")
+        .update({ last_generated_for: rn.due_date, last_work_item_id: item.id })
+        .eq("id", rn.id);
+      renewalsCreated += 1;
+      await logWorkEvent({
+        work_item_id: item.id,
+        event_type: "created",
+        new_status: "pending",
+        performed_by: null,
+        metadata: { source: "renewal", renewal_id: rn.id },
+      });
+      void notifyWorkAssigned(item as WorkItem);
+    }
+
+    return success({
+      date: todayISO,
+      created,
+      skipped,
+      failures,
+      renewals: { created: renewalsCreated, rolled_forward: renewalsRolled },
+    });
   } catch (err) {
     console.error("[MyWork] generate failed:", err);
     return error("Generation failed", 500);

--- a/apps/web/app/api/renewals/route.ts
+++ b/apps/web/app/api/renewals/route.ts
@@ -1,0 +1,85 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+/** Who may add/edit renewals (viewing is open to all staff). */
+const EDIT_ROLES = ["founder", "owner", "production_supervisor", "accountant"];
+
+const renewalSchema = z.object({
+  id: z.string().uuid().optional(), // present = update
+  name: z.string().min(2),
+  category: z
+    .enum(["insurance", "tax", "license", "vehicle", "amc", "other"])
+    .default("other"),
+  due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  cycle: z
+    .enum(["yearly", "half_yearly", "quarterly", "monthly", "one_time"])
+    .default("yearly"),
+  remind_days_before: z.number().int().min(0).max(180).default(30),
+  owner_user_id: z.string().uuid().nullable().optional(),
+  document_url: z
+    .string()
+    .url()
+    .nullable()
+    .optional()
+    .or(z.literal("").transform(() => null)),
+  notes: z.string().nullable().optional(),
+  status: z.enum(["active", "done", "archived"]).default("active"),
+});
+
+// GET /api/renewals — the register, soonest due first (any authenticated user)
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+    const { data, error: dbErr } = await supabaseAdmin
+      .from("compliance_renewals")
+      .select("*, owner:users!compliance_renewals_owner_user_id_fkey(id, name)")
+      .neq("status", "archived")
+      .order("due_date", { ascending: true });
+    if (dbErr) return error("Failed to load renewals", 500);
+    return success(data ?? []);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("renewals GET failed:", err);
+    return error("Failed to load renewals", 500);
+  }
+}
+
+// POST /api/renewals — create/update an entry (leadership/supervisor/accounts)
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!EDIT_ROLES.includes(user.role)) {
+      return error("You do not have permission to manage renewals", 403);
+    }
+    const parsed = await parseBody(request, renewalSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const result = id
+      ? await supabaseAdmin
+          .from("compliance_renewals")
+          .update(fields)
+          .eq("id", id)
+          .select("*")
+          .single()
+      : await supabaseAdmin
+          .from("compliance_renewals")
+          .insert({ ...fields, created_by: user.id })
+          .select("*")
+          .single();
+
+    if (result.error || !result.data) {
+      return error(`Failed to save renewal: ${result.error?.message}`, 500);
+    }
+    return success(result.data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("renewals POST failed:", err);
+    return error("Failed to save renewal", 500);
+  }
+}

--- a/apps/web/app/onehub/RenewalsCard.tsx
+++ b/apps/web/app/onehub/RenewalsCard.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+/**
+ * Renewals & Compliance register — visible to everyone on the OneHub page:
+ * 🔴 overdue → 🟠 due soon → ⚪ upcoming, so leadership can act in advance.
+ * Leadership/supervisor/accounts can add & edit inline. The daily generator
+ * turns each entry into an assigned My Work task `remind_days_before` its
+ * due date and rolls the date forward when the task is completed+approved.
+ */
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CalendarClock, Plus } from "lucide-react";
+import { useAuthStore } from "@/stores/authStore";
+import { onehub } from "./theme";
+
+const EDIT_ROLES = ["founder", "owner", "production_supervisor", "accountant"];
+
+const CATEGORIES = [
+  { value: "insurance", label: "Insurance", emoji: "🛡️" },
+  { value: "tax", label: "Tax / GST", emoji: "🧾" },
+  { value: "license", label: "License", emoji: "📜" },
+  { value: "vehicle", label: "Vehicle", emoji: "🚚" },
+  { value: "amc", label: "AMC / Service", emoji: "🔧" },
+  { value: "other", label: "Other", emoji: "📌" },
+] as const;
+
+const CYCLES = [
+  { value: "yearly", label: "Yearly" },
+  { value: "half_yearly", label: "Half-yearly" },
+  { value: "quarterly", label: "Quarterly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "one_time", label: "One-time" },
+] as const;
+
+interface Renewal {
+  id: string;
+  name: string;
+  category: (typeof CATEGORIES)[number]["value"];
+  due_date: string;
+  cycle: (typeof CYCLES)[number]["value"];
+  remind_days_before: number;
+  owner_user_id: string | null;
+  document_url: string | null;
+  notes: string | null;
+  status: "active" | "done" | "archived";
+  owner?: { id: string; name: string | null } | null;
+}
+
+interface Staff {
+  id: string;
+  name: string | null;
+  email: string;
+  is_active?: boolean;
+}
+
+function daysLeft(dueISO: string): number {
+  const today = new Date(
+    new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" }) +
+      "T00:00:00Z",
+  );
+  const due = new Date(`${dueISO}T00:00:00Z`);
+  return Math.round((due.getTime() - today.getTime()) / 86400000);
+}
+
+const inputCls =
+  "w-full rounded-xl border px-3 py-2 text-sm outline-none";
+const inputStyle = { borderColor: onehub.cardBorder, color: onehub.text };
+
+export function RenewalsCard() {
+  const { user } = useAuthStore();
+  const canEdit = EDIT_ROLES.includes(user?.role ?? "");
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["renewals"],
+    queryFn: async () => {
+      const res = await fetch("/api/renewals");
+      if (!res.ok) throw new Error("Failed to load renewals");
+      return res.json() as Promise<{ data: Renewal[] }>;
+    },
+  });
+
+  const { data: staffData } = useQuery({
+    queryKey: ["admin-staff"],
+    queryFn: async () => {
+      const res = await fetch("/api/users");
+      if (!res.ok) throw new Error("Failed to load staff");
+      return res.json() as Promise<{ data: Staff[] }>;
+    },
+    enabled: canEdit,
+  });
+
+  const save = useMutation({
+    mutationFn: async (input: Partial<Renewal>) => {
+      const res = await fetch("/api/renewals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error || "Failed to save");
+      return body;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["renewals"] }),
+  });
+
+  const [editing, setEditing] = useState<Partial<Renewal> | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const renewals = (data?.data ?? []).filter((r) => r.status === "active");
+  const groups = useMemo(() => {
+    const overdue = renewals.filter((r) => daysLeft(r.due_date) < 0);
+    const soon = renewals.filter((r) => {
+      const d = daysLeft(r.due_date);
+      return d >= 0 && d <= Math.max(r.remind_days_before, 60);
+    });
+    const upcoming = renewals.filter(
+      (r) => daysLeft(r.due_date) > Math.max(r.remind_days_before, 60),
+    );
+    return { overdue, soon, upcoming };
+  }, [renewals]);
+
+  const startNew = () =>
+    setEditing({
+      name: "",
+      category: "insurance",
+      due_date: "",
+      cycle: "yearly",
+      remind_days_before: 30,
+      owner_user_id: null,
+      document_url: "",
+      notes: "",
+      status: "active",
+    });
+
+  const submit = () => {
+    if (!editing?.name?.trim() || !/^\d{4}-\d{2}-\d{2}$/.test(editing.due_date ?? "")) return;
+    save.mutate(
+      {
+        ...(editing.id ? { id: editing.id } : {}),
+        name: editing.name.trim(),
+        category: editing.category,
+        due_date: editing.due_date,
+        cycle: editing.cycle,
+        remind_days_before: editing.remind_days_before ?? 30,
+        owner_user_id: editing.owner_user_id || null,
+        document_url: editing.document_url?.trim() || null,
+        notes: editing.notes?.trim() || null,
+        status: editing.status ?? "active",
+      },
+      {
+        onSuccess: () => {
+          setMsg(`“${editing.name?.trim()}” saved — reminder task will appear ${editing.remind_days_before ?? 30} days before due`);
+          setEditing(null);
+        },
+      },
+    );
+  };
+
+  const Row = ({ r, tone }: { r: Renewal; tone: "bad" | "warn" | "ok" }) => {
+    const d = daysLeft(r.due_date);
+    const cat = CATEGORIES.find((c) => c.value === r.category);
+    const toneStyle =
+      tone === "bad"
+        ? { bg: "#fbe4df", fg: "#c1453e" }
+        : tone === "warn"
+          ? { bg: "#f8ecd4", fg: "#b3781a" }
+          : { bg: "#e4f1e3", fg: "#3f7d4d" };
+    return (
+      <div className="flex items-center gap-3 rounded-xl px-2 py-2.5">
+        <span className="shrink-0 text-base">{cat?.emoji ?? "📌"}</span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium" style={{ color: onehub.text }}>
+            {r.name}
+            {r.document_url ? (
+              <a
+                href={r.document_url}
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 text-xs underline"
+                style={{ color: onehub.accent }}
+              >
+                doc
+              </a>
+            ) : null}
+          </p>
+          <p className="text-xs" style={{ color: onehub.textMuted }}>
+            {new Date(`${r.due_date}T00:00:00Z`).toLocaleDateString("en-IN", {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+              timeZone: "UTC",
+            })}
+            {" · "}
+            {CYCLES.find((c) => c.value === r.cycle)?.label}
+            {r.owner?.name ? ` · ${r.owner.name}` : ""}
+          </p>
+        </div>
+        <span
+          className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold"
+          style={{ background: toneStyle.bg, color: toneStyle.fg }}
+        >
+          {d < 0 ? `${-d}d overdue` : d === 0 ? "today" : `in ${d}d`}
+        </span>
+        {canEdit && (
+          <button
+            onClick={() => setEditing(r)}
+            className="shrink-0 text-xs font-semibold"
+            style={{ color: onehub.accent }}
+          >
+            Edit
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="mt-6">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-4 w-4" style={{ color: onehub.brand }} />
+          <h3 className="font-serif text-lg font-bold" style={{ color: onehub.brand }}>
+            Renewals &amp; Compliance
+          </h3>
+        </div>
+        {canEdit && (
+          <button
+            onClick={startNew}
+            className="flex items-center gap-1 rounded-xl px-3 py-1.5 text-xs font-semibold text-white"
+            style={{ background: onehub.accent }}
+          >
+            <Plus className="h-3.5 w-3.5" /> Add renewal
+          </button>
+        )}
+      </div>
+
+      {msg && (
+        <p className="mb-2 text-xs" style={{ color: "#3f7d4d" }}>
+          {msg}
+        </p>
+      )}
+      {save.isError && (
+        <p className="mb-2 text-xs" style={{ color: "#c1453e" }}>
+          {(save.error as Error).message}
+        </p>
+      )}
+
+      {editing && (
+        <div
+          className="mb-3 rounded-2xl border bg-white p-4"
+          style={{ borderColor: onehub.cardBorder }}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>
+                What needs renewing
+              </span>
+              <input className={inputCls} style={inputStyle} value={editing.name ?? ""} onChange={(e) => setEditing((p) => ({ ...p!, name: e.target.value }))} placeholder="e.g. Factory insurance — United India" />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Category</span>
+              <select className={inputCls} style={inputStyle} value={editing.category} onChange={(e) => setEditing((p) => ({ ...p!, category: e.target.value as Renewal["category"] }))}>
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.emoji} {c.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Due / expiry date</span>
+              <input className={inputCls} style={inputStyle} type="date" value={editing.due_date ?? ""} onChange={(e) => setEditing((p) => ({ ...p!, due_date: e.target.value }))} />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Repeats</span>
+              <select className={inputCls} style={inputStyle} value={editing.cycle} onChange={(e) => setEditing((p) => ({ ...p!, cycle: e.target.value as Renewal["cycle"] }))}>
+                {CYCLES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Remind days before</span>
+              <input className={inputCls} style={inputStyle} type="number" min={0} max={180} value={editing.remind_days_before ?? 30} onChange={(e) => setEditing((p) => ({ ...p!, remind_days_before: Number(e.target.value) || 0 }))} />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Owner (gets the task)</span>
+              <select className={inputCls} style={inputStyle} value={editing.owner_user_id ?? ""} onChange={(e) => setEditing((p) => ({ ...p!, owner_user_id: e.target.value || null }))}>
+                <option value="">Founders (default)</option>
+                {(staffData?.data ?? [])
+                  .filter((s) => s.is_active !== false)
+                  .map((s) => (
+                    <option key={s.id} value={s.id}>{s.name ?? s.email}</option>
+                  ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Document link (optional)</span>
+              <input className={inputCls} style={inputStyle} value={editing.document_url ?? ""} onChange={(e) => setEditing((p) => ({ ...p!, document_url: e.target.value }))} placeholder="https://drive.google.com/…" />
+            </label>
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Notes (optional)</span>
+              <input className={inputCls} style={inputStyle} value={editing.notes ?? ""} onChange={(e) => setEditing((p) => ({ ...p!, notes: e.target.value }))} placeholder="Policy number, agent contact…" />
+            </label>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button onClick={() => setEditing(null)} className="rounded-xl border px-3 py-2 text-sm" style={{ borderColor: onehub.cardBorder, color: onehub.textMuted }}>
+              Cancel
+            </button>
+            {editing.id && (
+              <button
+                onClick={() => {
+                  setEditing((p) => ({ ...p!, status: "archived" }));
+                  save.mutate(
+                    { id: editing.id, name: editing.name, category: editing.category, due_date: editing.due_date, cycle: editing.cycle, remind_days_before: editing.remind_days_before, owner_user_id: editing.owner_user_id || null, status: "archived" },
+                    { onSuccess: () => { setMsg("Archived"); setEditing(null); } },
+                  );
+                }}
+                className="rounded-xl border px-3 py-2 text-sm"
+                style={{ borderColor: "#e5c8c2", color: "#c1453e" }}
+              >
+                Archive
+              </button>
+            )}
+            <button
+              onClick={submit}
+              disabled={save.isPending || !editing.name?.trim() || !/^\d{4}-\d{2}-\d{2}$/.test(editing.due_date ?? "")}
+              className="rounded-xl px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              style={{ background: onehub.accent }}
+            >
+              {save.isPending ? "Saving…" : "Save renewal"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div
+        className="rounded-2xl border bg-white p-2"
+        style={{ borderColor: onehub.cardBorder }}
+      >
+        {isLoading ? (
+          <p className="px-2 py-3 text-sm" style={{ color: onehub.textMuted }}>Loading…</p>
+        ) : renewals.length === 0 ? (
+          <p className="px-2 py-3 text-sm" style={{ color: onehub.textMuted }}>
+            No renewals tracked yet{canEdit ? " — add your insurance, tax and license dates so nothing slips." : "."}
+          </p>
+        ) : (
+          <>
+            {groups.overdue.length > 0 && (
+              <p className="px-2 pt-2 text-[10px] font-bold uppercase tracking-wider" style={{ color: "#c1453e" }}>Overdue</p>
+            )}
+            {groups.overdue.map((r) => <Row key={r.id} r={r} tone="bad" />)}
+            {groups.soon.length > 0 && (
+              <p className="px-2 pt-2 text-[10px] font-bold uppercase tracking-wider" style={{ color: "#b3781a" }}>Due soon</p>
+            )}
+            {groups.soon.map((r) => <Row key={r.id} r={r} tone="warn" />)}
+            {groups.upcoming.length > 0 && (
+              <p className="px-2 pt-2 text-[10px] font-bold uppercase tracking-wider" style={{ color: onehub.textMuted }}>Upcoming</p>
+            )}
+            {groups.upcoming.map((r) => <Row key={r.id} r={r} tone="ok" />)}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/onehub/page.tsx
+++ b/apps/web/app/onehub/page.tsx
@@ -24,6 +24,7 @@ import {
   Youtube,
 } from "lucide-react";
 import { onehub } from "./theme";
+import { RenewalsCard } from "./RenewalsCard";
 
 /* ------------------------------------------------------------------ types */
 type Sop = {
@@ -307,6 +308,7 @@ export default function OneHubPage() {
 
         <section id="reminders" className="scroll-mt-24">
           <RemindersCard />
+          <RenewalsCard />
         </section>
       </div>
 

--- a/supabase/migrations/20260712120000_renewals.sql
+++ b/supabase/migrations/20260712120000_renewals.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- Renewals & Compliance register — long-horizon dated obligations (insurance,
+-- tax filings, licenses, vehicle FC, AMCs). The daily My Work generator turns
+-- each entry into an assigned, approval-gated work item `remind_days_before`
+-- its due date, then rolls the date forward one cycle on completion.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.compliance_renewals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'other'
+    CHECK (category IN ('insurance', 'tax', 'license', 'vehicle', 'amc', 'other')),
+  due_date DATE NOT NULL,
+  cycle TEXT NOT NULL DEFAULT 'yearly'
+    CHECK (cycle IN ('yearly', 'half_yearly', 'quarterly', 'monthly', 'one_time')),
+  remind_days_before INTEGER NOT NULL DEFAULT 30 CHECK (remind_days_before BETWEEN 0 AND 180),
+  owner_user_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  document_url TEXT,
+  notes TEXT,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'done', 'archived')),
+  -- idempotency: which due_date we already generated a work item for
+  last_generated_for DATE,
+  last_work_item_id UUID REFERENCES public.work_items(id) ON DELETE SET NULL,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_renewals_due
+  ON public.compliance_renewals (due_date) WHERE status = 'active';
+
+ALTER TABLE public.compliance_renewals ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "auth read renewals" ON public.compliance_renewals
+  FOR SELECT TO authenticated USING (true);
+
+-- updated_at trigger (reuses the shared helper if present, else defines it)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+DROP TRIGGER IF EXISTS trg_compliance_renewals_updated_at ON public.compliance_renewals;
+CREATE TRIGGER trg_compliance_renewals_updated_at
+  BEFORE UPDATE ON public.compliance_renewals
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
The no-code-DB alternative, built on existing rails.

- compliance_renewals table (already applied to prod): category, due date, cycle (yearly→one-time), remind-days-before, owner, doc link
- /api/renewals GET (all staff) / POST (leadership+accounts)
- Daily generator: entries entering their reminder window auto-create an assigned, approval-gated My Work task with push; completion rolls the due date forward one cycle (one-time entries close)
- OneHub page, Reminders section: full register visible to everyone — Overdue / Due soon / Upcoming with days-left chips; inline Add/Edit/Archive for leadership+accounts

Web-only; verified tsc clean.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a renewals and compliance register to track recurring obligations, due dates, reminders, owners, and statuses.
  * Added renewal management to OneHub, including overdue, due soon, and upcoming views.
  * Authorized users can create, edit, and archive renewal records.
  * Renewals can automatically generate assigned work items and advance recurring due dates after completion.
  * Added renewal summary details to work-generation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->