### PR TITLE
feat: OpenProject bridge — planning cockpit ↔ My Work phone queue

### DIFF
--- a/.claude/skills/maiyuri-architecture/SKILL.md
+++ b/.claude/skills/maiyuri-architecture/SKILL.md
@@ -215,7 +215,21 @@ Overlaps conceptually with My Work approvals — unifying is on the backlog.
 `/api/knowledge/ask` (language-aware Q&A), `/gaps`, `/pending`, `/scrape`.
 Auto-ingests call transcripts + published SOPs.
 
-### 3.13 Dashboards & Settings
+### 3.13 OpenProject bridge  (`src/lib/openproject.ts`)
+OpenProject (self-hosted at `op.maiyuri.com` via Cloudflare Tunnel from the
+founder's PC, container port 8080) = the founder's PLANNING cockpit (Gantt,
+dependencies). My Work stays the ONE staff queue. The bridge
+(`/api/cron/openproject-sync`, every 30 min): open assigned work packages →
+`work_items` (`source_module='openproject'`, `source_record_id=<wp id>`,
+assignee matched by email, push notification); title/due edits flow through;
+WPs closed in OP cancel the local item; items COMPLETED in the app close the
+WP + leave a completion comment. Env: `OPENPROJECT_URL`,
+`OPENPROJECT_API_KEY` (Basic auth, username literally `apikey`).
+**The tunnel host is a PC that sleeps** — the sync treats unreachable as a
+graceful skip (no alert); alerts mean real bugs. OP-derived tasks surface in
+the Daily Report through the existing Tasks tile (they ARE work_items).
+
+### 3.14 Dashboards & Settings
 - Multiple overlapping dashboards exist (dashboard, kpi, business-health,
   observability, analytics, daily-report) — consultant audit flagged
   consolidation onto Daily Report as the founder home.
@@ -245,6 +259,7 @@ UTC+5:30).
 | `plan-reminder` | — | evening | plan reminder | "update Odoo/plan" nudge |
 | `db-backup` | 21:00 | 02:30 | pg_dump (docker) | 30-day artifact |
 | `e2e` | 05:00 + post-push | 10:30 | Playwright smoke | read-only prod regression net |
+| `openproject-sync` | */30 | every 30 min | /api/cron/openproject-sync | OP work packages ↔ My Work bridge |
 
 Other CI: `ci.yml` (Code Quality — required check: typecheck+lint+test via
 turbo), `native-ci.yml` (native typecheck), `release.yml`, `android-apk.yml`,

