### PR TITLE
docs: OpenProject final topology — VMware VM + Tailscale Funnel

### DIFF
--- a/.claude/skills/maiyuri-architecture/SKILL.md
+++ b/.claude/skills/maiyuri-architecture/SKILL.md
@@ -216,18 +216,39 @@ Overlaps conceptually with My Work approvals — unifying is on the backlog.
 Auto-ingests call transcripts + published SOPs.
 
 ### 3.13 OpenProject bridge  (`src/lib/openproject.ts`)
-OpenProject (self-hosted at `op.maiyuri.com` via Cloudflare Tunnel from the
-founder's PC, container port 8080) = the founder's PLANNING cockpit (Gantt,
-dependencies). My Work stays the ONE staff queue. The bridge
-(`/api/cron/openproject-sync`, every 30 min): open assigned work packages →
-`work_items` (`source_module='openproject'`, `source_record_id=<wp id>`,
-assignee matched by email, push notification); title/due edits flow through;
-WPs closed in OP cancel the local item; items COMPLETED in the app close the
-WP + leave a completion comment. Env: `OPENPROJECT_URL`,
-`OPENPROJECT_API_KEY` (Basic auth, username literally `apikey`).
-**The tunnel host is a PC that sleeps** — the sync treats unreachable as a
-graceful skip (no alert); alerts mean real bugs. OP-derived tasks surface in
-the Daily Report through the existing Tasks tile (they ARE work_items).
+OpenProject = the founder's PLANNING cockpit (Gantt, dependencies); My Work
+stays the ONE staff queue. The bridge (`/api/cron/openproject-sync`, every
+30 min): open assigned work packages → `work_items`
+(`source_module='openproject'`, `source_record_id=<wp id>`, assignee matched
+by email, push notification); title/due edits flow through; WPs closed in OP
+cancel the local item; items COMPLETED in the app close the WP + leave a
+completion comment. Env: `OPENPROJECT_URL`, `OPENPROJECT_API_KEY` (API v3,
+Basic auth, username literally `apikey`). OP-derived tasks surface in the
+Daily Report through the existing Tasks tile (they ARE work_items).
+
+**Where OpenProject actually runs** (final topology, 2026-07-13):
+- Docker container `openproject` (image `openproject/openproject:16`,
+  bundled PG + memcached) inside the **VMware Workstation VM "Openclaw"**
+  (Ubuntu, hostname `ram-VMware-Virtual-Platform`) on the founder's PC —
+  NOT WSL, NOT Docker Desktop. Compose file:
+  `/home/ram/openproject-docker/docker-compose.yml` (user `ram`).
+- Public URL: **`https://ram-vmware-virtual-platform.tailec7c1f.ts.net`**
+  via **Tailscale Funnel** (`tailscale funnel --bg 8080`), NOT Cloudflare.
+  Container binds `127.0.0.1:8080:80` only — Funnel and the tailnet are the
+  only doors. `OPENPROJECT_HOST__NAME` = that ts.net name, `HTTPS=true`
+  (it 400s "Invalid host_name configuration" on any other Host header —
+  that is OpenProject's guard, not a network problem).
+- The VM also hosts: `maiyuri-metabase` (:3030), Mealie, Homepage. The
+  Openclaw VM's tailnet IP is 100.77.129.54; SSH access: key
+  `Claude workings/openproject/.ssh/openclaw_ed25519` as `ram@100.77.129.54`
+  (Tailscale SSH was tried and disabled — its check-mode kept denying;
+  plain sshd + authorized_keys works).
+- A leftover `op.maiyuri.com → host.docker.internal:8080` ingress exists in
+  the IMMICH Cloudflare tunnel config
+  (`Claude workings/immich/cloudflared/config.yml`) — redundant (no DNS
+  record was ever created); safe to remove.
+- **The VM sleeps with the PC** — the sync treats unreachable as a graceful
+  skip (no alert); an alert from openproject-sync means a real bug.
 
 ### 3.14 Dashboards & Settings
 - Multiple overlapping dashboards exist (dashboard, kpi, business-health,

--- a/docs/OPENPROJECT_TUNNEL.md
+++ b/docs/OPENPROJECT_TUNNEL.md
@@ -1,78 +1,56 @@
-# OpenProject @ op.maiyuri.com — tunnel runbook
+# OpenProject exposure — Tailscale Funnel runbook (current)
 
-OpenProject runs in Docker on the founder's PC (all-in-one image, port 8080,
-bundled PG + memcached). It is published to the internet as
-`https://op.maiyuri.com` through a **Cloudflare Tunnel** — no port
-forwarding, no router changes. maiyuri.com's DNS is already on Cloudflare,
-so the subdomain mapping is instant.
+> **History:** this doc originally described a Cloudflare Tunnel plan
+> (`op.maiyuri.com`). That path was abandoned when we found OpenProject was
+> not on the Windows host at all — it lives inside a VMware VM already on
+> the founder's tailnet, so **Tailscale Funnel** was the shorter road. A
+> leftover (harmless, DNS-less) `op.maiyuri.com` ingress entry remains in
+> the Immich cloudflared config and can be deleted.
 
-The app bridge (see `/api/cron/openproject-sync` + the maiyuri-architecture
-skill §3.13) treats "tunnel host offline" as a normal state — the sync skips
-quietly when this PC is asleep and catches up on the next 30-min tick.
+## Where everything is
 
-## One-time setup (~15 min)
+| Thing | Value |
+|---|---|
+| Host | VMware Workstation VM **"Openclaw"** (Ubuntu) on the founder's PC |
+| Container | `openproject` — `openproject/openproject:16` all-in-one (bundled PG + memcached) |
+| Compose | `/home/ram/openproject-docker/docker-compose.yml` (user `ram`) |
+| Local bind | `127.0.0.1:8080 → 80` (localhost-only, by design) |
+| Public URL | `https://ram-vmware-virtual-platform.tailec7c1f.ts.net` |
+| Exposure | `tailscale funnel --bg 8080` (survives reboots) |
+| VM tailnet IP | `100.77.129.54` |
+| SSH | `ssh -i "Claude workings/openproject/.ssh/openclaw_ed25519" ram@100.77.129.54` |
+| App env (Vercel) | `OPENPROJECT_URL` = the ts.net URL · `OPENPROJECT_API_KEY` = API token |
 
-### 0. Start Docker the safe way (this PC only)
-This machine leaves undeletable socket files behind. **Always** run
-`Start-Docker-Clean.ps1` before starting Docker Desktop, then bring
-OpenProject up and confirm `http://localhost:8080` answers.
+Key container env (already set): `OPENPROJECT_HOST__NAME` = the ts.net name,
+`OPENPROJECT_HTTPS=true`. OpenProject **400s with "Invalid host_name
+configuration"** for any Host header that doesn't match — if the URL ever
+changes, change this env and `docker compose up -d` again.
 
-### 1. Create the tunnel (Cloudflare dashboard)
-1. <https://one.dash.cloudflare.com> → **Networks → Tunnels → Create a tunnel**
-2. Connector type **Cloudflared**, name it `maiyuri-op`, Save.
-3. Cloudflare shows install commands — pick **Docker**. Copy ONLY the token
-   from the shown command (the long string after `--token`).
+## Day-2 operations
 
-### 2. Run the connector container
-Replace `<TOKEN>` with the copied token (fine to paste locally — it is a
-tunnel credential scoped to this one tunnel; treat it like a password):
+- **VM/PC asleep** → the funnel URL serves an error and the app's
+  `openproject-sync` cron skips gracefully (no Telegram alert). It catches
+  up on the next 30-min tick. Alerts from that workflow mean real bugs.
+- **Check funnel:** on the VM, `tailscale funnel status`. Re-enable with
+  `tailscale funnel --bg 8080` (user `ram` is the tailscale operator — no
+  sudo needed).
+- **Check container:** `docker ps`, `docker logs openproject --tail 50`,
+  restart with `cd ~/openproject-docker && docker compose up -d`.
+- **Backups:** pgdata lives in the named volume `openproject-docker_pgdata`
+  inside the VM. There is currently NO off-VM backup of OpenProject data —
+  if it becomes business-critical, add a dump job (and consider moving the
+  container to the Synology NAS).
+- **Other services on this VM:** `maiyuri-metabase` (:3030), Mealie (:9925),
+  Homepage (:3003) — unrelated; don't touch when working on OpenProject.
+- Tailscale SSH is intentionally **disabled** on the VM (`tailscale set
+  --ssh=false`): its check-mode kept denying sessions. Plain sshd +
+  authorized_keys is the working path.
 
-```powershell
-docker run -d --name maiyuri-op-tunnel --restart unless-stopped `
-  cloudflare/cloudflared:latest tunnel run --token <TOKEN>
-```
+## Bridge verification
 
-`--restart unless-stopped` makes it survive Docker/PC restarts.
-
-### 3. Map the hostname
-Back in the tunnel's **Public Hostname** tab → Add:
-- Subdomain `op`, domain `maiyuri.com`
-- Service **HTTP** → `host.docker.internal:8080`
-  (the connector runs inside Docker; `localhost` would point at the
-  container itself — `host.docker.internal` reaches the PC.)
-
-`https://op.maiyuri.com` should now open OpenProject. HTTPS is automatic.
-
-### 4. (Recommended) Lock it behind Cloudflare Access
-Zero Trust → **Access → Applications → Add** → Self-hosted →
-`op.maiyuri.com` → policy *Allow* with your team's email addresses.
-Outsiders then never even see the OpenProject login page.
-**Note:** if you enable Access, the API is also gated — create a
-**Service Token** (Access → Service Auth) and add a bypass policy for it,
-or scope the Access policy to paths excluding `/api/*`. Simplest working
-combo: Access policy on everything EXCEPT `/api/*` (add a second
-application for `op.maiyuri.com/api/*` with policy "Service Auth" or
-"Bypass" — OpenProject's own API-key auth still protects it).
-
-### 5. Wire the app
-1. OpenProject → avatar → **My account → Access tokens → API** → generate.
-2. Vercel → maiyuri project → Settings → Environment Variables:
-   - `OPENPROJECT_URL` = `https://op.maiyuri.com`
-   - `OPENPROJECT_API_KEY` = the token
-3. Redeploy.
-4. Staff who should receive OP tasks on their phone must have the **same
-   email** in OpenProject as in the app (Settings → Team).
-
-### 6. Verify
-GitHub → Actions → **OpenProject bridge sync** → Run workflow. Expect
-`{"packages":N,"created":...}` — or assign yourself a work package in OP,
-run it, and watch the push notification arrive in the Maiyuri app.
-
-## Day-2 notes
-- PC asleep ⇒ op.maiyuri.com serves a Cloudflare 5xx and the sync skips;
-  no alerts fire. Tasks already synced to phones keep working (they live
-  in the app's DB).
-- If OpenProject becomes business-critical, move its container + the
-  connector to the Synology NAS (Priyam_NAS) — same tunnel token works.
-- Container health: `docker logs maiyuri-op-tunnel --tail 20` shows the
-  four Cloudflare edge connections when healthy.
+GitHub → Actions → **OpenProject bridge sync** → Run workflow. Healthy
+responses: `{"packages":N,"created":…}` or, when the PC is off,
+`{"skipped":true,"reason":"OpenProject unreachable…"}`. Full loop test:
+assign a work package in OpenProject (assignee's email must match their app
+email) → push notification + My Work task on the phone → complete it in the
+app → the package closes in OpenProject with a comment.


### PR DESCRIPTION
Updates the maiyuri-architecture skill (§3.13) and the OpenProject runbook to match what actually got deployed:

- OpenProject = Docker (`openproject/openproject:16`) inside the **VMware VM "Openclaw"** (Ubuntu) on the founder's PC — not the Windows host, not WSL. Compose at `/home/ram/openproject-docker/`.
- Public URL: **`https://ram-vmware-virtual-platform.tailec7c1f.ts.net`** via **Tailscale Funnel** (verified through two public ingress IPs). The Cloudflare `op.maiyuri.com` plan is marked abandoned; its leftover DNS-less ingress in the Immich tunnel config is noted as safe to remove.
- Root cause of the original 400s documented: `OPENPROJECT_HOST__NAME` was `localhost:8080` — now the ts.net name with `HTTPS=true`; container re-bound to `127.0.0.1` only.
- Day-2 ops: funnel/container checks, SSH path (plain sshd + key; Tailscale SSH intentionally disabled after its check-mode kept denying), the no-off-VM-backup warning, and the other services sharing the VM (maiyuri-metabase, Mealie, Homepage).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)