--- a/.github/workflows/openproject-sync.yml
+++ b/.github/workflows/openproject-sync.yml
@@ -1,0 +1,32 @@
+name: OpenProject bridge sync
+
+# Every 30 min: open assigned work packages → My Work items (with push),
+# app completions → close the package + comment. The endpoint absorbs the
+# tunnel-host-offline case as a graceful skip, so a failure here means a
+# real bug — hence the alert.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger OpenProject sync
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/cron/openproject-sync")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/apps/web/app/api/cron/openproject-sync/route.ts
+++ b/apps/web/app/api/cron/openproject-sync/route.ts
@@ -1,0 +1,241 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { notifyWorkAssigned } from "@/lib/my-work-notify";
+import {
+  closeWorkPackage,
+  commentOnWorkPackage,
+  fetchClosedStatusHref,
+  fetchOpenAssignedWorkPackages,
+  fetchUserEmail,
+  isOpenProjectConfigured,
+  isUnreachableError,
+  type OpWorkPackage,
+} from "@/lib/openproject";
+import type { WorkItem } from "@maiyuri/shared";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+const OP_URL = process.env.OPENPROJECT_URL?.replace(/\/$/, "");
+
+/**
+ * POST /api/cron/openproject-sync — the OpenProject ↔ My Work bridge.
+ *
+ * OpenProject = the founder's planning cockpit (Gantt, dependencies).
+ * My Work    = the ONE queue staff see on their phones.
+ *
+ * Pass A (OP → phones): every open, assigned work package becomes a
+ *   work_item for the matching app user (matched by email), with a push
+ *   notification. Idempotent via source_module='openproject' +
+ *   source_record_id=<wp id>. Title/due changes flow through; packages
+ *   closed in OP cancel their local item.
+ *
+ * Pass B (phones → OP): work_items COMPLETED in the app whose package is
+ *   still open in OP get the package closed + a completion comment — the
+ *   Gantt updates itself from field reality.
+ *
+ * The OP host is a PC behind a Cloudflare tunnel and is often OFF. That is
+ * a normal state: we return success with skipped=true so the workflow's
+ * failure alert only fires on real bugs.
+ */
+
+const PRIORITY_MAP: Record<string, string> = {
+  low: "low",
+  normal: "medium",
+  high: "high",
+  immediate: "urgent",
+};
+
+function dueAtFromOp(dueDate: string | null): string | null {
+  // OP due dates are plain days; anchor to 18:00 IST like manual assignments.
+  return dueDate ? new Date(`${dueDate}T18:00:00+05:30`).toISOString() : null;
+}
+
+function wpUrl(id: number): string {
+  return `${OP_URL}/work_packages/${id}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+  if (!isOpenProjectConfigured()) {
+    return success({ skipped: true, reason: "OpenProject not configured" });
+  }
+
+  try {
+    // ---- Pull the open, assigned packages ----
+    let packages: OpWorkPackage[];
+    try {
+      packages = await fetchOpenAssignedWorkPackages();
+    } catch (err) {
+      if (isUnreachableError(err)) {
+        return success({
+          skipped: true,
+          reason: "OpenProject unreachable (tunnel host offline?)",
+        });
+      }
+      throw err;
+    }
+
+    // ---- Resolve assignee emails (cache per user href) ----
+    const emailByHref = new Map<string, string | null>();
+    for (const wp of packages) {
+      const href = wp._links.assignee?.href;
+      if (href && !emailByHref.has(href)) {
+        emailByHref.set(href, await fetchUserEmail(href));
+      }
+    }
+
+    // ---- App users by email ----
+    const { data: users } = await supabaseAdmin
+      .from("users")
+      .select("id, email, role, is_active")
+      .eq("is_active", true);
+    const userByEmail = new Map(
+      (users ?? []).map((u) => [String(u.email).toLowerCase(), u]),
+    );
+    const assigner =
+      (users ?? []).find((u) => u.role === "founder") ??
+      (users ?? []).find((u) => u.role === "owner");
+
+    // ---- Existing bridged items ----
+    const { data: existingRows } = await supabaseAdmin
+      .from("work_items")
+      .select(
+        "id, source_record_id, status, title, due_at, note, completed_at, assigned_user_id",
+      )
+      .eq("source_module", "openproject");
+    const existingByWp = new Map(
+      (existingRows ?? []).map((r) => [String(r.source_record_id), r]),
+    );
+    const openWpIds = new Set(packages.map((wp) => String(wp.id)));
+
+    let created = 0;
+    let updated = 0;
+    let unmatchedAssignees = 0;
+
+    // ---- Pass A: OP → work_items ----
+    for (const wp of packages) {
+      const href = wp._links.assignee?.href;
+      const email = href ? emailByHref.get(href) : null;
+      const appUser = email ? userByEmail.get(email.toLowerCase()) : undefined;
+      if (!appUser) {
+        unmatchedAssignees++;
+        continue; // assignee has no active app account — planning-only package
+      }
+
+      const existing = existingByWp.get(String(wp.id));
+      const due_at = dueAtFromOp(wp.dueDate);
+      const priority =
+        PRIORITY_MAP[(wp._links.priority?.title ?? "").toLowerCase()] ?? "medium";
+
+      if (!existing) {
+        const { data: item, error: insErr } = await supabaseAdmin
+          .from("work_items")
+          .insert({
+            title: wp.subject,
+            description: [
+              wp.description?.raw?.trim() || null,
+              `OpenProject: ${wpUrl(wp.id)}`,
+            ]
+              .filter(Boolean)
+              .join("\n\n"),
+            activity_type: "simple",
+            priority,
+            status: "pending",
+            assigned_user_id: appUser.id,
+            assigned_by_user_id: assigner?.id ?? appUser.id,
+            due_at,
+            related_label: wp._links.project.title ?? "OpenProject",
+            source_module: "openproject",
+            source_record_id: String(wp.id),
+          })
+          .select("*")
+          .single();
+        if (insErr || !item) {
+          console.error("[OPSync] insert failed for wp", wp.id, insErr);
+          continue;
+        }
+        created++;
+        try {
+          await notifyWorkAssigned(item as WorkItem);
+        } catch (nErr) {
+          console.error("[OPSync] notify failed:", nErr);
+        }
+      } else if (
+        (existing.status === "pending" || existing.status === "in_progress") &&
+        (existing.title !== wp.subject || existing.due_at !== due_at)
+      ) {
+        const { error: updErr } = await supabaseAdmin
+          .from("work_items")
+          .update({ title: wp.subject, due_at, updated_at: new Date().toISOString() })
+          .eq("id", existing.id);
+        if (!updErr) updated++;
+      }
+    }
+
+    // ---- Pass A2: closed in OP → cancel local open items ----
+    let cancelled = 0;
+    for (const row of existingRows ?? []) {
+      if (
+        !openWpIds.has(String(row.source_record_id)) &&
+        (row.status === "pending" || row.status === "in_progress")
+      ) {
+        const { error: cErr } = await supabaseAdmin
+          .from("work_items")
+          .update({
+            status: "cancelled",
+            cancelled_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", row.id);
+        if (!cErr) cancelled++;
+      }
+    }
+
+    // ---- Pass B: completed locally → close the OP package ----
+    let closedInOp = 0;
+    const toClose = (existingRows ?? []).filter(
+      (r) => r.status === "completed" && openWpIds.has(String(r.source_record_id)),
+    );
+    if (toClose.length) {
+      const closedHref = await fetchClosedStatusHref();
+      if (closedHref) {
+        const wpById = new Map(packages.map((wp) => [String(wp.id), wp]));
+        for (const row of toClose) {
+          const wp = wpById.get(String(row.source_record_id))!;
+          try {
+            await commentOnWorkPackage(
+              wp.id,
+              `✅ Completed in Maiyuri app on ${row.completed_at ?? "unknown date"}` +
+                (row.note ? ` — note: ${row.note}` : ""),
+            );
+            await closeWorkPackage(wp.id, wp.lockVersion, closedHref);
+            closedInOp++;
+          } catch (wErr) {
+            // lockVersion races just retry next cycle.
+            console.error("[OPSync] close failed for wp", wp.id, wErr);
+          }
+        }
+      }
+    }
+
+    return success({
+      packages: packages.length,
+      created,
+      updated,
+      cancelled,
+      closed_in_op: closedInOp,
+      unmatched_assignees: unmatchedAssignees,
+    });
+  } catch (err) {
+    console.error("[OPSync] failed:", err);
+    return error(err instanceof Error ? err.message : "OpenProject sync failed", 500);
+  }
+}

--- a/apps/web/src/lib/openproject.ts
+++ b/apps/web/src/lib/openproject.ts
@@ -1,0 +1,175 @@
+/**
+ * OpenProject API v3 client — the founder's project-planning cockpit
+ * (Gantt/dependencies at op.maiyuri.com) bridged to My Work (the staff
+ * execution queue on phones).
+ *
+ * Env (Vercel):
+ *   OPENPROJECT_URL      e.g. https://op.maiyuri.com
+ *   OPENPROJECT_API_KEY  personal access token (My account → Access tokens)
+ *
+ * Auth is HTTP Basic with the literal username "apikey".
+ *
+ * IMPORTANT: OpenProject is self-hosted behind a Cloudflare tunnel on a PC
+ * that is not always on. Callers must treat network failure as a NORMAL
+ * state (skip, don't alert) — see isUnreachableError().
+ */
+
+const OP_URL = process.env.OPENPROJECT_URL?.replace(/\/$/, "");
+const OP_KEY = process.env.OPENPROJECT_API_KEY;
+
+export function isOpenProjectConfigured(): boolean {
+  return Boolean(OP_URL && OP_KEY);
+}
+
+export class OpenProjectUnreachable extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "OpenProjectUnreachable";
+  }
+}
+
+export function isUnreachableError(err: unknown): boolean {
+  return (
+    err instanceof OpenProjectUnreachable ||
+    (err instanceof Error &&
+      /fetch failed|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|aborted|network|502|503|521|522|530/i.test(
+        err.message,
+      ))
+  );
+}
+
+async function opFetch<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  if (!OP_URL || !OP_KEY) throw new Error("OpenProject not configured");
+  const auth = Buffer.from(`apikey:${OP_KEY}`).toString("base64");
+
+  // Short timeout: when the tunnel host is asleep Cloudflare hangs then 5xxs;
+  // fail fast so the 30-min sync doesn't burn its runtime.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  let res: Response;
+  try {
+    res = await fetch(`${OP_URL}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+      signal: controller.signal,
+      cache: "no-store",
+    });
+  } catch (err) {
+    throw new OpenProjectUnreachable(
+      err instanceof Error ? err.message : "network error",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+  // Cloudflare's tunnel-offline pages are 5xx with HTML bodies.
+  if (res.status >= 502) {
+    throw new OpenProjectUnreachable(`OpenProject gateway ${res.status}`);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`OpenProject ${res.status} on ${path}: ${body.slice(0, 300)}`);
+  }
+  return (await res.json()) as T;
+}
+
+// ---------------------------------------------------------------- types
+
+export interface OpWorkPackage {
+  id: number;
+  lockVersion: number;
+  subject: string;
+  dueDate: string | null; // YYYY-MM-DD
+  description?: { raw?: string | null };
+  _links: {
+    status: { href: string; title?: string };
+    assignee?: { href: string | null; title?: string } | null;
+    project: { href: string; title?: string };
+    priority?: { href: string; title?: string };
+  };
+}
+
+interface OpCollection<T> {
+  total: number;
+  _embedded: { elements: T[] };
+}
+
+export interface OpStatus {
+  id: number;
+  name: string;
+  isClosed: boolean;
+  _links: { self: { href: string } };
+}
+
+// ---------------------------------------------------------------- reads
+
+/**
+ * All OPEN work packages that have an assignee, across projects.
+ * (operator "o" = open statuses; "!*" would be unassigned — we require one.)
+ */
+export async function fetchOpenAssignedWorkPackages(): Promise<OpWorkPackage[]> {
+  const filters = encodeURIComponent(
+    JSON.stringify([
+      { status: { operator: "o", values: [] } },
+      { assignee: { operator: "*", values: [] } },
+    ]),
+  );
+  const data = await opFetch<OpCollection<OpWorkPackage>>(
+    `/api/v3/work_packages?filters=${filters}&pageSize=200`,
+  );
+  return data._embedded.elements;
+}
+
+/** Resolve an assignee href (/api/v3/users/N) to the user's email. Cached per call site. */
+export async function fetchUserEmail(userHref: string): Promise<string | null> {
+  try {
+    const u = await opFetch<{ email?: string | null; login?: string | null }>(
+      userHref,
+    );
+    return u.email ?? null;
+  } catch (err) {
+    if (isUnreachableError(err)) throw err;
+    return null; // e.g. hidden email — skip this assignee
+  }
+}
+
+/** First closed status (usually "Closed") — used to complete work packages. */
+export async function fetchClosedStatusHref(): Promise<string | null> {
+  const data = await opFetch<OpCollection<OpStatus>>(`/api/v3/statuses`);
+  const closed = data._embedded.elements.find((s) => s.isClosed);
+  return closed?._links.self.href ?? null;
+}
+
+// ---------------------------------------------------------------- writes
+
+/** Close a work package (status → closed) with optimistic locking. */
+export async function closeWorkPackage(
+  wpId: number,
+  lockVersion: number,
+  closedStatusHref: string,
+): Promise<void> {
+  await opFetch(`/api/v3/work_packages/${wpId}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      lockVersion,
+      _links: { status: { href: closedStatusHref } },
+    }),
+  });
+}
+
+/** Comment on a work package (activity journal). */
+export async function commentOnWorkPackage(
+  wpId: number,
+  text: string,
+): Promise<void> {
+  await opFetch(`/api/v3/work_packages/${wpId}/activities`, {
+    method: "POST",
+    body: JSON.stringify({ comment: { raw: text } }),
+  });
+}

--- a/docs/OPENPROJECT_TUNNEL.md
+++ b/docs/OPENPROJECT_TUNNEL.md
@@ -1,0 +1,78 @@
+# OpenProject @ op.maiyuri.com — tunnel runbook
+
+OpenProject runs in Docker on the founder's PC (all-in-one image, port 8080,
+bundled PG + memcached). It is published to the internet as
+`https://op.maiyuri.com` through a **Cloudflare Tunnel** — no port
+forwarding, no router changes. maiyuri.com's DNS is already on Cloudflare,
+so the subdomain mapping is instant.
+
+The app bridge (see `/api/cron/openproject-sync` + the maiyuri-architecture
+skill §3.13) treats "tunnel host offline" as a normal state — the sync skips
+quietly when this PC is asleep and catches up on the next 30-min tick.
+
+## One-time setup (~15 min)
+
+### 0. Start Docker the safe way (this PC only)
+This machine leaves undeletable socket files behind. **Always** run
+`Start-Docker-Clean.ps1` before starting Docker Desktop, then bring
+OpenProject up and confirm `http://localhost:8080` answers.
+
+### 1. Create the tunnel (Cloudflare dashboard)
+1. <https://one.dash.cloudflare.com> → **Networks → Tunnels → Create a tunnel**
+2. Connector type **Cloudflared**, name it `maiyuri-op`, Save.
+3. Cloudflare shows install commands — pick **Docker**. Copy ONLY the token
+   from the shown command (the long string after `--token`).
+
+### 2. Run the connector container
+Replace `<TOKEN>` with the copied token (fine to paste locally — it is a
+tunnel credential scoped to this one tunnel; treat it like a password):
+
+```powershell
+docker run -d --name maiyuri-op-tunnel --restart unless-stopped `
+  cloudflare/cloudflared:latest tunnel run --token <TOKEN>
+```
+
+`--restart unless-stopped` makes it survive Docker/PC restarts.
+
+### 3. Map the hostname
+Back in the tunnel's **Public Hostname** tab → Add:
+- Subdomain `op`, domain `maiyuri.com`
+- Service **HTTP** → `host.docker.internal:8080`
+  (the connector runs inside Docker; `localhost` would point at the
+  container itself — `host.docker.internal` reaches the PC.)
+
+`https://op.maiyuri.com` should now open OpenProject. HTTPS is automatic.
+
+### 4. (Recommended) Lock it behind Cloudflare Access
+Zero Trust → **Access → Applications → Add** → Self-hosted →
+`op.maiyuri.com` → policy *Allow* with your team's email addresses.
+Outsiders then never even see the OpenProject login page.
+**Note:** if you enable Access, the API is also gated — create a
+**Service Token** (Access → Service Auth) and add a bypass policy for it,
+or scope the Access policy to paths excluding `/api/*`. Simplest working
+combo: Access policy on everything EXCEPT `/api/*` (add a second
+application for `op.maiyuri.com/api/*` with policy "Service Auth" or
+"Bypass" — OpenProject's own API-key auth still protects it).
+
+### 5. Wire the app
+1. OpenProject → avatar → **My account → Access tokens → API** → generate.
+2. Vercel → maiyuri project → Settings → Environment Variables:
+   - `OPENPROJECT_URL` = `https://op.maiyuri.com`
+   - `OPENPROJECT_API_KEY` = the token
+3. Redeploy.
+4. Staff who should receive OP tasks on their phone must have the **same
+   email** in OpenProject as in the app (Settings → Team).
+
+### 6. Verify
+GitHub → Actions → **OpenProject bridge sync** → Run workflow. Expect
+`{"packages":N,"created":...}` — or assign yourself a work package in OP,
+run it, and watch the push notification arrive in the Maiyuri app.
+
+## Day-2 notes
+- PC asleep ⇒ op.maiyuri.com serves a Cloudflare 5xx and the sync skips;
+  no alerts fire. Tasks already synced to phones keep working (they live
+  in the app's DB).
+- If OpenProject becomes business-critical, move its container + the
+  connector to the Synology NAS (Priyam_NAS) — same tunnel token works.
+- Container health: `docker logs maiyuri-op-tunnel --tail 20` shows the
+  four Cloudflare edge connections when healthy.


### PR DESCRIPTION
Connects self-hosted OpenProject (op.maiyuri.com via Cloudflare Tunnel, founder's PC :8080) to the app with a clear division of labour:

- **OpenProject = planning cockpit** — Gantt, dependencies, milestones (things the app lacks)
- **My Work = the ONE staff queue** — drivers/supervisors never open OpenProject

## The bridge (`/api/cron/openproject-sync`, every 30 min)
**OP → phones:** every open, assigned work package becomes a `work_item` for the matching app user (matched by email) with a push notification. Idempotent via `source_module='openproject'` + `source_record_id=<wp id>` — **no migration needed**. Title/due-date edits in OP flow through; packages closed in OP cancel the local item.

**Phones → OP:** items COMPLETED in the app (after the approval gate, if required) close the work package and leave a completion comment with the field note — the Gantt updates itself from field reality.

## Resilience by design
The tunnel host is a PC that sleeps. `openproject.ts` distinguishes *unreachable* (Cloudflare 5xx / network fail, 15s fail-fast) from real errors — unreachable returns a graceful `skipped` success, so the workflow's ❌ Telegram alert only fires on genuine bugs, not on the PC being off.

## Notes
- OP-derived tasks appear in the Daily Report automatically via the existing Tasks tile (they ARE work_items) — no duplicate tile
- API v3, Basic auth with the literal username `apikey`; env: `OPENPROJECT_URL`, `OPENPROJECT_API_KEY` (Vercel). Endpoint no-ops with a clear reason until both are set — safe to merge before the tunnel exists
- `maiyuri-architecture` skill updated (§3.13 + cron table)

## Activation checklist (user)
1. Start Docker via Start-Docker-Clean.ps1, bring up OpenProject
2. Cloudflare Zero Trust → create tunnel → run the cloudflared container → map `op.maiyuri.com` → `http://host.docker.internal:8080` (+ optional Access policy)
3. OP → My account → Access tokens → API key
4. Vercel env: `OPENPROJECT_URL=https://op.maiyuri.com`, `OPENPROJECT_API_KEY` → redeploy
5. Staff emails in OP must match their app emails

## Testing
- tsc + eslint clean; live E2E once the tunnel is up (Actions → OpenProject bridge sync → Run workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization between OpenProject work packages and app work items.
  * New work packages can create or update corresponding app tasks, including titles, priorities, and due dates.
  * Completed app tasks are reflected in OpenProject with a completion comment and closure.
  * Cancelled or missing OpenProject work packages are synchronized accordingly.
  * Synchronization runs every 30 minutes and can also be triggered manually.

* **Bug Fixes**
  * Added failure alerts for synchronization errors.
  * Improved handling when OpenProject is unavailable or not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->