### PR TITLE
feat: Reimbursement / Petty Cash module (web + mobile)

### DIFF
--- a/.claude/skills/maiyuri-architecture/SKILL.md
+++ b/.claude/skills/maiyuri-architecture/SKILL.md
@@ -250,7 +250,38 @@ Daily Report through the existing Tasks tile (they ARE work_items).
 - **The VM sleeps with the PC** — the sync treats unreachable as a graceful
   skip (no alert); an alert from openproject-sync means a real bug.
 
-### 3.14 Dashboards & Settings
+### 3.14 Reimbursement / Petty Cash  (`src/lib/expenses.ts`, `expenses-notify.ts`)
+Field staff hold a petty-cash **float**; they record expenses against it; the
+office tops it up. **Balance is computed live, never stored:**
+`Σ petty_cash_topups − Σ expense_claims(status in pending|approved)` —
+`getBalance()`/`getAllBalances()`. An expense deducts on **submit** (overspend
+guard: POST rejects if amount > balance); **approve** is the audit gate;
+**reject** restores the money (excluded from the sum).
+- Tables: `expense_types` (master; `kind` standard|petrol, `cost_category`
+  maps to cost_entries), `expense_vehicle_rates` (per-km petrol rates),
+  `petty_cash_topups` (admin credits), `expense_claims` (debits; petrol carries
+  vehicle_rate_id/km/from/to/customer + `per_km_rate_applied` snapshot).
+  Migration `supabase/migrations/20260714120000_expenses.sql`.
+- **Petrol amount is computed server-side** (`km × vehicle_rate`) — the client
+  number is never trusted.
+- API `apps/web/app/api/expenses/*`: GET (own view / `?view=all` admin),
+  POST (submit), `[id]/approve`+`/reject`, `topups`, `rates`, `types`,
+  `receipts` (upload + signer; private `expense-receipts` bucket).
+- On **approve**, a project-linked claim best-effort posts a `cost_entries`
+  row (`postClaimToProjectCost`, `source='manual'` since that CHECK excludes
+  other values, `payment_status='paid'`, back-linked via `claim.cost_entry_id`)
+  + `recomputeProject()` — field spend flows into project actuals/variance.
+- Roles: `EXPENSE_SUBMITTER_ROLES` = engineer/driver/sales/production_supervisor;
+  `EXPENSE_ADMIN_ROLES` = founder/owner/accountant (approve/topup/masters).
+- Surfaces: web admin cockpit `/expenses` (balances, pending queue, top-ups,
+  vehicle-rate master) — nav gated to accountant + founder/owner. Mobile
+  (submitters): `onehub/expenses/{index,new}` (balance card + petrol
+  live-calc form + receipt camera) via `use-expenses.ts`; admins get an
+  "Expense claims" queue on the shared `onehub/approvals` screen. Push via
+  `expenses-notify.ts` (submitted→admins, approved/rejected/topup→user).
+- No cron. Receipts in the private `expense-receipts` bucket (signed URLs).
+
+### 3.15 Dashboards & Settings
 - Multiple overlapping dashboards exist (dashboard, kpi, business-health,
   observability, analytics, daily-report) — consultant audit flagged
   consolidation onto Daily Report as the founder home.

--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -17,6 +17,11 @@ export default function OneHubLayout() {
         options={{ title: 'Assign Work', presentation: 'modal' }}
       />
       <Stack.Screen name="approvals" options={{ title: '👀 Approvals' }} />
+      <Stack.Screen name="expenses/index" options={{ title: '💰 My Expenses' }} />
+      <Stack.Screen
+        name="expenses/new"
+        options={{ title: 'Add Expense', presentation: 'modal' }}
+      />
       <Stack.Screen name="department/[dept]" options={{ title: 'SOPs' }} />
       <Stack.Screen name="sop/[slug]" options={{ title: 'SOP' }} />
       <Stack.Screen name="edit/[slug]" options={{ title: 'Edit SOP', presentation: 'modal' }} />

--- a/apps/native/app/onehub/approvals.tsx
+++ b/apps/native/app/onehub/approvals.tsx
@@ -1,4 +1,4 @@
-import type { Ticket, WorkItem } from '@maiyuri/shared';
+import type { ExpenseClaim, Ticket, WorkItem } from '@maiyuri/shared';
 import { Link } from 'expo-router';
 import { useState } from 'react';
 import {
@@ -19,7 +19,16 @@ import {
   useRejectTicket,
   useWorkReviewQueue,
 } from '@/hooks/use-approvals';
+import {
+  EXPENSE_ADMIN_ROLES,
+  useApproveExpense,
+  useExpenseQueue,
+  useRejectExpense,
+} from '@/hooks/use-expenses';
 import { toast } from '@/lib/toast';
+
+const inr = (n: number | null | undefined) =>
+  `₹${Math.round(Number(n) || 0).toLocaleString('en-IN')}`;
 
 const TYPE_LABEL: Record<string, string> = {
   production_order: '🏭 Production order',
@@ -149,24 +158,126 @@ function WorkRow({ item }: { item: WorkItem }) {
   );
 }
 
+function ExpenseCard({ claim }: { claim: ExpenseClaim }) {
+  const approve = useApproveExpense();
+  const reject = useRejectExpense();
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState('');
+  const busy = approve.isPending || reject.isPending;
+
+  return (
+    <View className="mb-2 rounded-xl border border-slate-200 bg-white p-4">
+      <View className="flex-row items-center justify-between">
+        <Text className="flex-1 pr-2 text-sm font-semibold text-ink" numberOfLines={1}>
+          {claim.expense_type?.icon ?? '🧾'} {claim.expense_type?.name ?? 'Expense'}
+        </Text>
+        <Text className="text-sm font-bold text-ink">{inr(claim.amount)}</Text>
+      </View>
+      <Text className="mt-0.5 text-xs text-slate-400">
+        {claim.user?.name ?? 'staff'} · {claim.expense_date}
+        {claim.project ? ` · ${claim.project.name}` : ''}
+      </Text>
+      {claim.km ? (
+        <Text className="mt-0.5 text-xs text-slate-500">
+          🚗 {claim.from_location} → {claim.to_location} · {claim.km} km ×{' '}
+          {inr(claim.per_km_rate_applied)}/km
+          {claim.customer_name ? ` · ${claim.customer_name}` : ''}
+        </Text>
+      ) : null}
+      {claim.description ? (
+        <Text className="mt-1 text-sm text-slate-600">{claim.description}</Text>
+      ) : null}
+
+      {rejecting ? (
+        <View className="mt-2">
+          <TextInput
+            value={reason}
+            onChangeText={setReason}
+            placeholder="Why is this rejected? (required)"
+            placeholderTextColor="#94a3b8"
+            className="min-h-[40px] rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-ink"
+          />
+          <View className="mt-2 flex-row gap-2">
+            <Pressable
+              disabled={busy || reason.trim().length < 3}
+              onPress={() =>
+                reject.mutate(
+                  { id: claim.id, reason: reason.trim() },
+                  {
+                    onSuccess: () => toast.success('Rejected'),
+                    onError: (e) =>
+                      toast.error(e instanceof Error ? e.message : 'Failed'),
+                  },
+                )
+              }
+              className={`flex-1 items-center rounded-lg py-2 ${reason.trim().length < 3 || busy ? 'bg-slate-200' : 'bg-red-500 active:opacity-80'}`}
+            >
+              <Text className="text-xs font-semibold text-white">Confirm reject</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => setRejecting(false)}
+              className="items-center rounded-lg px-4 py-2 active:opacity-70"
+            >
+              <Text className="text-xs font-semibold text-slate-400">Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : (
+        <View className="mt-2.5 flex-row gap-2 border-t border-slate-100 pt-2.5">
+          <Pressable
+            disabled={busy}
+            onPress={() =>
+              approve.mutate(claim.id, {
+                onSuccess: () => toast.success('Approved ✅'),
+                onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed'),
+              })
+            }
+            className={`flex-1 items-center rounded-lg py-2 ${busy ? 'bg-slate-200' : 'bg-green-500 active:opacity-80'}`}
+          >
+            {approve.isPending ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text className="text-xs font-semibold text-white">✅ Approve</Text>
+            )}
+          </Pressable>
+          <Pressable
+            disabled={busy}
+            onPress={() => setRejecting(true)}
+            className="flex-1 items-center rounded-lg border border-red-200 py-2 active:opacity-70"
+          >
+            <Text className="text-xs font-semibold text-red-500">✖ Reject</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function ApprovalsScreen() {
   const role = useMyRole();
   const canTickets = TICKET_APPROVER_ROLES.includes(role);
   const canWork = WORK_ADMIN_ROLES.includes(role);
+  const canExpenses = EXPENSE_ADMIN_ROLES.includes(role);
 
   const tickets = usePendingTickets(canTickets);
   const work = useWorkReviewQueue(canWork);
+  const expenses = useExpenseQueue(canExpenses);
 
   const loading =
-    (canTickets && tickets.isLoading) || (canWork && work.isLoading);
-  const refreshing = tickets.isRefetching || work.isRefetching;
+    (canTickets && tickets.isLoading) ||
+    (canWork && work.isLoading) ||
+    (canExpenses && expenses.isLoading);
+  const refreshing =
+    tickets.isRefetching || work.isRefetching || expenses.isRefetching;
   const refetchAll = () => {
     if (canTickets) void tickets.refetch();
     if (canWork) void work.refetch();
+    if (canExpenses) void expenses.refetch();
   };
 
   const pendingTickets = tickets.data?.data ?? [];
   const submissions = work.data?.data ?? [];
+  const pendingExpenses = expenses.data?.data?.pending ?? [];
 
   return (
     <ScrollView
@@ -224,7 +335,31 @@ export default function ApprovalsScreen() {
             </>
           ) : null}
 
-          {!canTickets && !canWork ? (
+          {canExpenses ? (
+            <>
+              <Text className="mb-2 mt-4 text-base font-bold text-ink">
+                💰 Expense claims{' '}
+                {pendingExpenses.length ? `(${pendingExpenses.length})` : ''}
+              </Text>
+              {expenses.isError ? (
+                <Text className="mb-3 text-sm text-red-500">
+                  {expenses.error instanceof Error
+                    ? expenses.error.message
+                    : 'Failed to load expenses'}
+                </Text>
+              ) : pendingExpenses.length === 0 ? (
+                <View className="items-center rounded-xl border border-slate-200 bg-white p-4">
+                  <Text className="text-sm text-slate-400">
+                    ✅ No expenses to approve
+                  </Text>
+                </View>
+              ) : (
+                pendingExpenses.map((c) => <ExpenseCard key={c.id} claim={c} />)
+              )}
+            </>
+          ) : null}
+
+          {!canTickets && !canWork && !canExpenses ? (
             <View className="mt-10 items-center">
               <Text className="text-sm text-slate-400">
                 Your role has no approval duties.

--- a/apps/native/app/onehub/expenses/index.tsx
+++ b/apps/native/app/onehub/expenses/index.tsx
@@ -1,0 +1,130 @@
+import type { ExpenseClaim, PettyCashTopup } from '@maiyuri/shared';
+import { Link } from 'expo-router';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { useMyExpenses } from '@/hooks/use-expenses';
+
+const inr = (n: number | null | undefined) =>
+  `₹${Math.round(Number(n) || 0).toLocaleString('en-IN')}`;
+
+const STATUS: Record<string, { label: string; cls: string }> = {
+  pending: { label: 'Pending', cls: 'bg-amber-100 text-amber-700' },
+  approved: { label: 'Approved', cls: 'bg-green-100 text-green-700' },
+  rejected: { label: 'Rejected', cls: 'bg-red-100 text-red-700' },
+};
+
+function ClaimRow({ claim }: { claim: ExpenseClaim }) {
+  const s = STATUS[claim.status] ?? STATUS.pending;
+  return (
+    <View className="mb-2 rounded-xl border border-slate-200 bg-white p-3.5">
+      <View className="flex-row items-center justify-between">
+        <Text className="flex-1 pr-2 text-sm font-semibold text-ink" numberOfLines={1}>
+          {claim.expense_type?.icon ?? '🧾'} {claim.expense_type?.name ?? 'Expense'}
+        </Text>
+        <Text className="text-sm font-bold text-ink">{inr(claim.amount)}</Text>
+      </View>
+      <View className="mt-1 flex-row items-center justify-between">
+        <Text className="text-xs text-slate-400" numberOfLines={1}>
+          {claim.expense_date}
+          {claim.km ? ` · ${claim.km} km` : ''}
+          {claim.project ? ` · ${claim.project.name}` : ''}
+        </Text>
+        <View className={`rounded-md px-1.5 py-0.5 ${s.cls.split(' ')[0]}`}>
+          <Text className={`text-[11px] font-medium ${s.cls.split(' ')[1]}`}>
+            {s.label}
+          </Text>
+        </View>
+      </View>
+      {claim.status === 'rejected' && claim.reject_reason ? (
+        <Text className="mt-1 text-xs text-red-500">✖ {claim.reject_reason}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+export default function ExpensesHome() {
+  const { data, isLoading, isRefetching, refetch } = useMyExpenses();
+  const d = data?.data;
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-slate-50">
+        <ActivityIndicator size="large" color="#f97316" />
+      </View>
+    );
+  }
+
+  const claims = d?.claims ?? [];
+  const topups = d?.topups ?? [];
+
+  return (
+    <ScrollView
+      className="flex-1 bg-slate-50"
+      contentContainerClassName="p-4 pb-10"
+      refreshControl={
+        <RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />
+      }
+    >
+      {/* Balance card */}
+      <View className="rounded-2xl bg-ink p-5">
+        <Text className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+          💰 Available balance
+        </Text>
+        <Text className="mt-1 text-4xl font-bold text-white">{inr(d?.balance)}</Text>
+        <View className="mt-3 flex-row">
+          <View className="flex-1">
+            <Text className="text-xs text-slate-400">Given</Text>
+            <Text className="text-sm font-semibold text-slate-200">
+              {inr(d?.topups_total)}
+            </Text>
+          </View>
+          <View className="flex-1">
+            <Text className="text-xs text-slate-400">Spent</Text>
+            <Text className="text-sm font-semibold text-slate-200">
+              {inr(d?.spent_total)}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <Link href={'/onehub/expenses/new' as import('expo-router').Href} asChild>
+        <Pressable className="mt-3 items-center rounded-xl bg-brand py-3.5 active:opacity-80">
+          <Text className="text-base font-bold text-ink">＋ Add expense</Text>
+        </Pressable>
+      </Link>
+
+      <Text className="mb-2 mt-5 text-base font-bold text-ink">My expenses</Text>
+      {claims.length === 0 ? (
+        <View className="items-center rounded-xl border border-slate-200 bg-white p-6">
+          <Text className="text-sm text-slate-400">No expenses yet.</Text>
+        </View>
+      ) : (
+        claims.map((c) => <ClaimRow key={c.id} claim={c} />)
+      )}
+
+      {topups.length ? (
+        <>
+          <Text className="mb-2 mt-5 text-base font-bold text-ink">Top-ups received</Text>
+          {topups.map((t: PettyCashTopup) => (
+            <View
+              key={t.id}
+              className="mb-2 flex-row items-center justify-between rounded-xl border border-slate-200 bg-white p-3.5"
+            >
+              <Text className="text-xs text-slate-500">
+                {new Date(t.created_at).toLocaleDateString('en-IN')}
+                {t.note ? ` · ${t.note}` : ''}
+              </Text>
+              <Text className="text-sm font-bold text-green-600">+{inr(t.amount)}</Text>
+            </View>
+          ))}
+        </>
+      ) : null}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/expenses/new.tsx
+++ b/apps/native/app/onehub/expenses/new.tsx
@@ -1,0 +1,323 @@
+import type { ExpenseType, ExpenseVehicleRate, Lead, Project } from '@maiyuri/shared';
+import * as ImagePicker from 'expo-image-picker';
+import { useRouter } from 'expo-router';
+import { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useCreateExpense, useMyExpenses, useUploadReceipt } from '@/hooks/use-expenses';
+import { toast } from '@/lib/toast';
+
+const inr = (n: number) => `₹${Math.round(n).toLocaleString('en-IN')}`;
+
+function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`mb-2 mr-2 rounded-full px-3 py-1.5 ${
+        active ? 'bg-ink' : 'border border-slate-200 bg-white'
+      }`}
+    >
+      <Text className={`text-xs font-medium ${active ? 'text-white' : 'text-slate-600'}`}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+export default function NewExpense() {
+  const router = useRouter();
+  const { data: mine } = useMyExpenses();
+  const create = useCreateExpense();
+  const uploadReceipt = useUploadReceipt();
+
+  const types = mine?.data?.types ?? [];
+  const rates = mine?.data?.vehicleRates ?? [];
+  const balance = mine?.data?.balance ?? 0;
+
+  const projects = useQuery({
+    queryKey: ['projects', 'picker'],
+    queryFn: () => api.get<Project[]>('/api/projects'),
+  });
+  const leads = useQuery({
+    queryKey: ['leads', 'picker'],
+    queryFn: () => api.get<Lead[]>('/api/leads', { limit: 50 }),
+  });
+
+  const [typeId, setTypeId] = useState<string | null>(null);
+  const [amount, setAmount] = useState('');
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [description, setDescription] = useState('');
+  const [receiptUri, setReceiptUri] = useState<string | null>(null);
+  // petrol
+  const [vehicleId, setVehicleId] = useState<string | null>(null);
+  const [leadId, setLeadId] = useState<string | null>(null);
+  const [customer, setCustomer] = useState('');
+  const [fromLoc, setFromLoc] = useState('');
+  const [toLoc, setToLoc] = useState('');
+  const [km, setKm] = useState('');
+
+  const type = types.find((t) => t.id === typeId) as ExpenseType | undefined;
+  const isPetrol = type?.kind === 'petrol';
+  const vehicle = rates.find((r) => r.id === vehicleId) as
+    | ExpenseVehicleRate
+    | undefined;
+
+  const petrolAmount = useMemo(() => {
+    if (!isPetrol || !vehicle || !Number(km)) return 0;
+    return Math.round(Number(vehicle.per_km_rate) * Number(km) * 100) / 100;
+  }, [isPetrol, vehicle, km]);
+
+  const effectiveAmount = isPetrol ? petrolAmount : Number(amount) || 0;
+
+  const takePhoto = async () => {
+    const perm = await ImagePicker.requestCameraPermissionsAsync();
+    if (!perm.granted) return;
+    const res = await ImagePicker.launchCameraAsync({ quality: 0.4 });
+    if (!res.canceled && res.assets?.[0]?.uri) setReceiptUri(res.assets[0].uri);
+  };
+
+  const submit = async () => {
+    if (!type) return toast.error('Pick an expense type');
+    if (type.requires_project && !projectId) return toast.error('Pick a project');
+    if (isPetrol) {
+      if (!vehicleId) return toast.error('Pick a vehicle');
+      if (!Number(km)) return toast.error('Enter kilometres');
+    } else if (!Number(amount)) {
+      return toast.error('Enter an amount');
+    }
+    if (effectiveAmount > balance) {
+      return toast.error(`Over balance — you have ${inr(balance)}`);
+    }
+
+    // Upload the receipt first (if any), then create the claim with its path.
+    let receiptPath: string | null = null;
+    if (receiptUri) {
+      try {
+        const up = await uploadReceipt.mutateAsync(receiptUri);
+        receiptPath = up.path;
+      } catch (e) {
+        return toast.error(e instanceof Error ? e.message : 'Receipt upload failed');
+      }
+    }
+
+    create.mutate(
+      {
+        expense_type_id: type.id,
+        project_id: projectId ?? undefined,
+        description: description.trim() || undefined,
+        receipt_url: receiptPath ?? undefined,
+        ...(isPetrol
+          ? {
+              vehicle_rate_id: vehicleId ?? undefined,
+              km: Number(km),
+              lead_id: leadId ?? undefined,
+              customer_name: customer.trim() || undefined,
+              from_location: fromLoc.trim() || undefined,
+              to_location: toLoc.trim() || undefined,
+            }
+          : { amount: Number(amount) }),
+      },
+      {
+        onSuccess: () => {
+          toast.success('Expense submitted ✅');
+          router.back();
+        },
+        onError: (e) => toast.error(e instanceof Error ? e.message : 'Failed'),
+      },
+    );
+  };
+
+  const busy = create.isPending || uploadReceipt.isPending;
+
+  return (
+    <ScrollView className="flex-1 bg-slate-50" contentContainerClassName="p-4 pb-16">
+      <Text className="mb-1 text-xs text-slate-400">
+        Available balance {inr(balance)}
+      </Text>
+
+      <Text className="mb-2 mt-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Expense type
+      </Text>
+      <View className="flex-row flex-wrap">
+        {types.map((t) => (
+          <Chip
+            key={t.id}
+            label={`${t.icon ?? ''} ${t.name}`}
+            active={typeId === t.id}
+            onPress={() => setTypeId(t.id)}
+          />
+        ))}
+      </View>
+
+      {isPetrol ? (
+        <>
+          <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Vehicle
+          </Text>
+          <View className="flex-row flex-wrap">
+            {rates.map((r) => (
+              <Chip
+                key={r.id}
+                label={`${r.label} · ₹${r.per_km_rate}/km`}
+                active={vehicleId === r.id}
+                onPress={() => setVehicleId(r.id)}
+              />
+            ))}
+          </View>
+
+          <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Customer (optional)
+          </Text>
+          <View className="flex-row flex-wrap">
+            {(leads.data?.data ?? []).slice(0, 12).map((l) => (
+              <Chip
+                key={l.id}
+                label={l.name}
+                active={leadId === l.id}
+                onPress={() => {
+                  setLeadId(leadId === l.id ? null : l.id);
+                  setCustomer('');
+                }}
+              />
+            ))}
+          </View>
+          {!leadId ? (
+            <TextInput
+              value={customer}
+              onChangeText={setCustomer}
+              placeholder="…or type a customer name"
+              placeholderTextColor="#94a3b8"
+              className="mt-1 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+            />
+          ) : null}
+
+          <View className="mt-3 flex-row gap-2">
+            <TextInput
+              value={fromLoc}
+              onChangeText={setFromLoc}
+              placeholder="From"
+              placeholderTextColor="#94a3b8"
+              className="flex-1 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+            />
+            <TextInput
+              value={toLoc}
+              onChangeText={setToLoc}
+              placeholder="To"
+              placeholderTextColor="#94a3b8"
+              className="flex-1 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+            />
+          </View>
+          <TextInput
+            value={km}
+            onChangeText={setKm}
+            keyboardType="numeric"
+            placeholder="Kilometres"
+            placeholderTextColor="#94a3b8"
+            className="mt-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+          />
+          <View className="mt-2 rounded-xl bg-orange-50 p-3">
+            <Text className="text-sm font-semibold text-orange-800">
+              {vehicle && Number(km)
+                ? `${km} km × ₹${vehicle.per_km_rate}/km = ${inr(petrolAmount)}`
+                : 'Pick a vehicle and enter km to see the amount'}
+            </Text>
+          </View>
+        </>
+      ) : (
+        <>
+          <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Amount ₹
+          </Text>
+          <TextInput
+            value={amount}
+            onChangeText={setAmount}
+            keyboardType="numeric"
+            placeholder="Amount"
+            placeholderTextColor="#94a3b8"
+            className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+          />
+        </>
+      )}
+
+      <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Project {type?.requires_project ? '(required)' : '(optional)'}
+      </Text>
+      <View className="flex-row flex-wrap">
+        <Chip label="None" active={projectId === null} onPress={() => setProjectId(null)} />
+        {(projects.data?.data ?? []).map((p) => (
+          <Chip
+            key={p.id}
+            label={p.name}
+            active={projectId === p.id}
+            onPress={() => setProjectId(p.id)}
+          />
+        ))}
+      </View>
+
+      <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Notes
+      </Text>
+      <TextInput
+        value={description}
+        onChangeText={setDescription}
+        placeholder="What was this for?"
+        placeholderTextColor="#94a3b8"
+        multiline
+        className="min-h-[60px] rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-ink"
+      />
+
+      <Text className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        Receipt
+      </Text>
+      {receiptUri ? (
+        <Pressable onPress={() => setReceiptUri(null)}>
+          <Image
+            source={{ uri: receiptUri }}
+            style={{ width: 96, height: 96, borderRadius: 10 }}
+          />
+          <Text className="mt-1 text-xs text-slate-400">Tap to remove</Text>
+        </Pressable>
+      ) : (
+        <Pressable
+          onPress={takePhoto}
+          className="h-[80px] w-[80px] items-center justify-center rounded-xl border-2 border-dashed border-slate-300 active:opacity-70"
+        >
+          <Text className="text-2xl">📷</Text>
+        </Pressable>
+      )}
+
+      <Pressable
+        onPress={submit}
+        disabled={busy}
+        className={`mt-6 items-center rounded-xl py-3.5 ${
+          busy ? 'bg-slate-200' : 'bg-brand active:opacity-80'
+        }`}
+      >
+        {busy ? (
+          <ActivityIndicator color="#0f172a" />
+        ) : (
+          <Text className="text-base font-bold text-ink">
+            Submit {effectiveAmount > 0 ? inr(effectiveAmount) : ''}
+          </Text>
+        )}
+      </Pressable>
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/index.tsx
+++ b/apps/native/app/onehub/index.tsx
@@ -5,6 +5,10 @@ import {
   WORK_ADMIN_ROLES,
   useMyRole,
 } from '@/hooks/use-approvals';
+import {
+  EXPENSE_ADMIN_ROLES,
+  EXPENSE_SUBMITTER_ROLES,
+} from '@/hooks/use-expenses';
 import { useSops } from '@/hooks/use-onehub';
 
 export const DEPARTMENTS: { key: string; label: string; ta: string; icon: string }[] = [
@@ -21,6 +25,8 @@ export default function OneHubHome() {
   const role = useMyRole();
   const showApprovals =
     TICKET_APPROVER_ROLES.includes(role) || WORK_ADMIN_ROLES.includes(role);
+  const showExpenses =
+    EXPENSE_SUBMITTER_ROLES.includes(role) || EXPENSE_ADMIN_ROLES.includes(role);
   const counts = new Map<string, number>();
   for (const sop of data?.data ?? []) {
     counts.set(sop.department, (counts.get(sop.department) ?? 0) + 1);
@@ -60,6 +66,22 @@ export default function OneHubHome() {
           <Text className="text-slate-400">→</Text>
         </Pressable>
       </Link>
+
+      {/* My Expenses — petty-cash balance + claims */}
+      {showExpenses ? (
+        <Link href={"/onehub/expenses" as import("expo-router").Href} asChild>
+          <Pressable className="mt-3 flex-row items-center rounded-2xl border border-slate-200 bg-white p-4 active:opacity-70">
+            <Text className="mr-3 text-3xl">💰</Text>
+            <View className="flex-1">
+              <Text className="text-base font-bold text-ink">My Expenses</Text>
+              <Text className="text-xs text-slate-500">
+                Your petty-cash balance — record petrol, materials & more
+              </Text>
+            </View>
+            <Text className="text-slate-400">→</Text>
+          </Pressable>
+        </Link>
+      ) : null}
 
       {/* Approvals — supervisors / accountants / founders */}
       {showApprovals ? (

--- a/apps/native/src/hooks/use-expenses.ts
+++ b/apps/native/src/hooks/use-expenses.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  AllExpensesResponse,
+  CreateExpenseInput,
+  ExpenseClaim,
+  MyExpensesResponse,
+} from '@maiyuri/shared';
+import { api } from '@/lib/api';
+import { supabase } from '@/lib/supabase';
+
+const BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://mb.maiyuri.com';
+
+/** Roles that hold a petty-cash balance and record expenses. */
+export const EXPENSE_SUBMITTER_ROLES = [
+  'engineer',
+  'driver',
+  'sales',
+  'production_supervisor',
+];
+export const EXPENSE_ADMIN_ROLES = ['founder', 'owner', 'accountant'];
+
+/** The signed-in staffer's balance + own claims/topups + masters. */
+export function useMyExpenses() {
+  return useQuery({
+    queryKey: ['expenses', 'mine'],
+    queryFn: () => api.get<MyExpensesResponse>('/api/expenses'),
+  });
+}
+
+export function useCreateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: Partial<CreateExpenseInput>) =>
+      api.post<ExpenseClaim>('/api/expenses', body),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ['expenses'] }),
+  });
+}
+
+/** Upload a receipt image (multipart). Returns the storage path to store. */
+export function useUploadReceipt() {
+  return useMutation({
+    mutationFn: async (uri: string): Promise<{ path: string; url: string | null }> => {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      const form = new FormData();
+      form.append('file', {
+        uri,
+        name: `receipt-${Date.now()}.jpg`,
+        type: 'image/jpeg',
+      } as unknown as Blob);
+      const res = await fetch(`${BASE_URL}/api/expenses/receipts`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        body: form,
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(json?.error ?? `Upload failed (${res.status})`);
+      return json.data;
+    },
+  });
+}
+
+// ---- admin (approvals screen) ----
+
+export function useExpenseQueue(enabled: boolean) {
+  return useQuery({
+    queryKey: ['expenses', 'queue'],
+    queryFn: () => api.get<AllExpensesResponse>('/api/expenses', { view: 'all' }),
+    enabled,
+  });
+}
+
+export function useApproveExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.post(`/api/expenses/${id}/approve`, {}),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ['expenses'] }),
+  });
+}
+
+export function useRejectExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (v: { id: string; reason: string }) =>
+      api.post(`/api/expenses/${v.id}/reject`, { reason: v.reason }),
+    onSuccess: () =>
+      void queryClient.invalidateQueries({ queryKey: ['expenses'] }),
+  });
+}

--- a/apps/web/app/(dashboard)/expenses/page.tsx
+++ b/apps/web/app/(dashboard)/expenses/page.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+/**
+ * Reimbursement / Petty Cash — founder/accountant cockpit.
+ * All-staff balances, the pending-approval queue, one-click top-ups, and the
+ * per-km vehicle-rate master. Engineers use the mobile app; this is the office
+ * side (approve / reject / refill / set rates).
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import type {
+  AllExpensesResponse,
+  ExpenseBalance,
+  ExpenseClaim,
+  ExpenseVehicleRate,
+} from "@maiyuri/shared";
+
+const inr = (n: number) => `₹${Math.round(Number(n) || 0).toLocaleString("en-IN")}`;
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data as T;
+}
+async function postJson(url: string, payload: unknown, method = "POST") {
+  const res = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data;
+}
+
+function useAllExpenses() {
+  return useQuery({
+    queryKey: ["expenses-all"],
+    queryFn: () => getJson<AllExpensesResponse>("/api/expenses?view=all"),
+    refetchInterval: 60_000,
+  });
+}
+function useVehicleRates() {
+  return useQuery({
+    queryKey: ["expense-rates"],
+    queryFn: () => getJson<ExpenseVehicleRate[]>("/api/expenses/rates"),
+  });
+}
+
+export default function ExpensesCockpit() {
+  const qc = useQueryClient();
+  const { data, isLoading, isError, error } = useAllExpenses();
+  const rates = useVehicleRates();
+  const [tab, setTab] = useState<"queue" | "balances" | "rates">("queue");
+  const [rejecting, setRejecting] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const [topupFor, setTopupFor] = useState<ExpenseBalance | null>(null);
+  const [topupAmt, setTopupAmt] = useState("");
+  const [topupNote, setTopupNote] = useState("");
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: ["expenses-all"] });
+  };
+
+  const approve = useMutation({
+    mutationFn: (id: string) => postJson(`/api/expenses/${id}/approve`, {}),
+    onSuccess: invalidate,
+  });
+  const reject = useMutation({
+    mutationFn: (v: { id: string; reason: string }) =>
+      postJson(`/api/expenses/${v.id}/reject`, { reason: v.reason }),
+    onSuccess: () => {
+      setRejecting(null);
+      setReason("");
+      invalidate();
+    },
+  });
+  const topup = useMutation({
+    mutationFn: (v: { user_id: string; amount: number; note?: string }) =>
+      postJson("/api/expenses/topups", v),
+    onSuccess: () => {
+      setTopupFor(null);
+      setTopupAmt("");
+      setTopupNote("");
+      invalidate();
+    },
+  });
+  const saveRate = useMutation({
+    mutationFn: (v: Partial<ExpenseVehicleRate>) =>
+      postJson("/api/expenses/rates", v, "PUT"),
+    onSuccess: () => rates.refetch(),
+  });
+
+  const pending = data?.pending ?? [];
+  const balances = data?.balances ?? [];
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-4">
+        <h1 className="text-2xl font-bold text-slate-900">💰 Reimbursements</h1>
+        <p className="text-sm text-slate-500">
+          Petty-cash balances, expense approvals, and top-ups.
+        </p>
+      </div>
+
+      <div className="mb-4 flex gap-2">
+        {([
+          ["queue", `Pending (${pending.length})`],
+          ["balances", "Balances"],
+          ["rates", "Vehicle rates"],
+        ] as const).map(([k, label]) => (
+          <button
+            key={k}
+            onClick={() => setTab(k)}
+            className={`rounded-full px-3.5 py-1.5 text-sm font-medium ${
+              tab === k
+                ? "bg-slate-900 text-white"
+                : "border border-slate-200 bg-white text-slate-600"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <div className="py-16 text-center text-slate-400">Loading…</div>
+      ) : isError ? (
+        <div className="py-16 text-center text-red-500">
+          {error instanceof Error ? error.message : "Failed to load"}
+        </div>
+      ) : tab === "queue" ? (
+        pending.length === 0 ? (
+          <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-slate-400">
+            ✅ No expenses waiting for approval
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {pending.map((c: ExpenseClaim) => (
+              <div key={c.id} className="rounded-xl border border-slate-200 bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-semibold text-slate-900">
+                      {c.expense_type?.icon ?? "🧾"} {c.expense_type?.name ?? "Expense"} ·{" "}
+                      {inr(c.amount)}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      {c.user?.name ?? "staff"} · {c.expense_date}
+                      {c.project ? ` · ${c.project.name}` : ""}
+                    </div>
+                    {c.km ? (
+                      <div className="mt-1 text-xs text-slate-500">
+                        🚗 {c.from_location} → {c.to_location} · {c.km} km ×{" "}
+                        {inr(c.per_km_rate_applied ?? 0)}/km
+                        {c.customer_name ? ` · ${c.customer_name}` : ""}
+                      </div>
+                    ) : null}
+                    {c.description ? (
+                      <div className="mt-1 text-sm text-slate-600">{c.description}</div>
+                    ) : null}
+                    {c.receipt_url ? (
+                      <button
+                        onClick={async () => {
+                          const r = await getJson<{ url: string }>(
+                            `/api/expenses/receipts?path=${encodeURIComponent(c.receipt_url!)}`,
+                          );
+                          window.open(r.url, "_blank");
+                        }}
+                        className="mt-1 text-xs font-medium text-sky-600 hover:underline"
+                      >
+                        📎 View receipt
+                      </button>
+                    ) : null}
+                  </div>
+                  {rejecting === c.id ? null : (
+                    <div className="flex shrink-0 gap-2">
+                      <button
+                        onClick={() => approve.mutate(c.id)}
+                        disabled={approve.isPending}
+                        className="rounded-lg bg-green-500 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={() => setRejecting(c.id)}
+                        className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+                {rejecting === c.id ? (
+                  <div className="mt-3 flex gap-2">
+                    <input
+                      value={reason}
+                      onChange={(e) => setReason(e.target.value)}
+                      placeholder="Reason for rejection"
+                      className="flex-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
+                    />
+                    <button
+                      onClick={() => reject.mutate({ id: c.id, reason })}
+                      disabled={reason.trim().length < 3 || reject.isPending}
+                      className="rounded-lg bg-red-500 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => {
+                        setRejecting(null);
+                        setReason("");
+                      }}
+                      className="px-2 text-xs text-slate-400"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )
+      ) : tab === "balances" ? (
+        <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wider text-slate-400">
+                <th className="px-4 py-3">Staff</th>
+                <th className="px-4 py-3">Given</th>
+                <th className="px-4 py-3">Spent</th>
+                <th className="px-4 py-3">Balance</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {balances.map((b: ExpenseBalance) => (
+                <tr key={b.user_id} className="border-b border-slate-50">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-slate-900">{b.name ?? "—"}</div>
+                    <div className="text-xs text-slate-400">
+                      {b.role.replace(/_/g, " ")}
+                      {b.pending_count ? ` · ${b.pending_count} pending` : ""}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{inr(b.topups_total)}</td>
+                  <td className="px-4 py-3 text-slate-600">{inr(b.spent_total)}</td>
+                  <td
+                    className={`px-4 py-3 font-semibold ${b.balance < 0 ? "text-red-600" : "text-slate-900"}`}
+                  >
+                    {inr(b.balance)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => setTopupFor(b)}
+                      className="rounded-lg bg-orange-500 px-3 py-1.5 text-xs font-semibold text-white"
+                    >
+                      + Top up
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {balances.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-slate-400">
+                    No field staff with petty-cash access yet.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <RatesEditor
+          rates={rates.data ?? []}
+          onSave={(v) => saveRate.mutate(v)}
+          saving={saveRate.isPending}
+        />
+      )}
+
+      {/* Top-up modal */}
+      {topupFor ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-sm rounded-xl bg-white p-5">
+            <h3 className="text-lg font-bold text-slate-900">
+              Top up — {topupFor.name}
+            </h3>
+            <p className="text-xs text-slate-500">
+              Current balance {inr(topupFor.balance)}
+            </p>
+            <input
+              value={topupAmt}
+              onChange={(e) => setTopupAmt(e.target.value)}
+              inputMode="numeric"
+              placeholder="Amount ₹"
+              className="mt-3 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            />
+            <input
+              value={topupNote}
+              onChange={(e) => setTopupNote(e.target.value)}
+              placeholder="Note (optional)"
+              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            />
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setTopupFor(null)}
+                className="px-3 py-2 text-sm text-slate-500"
+              >
+                Cancel
+              </button>
+              <button
+                disabled={!Number(topupAmt) || topup.isPending}
+                onClick={() =>
+                  topup.mutate({
+                    user_id: topupFor.user_id,
+                    amount: Number(topupAmt),
+                    note: topupNote || undefined,
+                  })
+                }
+                className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                {topup.isPending ? "Adding…" : "Add top-up"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RatesEditor({
+  rates,
+  onSave,
+  saving,
+}: {
+  rates: ExpenseVehicleRate[];
+  onSave: (v: Partial<ExpenseVehicleRate>) => void;
+  saving: boolean;
+}) {
+  const [newLabel, setNewLabel] = useState("");
+  const [newRate, setNewRate] = useState("");
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <p className="mb-3 text-sm text-slate-500">
+        Per-kilometre rates used to compute petrol reimbursement (amount = km ×
+        rate).
+      </p>
+      <div className="space-y-2">
+        {rates.map((r) => (
+          <RateRow key={r.id} rate={r} onSave={onSave} saving={saving} />
+        ))}
+      </div>
+      <div className="mt-4 flex items-end gap-2 border-t border-slate-100 pt-4">
+        <div className="flex-1">
+          <label className="text-xs text-slate-400">New vehicle</label>
+          <input
+            value={newLabel}
+            onChange={(e) => setNewLabel(e.target.value)}
+            placeholder="e.g. Tempo"
+            className="w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
+          />
+        </div>
+        <div className="w-28">
+          <label className="text-xs text-slate-400">₹/km</label>
+          <input
+            value={newRate}
+            onChange={(e) => setNewRate(e.target.value)}
+            inputMode="numeric"
+            className="w-full rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
+          />
+        </div>
+        <button
+          disabled={!newLabel.trim() || !Number(newRate) || saving}
+          onClick={() => {
+            onSave({ label: newLabel.trim(), per_km_rate: Number(newRate) });
+            setNewLabel("");
+            setNewRate("");
+          }}
+          className="rounded-lg bg-slate-900 px-4 py-1.5 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RateRow({
+  rate,
+  onSave,
+  saving,
+}: {
+  rate: ExpenseVehicleRate;
+  onSave: (v: Partial<ExpenseVehicleRate>) => void;
+  saving: boolean;
+}) {
+  const [val, setVal] = useState(String(rate.per_km_rate));
+  const dirty = val !== String(rate.per_km_rate);
+  return (
+    <div className="flex items-center gap-3">
+      <span className="flex-1 text-sm text-slate-700">{rate.label}</span>
+      <input
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        inputMode="numeric"
+        className="w-24 rounded-lg border border-slate-200 px-3 py-1.5 text-sm"
+      />
+      <span className="text-xs text-slate-400">₹/km</span>
+      <button
+        disabled={!dirty || !Number(val) || saving}
+        onClick={() => onSave({ id: rate.id, label: rate.label, per_km_rate: Number(val) })}
+        className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 disabled:opacity-40"
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -58,6 +58,7 @@ const navigation: NavItem[] = [
   },
   { name: "Plan", href: "/planning", icon: ProductionIcon, key: "planning" },
   { name: "Projects", href: "/projects", icon: ProductionIcon, key: "projects" },
+  { name: "Reimbursements", href: "/expenses", icon: KPIIcon, key: "expenses" },
   {
     name: "Approvals",
     href: "/approvals",
@@ -90,6 +91,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
     "knowledge",
     "coaching",
     "projects",
+    "expenses",
   ],
   engineer: [
     "dashboard",

--- a/apps/web/app/api/expenses/[id]/approve/route.ts
+++ b/apps/web/app/api/expenses/[id]/approve/route.ts
@@ -1,0 +1,77 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { approveExpenseSchema } from "@maiyuri/shared";
+import { EXPENSE_ADMIN_ROLES, postClaimToProjectCost } from "@/lib/expenses";
+import { notifyExpenseApproved } from "@/lib/expenses-notify";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/expenses/[id]/approve — admin approves a pending claim.
+// (Balance was already deducted on submit; approval posts to project costs.)
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const user = await requireAuth(request);
+    if (!EXPENSE_ADMIN_ROLES.includes(user.role)) {
+      return error("Only founders, owners and accountants can approve", 403);
+    }
+    const { id } = await params;
+    const parsed = await parseBody(request, approveExpenseSchema);
+    if (parsed.error) return parsed.error;
+
+    // Load the claim + its type's cost_category for the project-cost post.
+    const { data: claim } = await supabaseAdmin
+      .from("expense_claims")
+      .select("*, expense_type:expense_types(cost_category)")
+      .eq("id", id)
+      .single();
+    if (!claim) return error("Expense not found", 404);
+    if (claim.status !== "pending") {
+      return error("This expense is no longer pending", 409);
+    }
+
+    // Post to project costing (best-effort; never blocks approval).
+    const costEntryId = await postClaimToProjectCost({
+      id: claim.id,
+      project_id: claim.project_id,
+      amount: Number(claim.amount),
+      description: claim.description,
+      expense_date: claim.expense_date,
+      receipt_url: claim.receipt_url,
+      cost_category:
+        (claim.expense_type as { cost_category?: string } | null)?.cost_category ??
+        "miscellaneous",
+      vendor_name: claim.customer_name,
+    });
+
+    const { data: updated, error: updErr } = await supabaseAdmin
+      .from("expense_claims")
+      .update({
+        status: "approved",
+        approved_by: user.id,
+        approved_at: new Date().toISOString(),
+        cost_entry_id: costEntryId,
+      })
+      .eq("id", id)
+      .eq("status", "pending") // optimistic guard against a concurrent decision
+      .select("*")
+      .single();
+    if (updErr || !updated) return error("Failed to approve expense", 500);
+
+    void notifyExpenseApproved({
+      userId: claim.user_id,
+      amount: Number(claim.amount),
+    });
+
+    return success(updated);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] approve failed:", err);
+    return error("Failed to approve expense", 500);
+  }
+}

--- a/apps/web/app/api/expenses/[id]/reject/route.ts
+++ b/apps/web/app/api/expenses/[id]/reject/route.ts
@@ -1,0 +1,63 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { rejectExpenseSchema } from "@maiyuri/shared";
+import { EXPENSE_ADMIN_ROLES } from "@/lib/expenses";
+import { notifyExpenseRejected } from "@/lib/expenses-notify";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/expenses/[id]/reject — admin rejects; the amount leaves the
+// "spent" sum so the staffer's available balance is restored automatically.
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const user = await requireAuth(request);
+    if (!EXPENSE_ADMIN_ROLES.includes(user.role)) {
+      return error("Only founders, owners and accountants can reject", 403);
+    }
+    const { id } = await params;
+    const parsed = await parseBody(request, rejectExpenseSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data: claim } = await supabaseAdmin
+      .from("expense_claims")
+      .select("user_id, amount, status")
+      .eq("id", id)
+      .single();
+    if (!claim) return error("Expense not found", 404);
+    if (claim.status !== "pending") {
+      return error("This expense is no longer pending", 409);
+    }
+
+    const { data: updated, error: updErr } = await supabaseAdmin
+      .from("expense_claims")
+      .update({
+        status: "rejected",
+        reject_reason: parsed.data.reason,
+        approved_by: user.id,
+        approved_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .eq("status", "pending")
+      .select("*")
+      .single();
+    if (updErr || !updated) return error("Failed to reject expense", 500);
+
+    void notifyExpenseRejected({
+      userId: claim.user_id,
+      amount: Number(claim.amount),
+      reason: parsed.data.reason,
+    });
+
+    return success(updated);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] reject failed:", err);
+    return error("Failed to reject expense", 500);
+  }
+}

--- a/apps/web/app/api/expenses/rates/route.ts
+++ b/apps/web/app/api/expenses/rates/route.ts
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { vehicleRateSchema } from "@maiyuri/shared";
+import { EXPENSE_ADMIN_ROLES } from "@/lib/expenses";
+
+// GET /api/expenses/rates — vehicle per-km rates (any authenticated caller).
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+    const { data } = await supabaseAdmin
+      .from("expense_vehicle_rates")
+      .select("*")
+      .order("per_km_rate");
+    return success(data ?? []);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    return error("Failed to load vehicle rates", 500);
+  }
+}
+
+// PUT /api/expenses/rates — admin upsert (id present = update, else insert).
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!EXPENSE_ADMIN_ROLES.includes(user.role)) {
+      return error("Not permitted", 403);
+    }
+    const parsed = await parseBody(request, vehicleRateSchema);
+    if (parsed.error) return parsed.error;
+    const v = parsed.data;
+
+    if (v.id) {
+      const { data, error: e } = await supabaseAdmin
+        .from("expense_vehicle_rates")
+        .update({
+          label: v.label,
+          per_km_rate: v.per_km_rate,
+          ...(v.active != null ? { active: v.active } : {}),
+        })
+        .eq("id", v.id)
+        .select("*")
+        .single();
+      if (e) return error("Failed to update rate", 500);
+      return success(data);
+    }
+    const { data, error: e } = await supabaseAdmin
+      .from("expense_vehicle_rates")
+      .insert({ label: v.label, per_km_rate: v.per_km_rate })
+      .select("*")
+      .single();
+    if (e) return error("Failed to add rate", 500);
+    return success(data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    return error("Failed to save vehicle rate", 500);
+  }
+}

--- a/apps/web/app/api/expenses/receipts/route.ts
+++ b/apps/web/app/api/expenses/receipts/route.ts
@@ -1,0 +1,93 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { EXPENSE_ADMIN_ROLES, EXPENSE_SUBMITTER_ROLES } from "@/lib/expenses";
+
+export const EXPENSE_RECEIPT_BUCKET = "expense-receipts";
+
+const ALLOWED_MIME = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+  "application/pdf",
+];
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * POST /api/expenses/receipts — multipart receipt upload (before claim save).
+ * Returns { path, url } — the claim stores `path` in receipt_url; `url` is a
+ * short-lived signed URL for immediate preview. Fetch a fresh URL later via
+ * GET /api/expenses/receipts?path=...
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (
+      !EXPENSE_SUBMITTER_ROLES.includes(user.role) &&
+      !EXPENSE_ADMIN_ROLES.includes(user.role)
+    ) {
+      return error("Not permitted", 403);
+    }
+    const form = await request.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) return error("No file provided", 400);
+    if (!ALLOWED_MIME.includes(file.type)) {
+      return error("Only images or PDF receipts are allowed", 400);
+    }
+    if (file.size > MAX_SIZE_BYTES) return error("Receipt too large (max 10MB)", 400);
+
+    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(-80);
+    const path = `${user.id}/${Date.now()}-${safeName}`;
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const { error: upErr } = await supabaseAdmin.storage
+      .from(EXPENSE_RECEIPT_BUCKET)
+      .upload(path, buffer, { contentType: file.type });
+    if (upErr) {
+      console.error("[Expenses] receipt upload failed:", upErr);
+      return error("Receipt upload failed", 500);
+    }
+
+    const { data: signed } = await supabaseAdmin.storage
+      .from(EXPENSE_RECEIPT_BUCKET)
+      .createSignedUrl(path, 3600);
+
+    return success({ path, url: signed?.signedUrl ?? null });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] receipt POST error:", err);
+    return error("Receipt upload failed", 500);
+  }
+}
+
+/**
+ * GET /api/expenses/receipts?path=... — fresh signed URL for a stored receipt.
+ * Allowed for the claim's owner or an admin.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    const path = new URL(request.url).searchParams.get("path");
+    if (!path) return error("path required", 400);
+
+    const isAdmin = EXPENSE_ADMIN_ROLES.includes(user.role);
+    if (!isAdmin) {
+      // Non-admins may only sign their own uploads (paths are prefixed by uid).
+      if (!path.startsWith(`${user.id}/`)) return error("Not permitted", 403);
+    }
+
+    const { data: signed, error: sErr } = await supabaseAdmin.storage
+      .from(EXPENSE_RECEIPT_BUCKET)
+      .createSignedUrl(path, 3600);
+    if (sErr || !signed) return error("Receipt not found", 404);
+    return success({ url: signed.signedUrl });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    return error("Failed to sign receipt", 500);
+  }
+}

--- a/apps/web/app/api/expenses/route.ts
+++ b/apps/web/app/api/expenses/route.ts
@@ -1,0 +1,186 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { createExpenseSchema } from "@maiyuri/shared";
+import type {
+  AllExpensesResponse,
+  ExpenseClaim,
+  MyExpensesResponse,
+} from "@maiyuri/shared";
+import {
+  EXPENSE_ADMIN_ROLES,
+  EXPENSE_SUBMITTER_ROLES,
+  getAllBalances,
+  getBalance,
+} from "@/lib/expenses";
+import { notifyExpenseSubmitted } from "@/lib/expenses-notify";
+
+const CLAIM_SELECT =
+  "*, expense_type:expense_types(id, name, kind, icon), project:projects(id, name), user:users!expense_claims_user_id_fkey(id, name)";
+
+// GET /api/expenses           → my balance + my claims/topups + masters
+// GET /api/expenses?view=all  → admin: all balances + pending queue
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    const isAdmin = EXPENSE_ADMIN_ROLES.includes(user.role);
+    const view = new URL(request.url).searchParams.get("view");
+
+    if (view === "all") {
+      if (!isAdmin) return error("Not permitted", 403);
+      const [balances, pendingRes] = await Promise.all([
+        getAllBalances(),
+        supabaseAdmin
+          .from("expense_claims")
+          .select(CLAIM_SELECT)
+          .eq("status", "pending")
+          .order("created_at", { ascending: true }),
+      ]);
+      return success<AllExpensesResponse>({
+        balances,
+        pending: (pendingRes.data ?? []) as ExpenseClaim[],
+      });
+    }
+
+    // Own view
+    const [bal, claimsRes, topupsRes, typesRes, ratesRes] = await Promise.all([
+      getBalance(user.id),
+      supabaseAdmin
+        .from("expense_claims")
+        .select(CLAIM_SELECT)
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(100),
+      supabaseAdmin
+        .from("petty_cash_topups")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(50),
+      supabaseAdmin
+        .from("expense_types")
+        .select("*")
+        .eq("active", true)
+        .order("sort_order"),
+      supabaseAdmin
+        .from("expense_vehicle_rates")
+        .select("*")
+        .eq("active", true)
+        .order("per_km_rate"),
+    ]);
+
+    return success<MyExpensesResponse>({
+      balance: bal.balance,
+      topups_total: bal.topups_total,
+      spent_total: bal.spent_total,
+      claims: (claimsRes.data ?? []) as ExpenseClaim[],
+      topups: topupsRes.data ?? [],
+      types: typesRes.data ?? [],
+      vehicleRates: ratesRes.data ?? [],
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] GET failed:", err);
+    return error("Failed to load expenses", 500);
+  }
+}
+
+// POST /api/expenses — submit a claim (deducts from available balance now)
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (
+      !EXPENSE_SUBMITTER_ROLES.includes(user.role) &&
+      !EXPENSE_ADMIN_ROLES.includes(user.role)
+    ) {
+      return error("Your role cannot record expenses", 403);
+    }
+
+    const parsed = await parseBody(request, createExpenseSchema);
+    if (parsed.error) return parsed.error;
+    const input = parsed.data;
+
+    const { data: type } = await supabaseAdmin
+      .from("expense_types")
+      .select("id, name, kind, requires_project, active")
+      .eq("id", input.expense_type_id)
+      .single();
+    if (!type || !type.active) return error("Invalid expense type", 400);
+    if (type.requires_project && !input.project_id) {
+      return error("This expense type requires a project", 400);
+    }
+
+    // Resolve the amount. For petrol, ALWAYS compute server-side from the
+    // chosen vehicle rate × km — the client's number is never trusted.
+    let amount: number;
+    let perKmApplied: number | null = null;
+    if (type.kind === "petrol") {
+      if (!input.vehicle_rate_id || !input.km || input.km <= 0) {
+        return error("Petrol expense needs a vehicle and kilometres", 400);
+      }
+      const { data: rate } = await supabaseAdmin
+        .from("expense_vehicle_rates")
+        .select("per_km_rate, active")
+        .eq("id", input.vehicle_rate_id)
+        .single();
+      if (!rate || !rate.active) return error("Invalid vehicle rate", 400);
+      perKmApplied = Number(rate.per_km_rate);
+      amount = Math.round(perKmApplied * input.km * 100) / 100;
+    } else {
+      if (input.amount == null || input.amount < 0) {
+        return error("Amount is required", 400);
+      }
+      amount = input.amount;
+    }
+
+    // Overspend guard: available balance must cover this claim.
+    const bal = await getBalance(user.id);
+    if (amount > bal.balance) {
+      return error(
+        `Amount ₹${Math.round(amount)} exceeds your available balance ₹${Math.round(bal.balance)}`,
+        400,
+      );
+    }
+
+    const { data: claim, error: insErr } = await supabaseAdmin
+      .from("expense_claims")
+      .insert({
+        user_id: user.id,
+        expense_type_id: input.expense_type_id,
+        project_id: input.project_id ?? null,
+        amount,
+        description: input.description ?? null,
+        expense_date: input.expense_date || new Date().toISOString().slice(0, 10),
+        receipt_url: input.receipt_url ?? null,
+        status: "pending",
+        vehicle_rate_id: input.vehicle_rate_id ?? null,
+        lead_id: input.lead_id ?? null,
+        customer_name: input.customer_name ?? null,
+        from_location: input.from_location ?? null,
+        to_location: input.to_location ?? null,
+        km: input.km ?? null,
+        per_km_rate_applied: perKmApplied,
+      })
+      .select(CLAIM_SELECT)
+      .single();
+    if (insErr || !claim) {
+      console.error("[Expenses] insert failed:", insErr);
+      return error("Failed to save expense", 500);
+    }
+
+    void notifyExpenseSubmitted({
+      submitterName: user.email,
+      amount,
+      typeName: type.name,
+    });
+
+    return success<ExpenseClaim>(claim as ExpenseClaim);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] POST failed:", err);
+    return error("Failed to save expense", 500);
+  }
+}

--- a/apps/web/app/api/expenses/topups/route.ts
+++ b/apps/web/app/api/expenses/topups/route.ts
@@ -1,0 +1,43 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { topupSchema } from "@maiyuri/shared";
+import { EXPENSE_ADMIN_ROLES } from "@/lib/expenses";
+import { notifyTopup } from "@/lib/expenses-notify";
+
+// POST /api/expenses/topups — admin credits a staffer's petty-cash float.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!EXPENSE_ADMIN_ROLES.includes(user.role)) {
+      return error("Only founders, owners and accountants can add top-ups", 403);
+    }
+    const parsed = await parseBody(request, topupSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data: topup, error: insErr } = await supabaseAdmin
+      .from("petty_cash_topups")
+      .insert({
+        user_id: parsed.data.user_id,
+        amount: parsed.data.amount,
+        note: parsed.data.note ?? null,
+        created_by: user.id,
+      })
+      .select("*")
+      .single();
+    if (insErr || !topup) {
+      console.error("[Expenses] topup failed:", insErr);
+      return error("Failed to add top-up", 500);
+    }
+
+    void notifyTopup({ userId: parsed.data.user_id, amount: parsed.data.amount });
+    return success(topup);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Expenses] topup error:", err);
+    return error("Failed to add top-up", 500);
+  }
+}

--- a/apps/web/app/api/expenses/types/route.ts
+++ b/apps/web/app/api/expenses/types/route.ts
@@ -1,0 +1,67 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { expenseTypeSchema } from "@maiyuri/shared";
+import { EXPENSE_ADMIN_ROLES } from "@/lib/expenses";
+
+// GET /api/expenses/types — expense-type master (any authenticated caller).
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+    const { data } = await supabaseAdmin
+      .from("expense_types")
+      .select("*")
+      .order("sort_order");
+    return success(data ?? []);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    return error("Failed to load expense types", 500);
+  }
+}
+
+// PUT /api/expenses/types — admin upsert (id present = update, else insert).
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!EXPENSE_ADMIN_ROLES.includes(user.role)) {
+      return error("Not permitted", 403);
+    }
+    const parsed = await parseBody(request, expenseTypeSchema);
+    if (parsed.error) return parsed.error;
+    const t = parsed.data;
+
+    const fields = {
+      name: t.name,
+      cost_category: t.cost_category,
+      ...(t.kind != null ? { kind: t.kind } : {}),
+      ...(t.requires_project != null ? { requires_project: t.requires_project } : {}),
+      ...(t.icon !== undefined ? { icon: t.icon } : {}),
+      ...(t.sort_order != null ? { sort_order: t.sort_order } : {}),
+      ...(t.active != null ? { active: t.active } : {}),
+    };
+
+    if (t.id) {
+      const { data, error: e } = await supabaseAdmin
+        .from("expense_types")
+        .update(fields)
+        .eq("id", t.id)
+        .select("*")
+        .single();
+      if (e) return error("Failed to update type", 500);
+      return success(data);
+    }
+    const { data, error: e } = await supabaseAdmin
+      .from("expense_types")
+      .insert(fields)
+      .select("*")
+      .single();
+    if (e) return error("Failed to add type", 500);
+    return success(data);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    return error("Failed to save expense type", 500);
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -23,6 +23,7 @@ const protectedRoutes = [
   "/quotes",
   "/planning",
   "/projects",
+  "/expenses",
   "/approvals",
   "/production",
   "/deliveries",

--- a/apps/web/src/lib/expenses-notify.ts
+++ b/apps/web/src/lib/expenses-notify.ts
@@ -1,0 +1,77 @@
+/**
+ * Reimbursement push notifications. Fire-and-forget — never fail a write
+ * because a push failed. Deep link `/onehub/expenses` resolves on web + native.
+ */
+import {
+  filterByPushPref,
+  getUserIdsByRoles,
+  isFcmConfigured,
+  sendPushToUsers,
+} from "@/lib/push/fcm";
+import { EXPENSE_ADMIN_ROLES } from "@/lib/expenses";
+
+const URL = "/onehub/expenses";
+
+async function safeSend(
+  userIds: string[],
+  payload: { title: string; body: string; data?: Record<string, string> },
+): Promise<void> {
+  try {
+    if (!isFcmConfigured() || userIds.length === 0) return;
+    const recipients = await filterByPushPref(userIds, "push_ops");
+    if (!recipients.length) return;
+    await sendPushToUsers(recipients, payload);
+  } catch (err) {
+    console.error("[Expenses] push failed (ignored):", err);
+  }
+}
+
+const inr = (n: number) => `₹${Math.round(n).toLocaleString("en-IN")}`;
+
+/** New claim submitted → tell the admins (approvers). */
+export async function notifyExpenseSubmitted(opts: {
+  submitterName: string;
+  amount: number;
+  typeName: string;
+}): Promise<void> {
+  const admins = await getUserIdsByRoles(EXPENSE_ADMIN_ROLES);
+  await safeSend(admins, {
+    title: "🧾 Expense to approve",
+    body: `${opts.submitterName}: ${opts.typeName} ${inr(opts.amount)}`,
+    data: { url: URL },
+  });
+}
+
+export async function notifyExpenseApproved(opts: {
+  userId: string;
+  amount: number;
+}): Promise<void> {
+  await safeSend([opts.userId], {
+    title: "✅ Expense approved",
+    body: `Your ${inr(opts.amount)} claim was approved.`,
+    data: { url: URL },
+  });
+}
+
+export async function notifyExpenseRejected(opts: {
+  userId: string;
+  amount: number;
+  reason: string;
+}): Promise<void> {
+  await safeSend([opts.userId], {
+    title: "❌ Expense rejected",
+    body: `${inr(opts.amount)} — ${opts.reason}`.slice(0, 140),
+    data: { url: URL },
+  });
+}
+
+export async function notifyTopup(opts: {
+  userId: string;
+  amount: number;
+}): Promise<void> {
+  await safeSend([opts.userId], {
+    title: "💰 Petty cash added",
+    body: `${inr(opts.amount)} added to your balance.`,
+    data: { url: URL },
+  });
+}

--- a/apps/web/src/lib/expenses.ts
+++ b/apps/web/src/lib/expenses.ts
@@ -1,0 +1,142 @@
+/**
+ * Reimbursement / Petty Cash — server helpers.
+ *
+ * Balance is ALWAYS computed, never stored:
+ *   balance(user) = Σ topups.amount − Σ claims.amount WHERE status IN (pending, approved)
+ * A pending claim already reduces the available balance (overspend guard);
+ * a rejected claim is excluded, so rejecting restores the money.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { recomputeProject } from "@/lib/projects/recompute";
+import type { ExpenseBalance } from "@maiyuri/shared";
+
+export const EXPENSE_SUBMITTER_ROLES = [
+  "engineer",
+  "driver",
+  "sales",
+  "production_supervisor",
+];
+export const EXPENSE_ADMIN_ROLES = ["founder", "owner", "accountant"];
+
+const num = (v: unknown): number =>
+  typeof v === "number" ? v : Number(v) || 0;
+
+/** One staffer's live balance. */
+export async function getBalance(userId: string): Promise<{
+  balance: number;
+  topups_total: number;
+  spent_total: number;
+}> {
+  const [topupsRes, claimsRes] = await Promise.all([
+    supabaseAdmin.from("petty_cash_topups").select("amount").eq("user_id", userId),
+    supabaseAdmin
+      .from("expense_claims")
+      .select("amount")
+      .eq("user_id", userId)
+      .in("status", ["pending", "approved"]),
+  ]);
+  const topups_total = (topupsRes.data ?? []).reduce((s, r) => s + num(r.amount), 0);
+  const spent_total = (claimsRes.data ?? []).reduce((s, r) => s + num(r.amount), 0);
+  return {
+    topups_total,
+    spent_total,
+    balance: topups_total - spent_total,
+  };
+}
+
+/** Balances for every submitter-role staffer (admin all-staff view). */
+export async function getAllBalances(): Promise<ExpenseBalance[]> {
+  const { data: users } = await supabaseAdmin
+    .from("users")
+    .select("id, name, role, is_active")
+    .eq("is_active", true)
+    .in("role", EXPENSE_SUBMITTER_ROLES);
+
+  const ids = (users ?? []).map((u) => u.id);
+  if (!ids.length) return [];
+
+  const [topupsRes, claimsRes] = await Promise.all([
+    supabaseAdmin.from("petty_cash_topups").select("user_id, amount").in("user_id", ids),
+    supabaseAdmin
+      .from("expense_claims")
+      .select("user_id, amount, status")
+      .in("user_id", ids)
+      .in("status", ["pending", "approved"]),
+  ]);
+
+  const topupByUser = new Map<string, number>();
+  for (const t of topupsRes.data ?? []) {
+    topupByUser.set(t.user_id, (topupByUser.get(t.user_id) ?? 0) + num(t.amount));
+  }
+  const spentByUser = new Map<string, number>();
+  const pendingByUser = new Map<string, number>();
+  for (const c of claimsRes.data ?? []) {
+    spentByUser.set(c.user_id, (spentByUser.get(c.user_id) ?? 0) + num(c.amount));
+    if (c.status === "pending") {
+      pendingByUser.set(c.user_id, (pendingByUser.get(c.user_id) ?? 0) + 1);
+    }
+  }
+
+  return (users ?? [])
+    .map((u) => {
+      const topups_total = topupByUser.get(u.id) ?? 0;
+      const spent_total = spentByUser.get(u.id) ?? 0;
+      return {
+        user_id: u.id,
+        name: u.name,
+        role: u.role,
+        topups_total,
+        spent_total,
+        balance: topups_total - spent_total,
+        pending_count: pendingByUser.get(u.id) ?? 0,
+      };
+    })
+    .sort((a, b) => b.pending_count - a.pending_count || b.balance - a.balance);
+}
+
+/**
+ * On approval of a PROJECT-linked claim, post it into the project cost ledger
+ * so actuals/variance reflect field spend. Best-effort: a failure here must
+ * never block the approval (mirrors the deliveries trip-cost write). Returns
+ * the created cost_entry id, or null.
+ */
+export async function postClaimToProjectCost(claim: {
+  id: string;
+  project_id: string | null;
+  amount: number;
+  description: string | null;
+  expense_date: string;
+  receipt_url: string | null;
+  cost_category: string;
+  vendor_name: string | null;
+}): Promise<string | null> {
+  if (!claim.project_id) return null;
+  try {
+    const { data: entry, error: insErr } = await supabaseAdmin
+      .from("cost_entries")
+      .insert({
+        project_id: claim.project_id,
+        entry_date: claim.expense_date,
+        cost_category: claim.cost_category,
+        description:
+          `Reimbursement: ${claim.description ?? "field expense"}`.slice(0, 500),
+        amount: claim.amount,
+        vendor: claim.vendor_name,
+        payment_status: "paid", // the staffer already paid out of the float
+        attachment_url: claim.receipt_url,
+        source: "manual", // CHECK allows manual|telegram|ai only
+        approval_status: "approved",
+      })
+      .select("id")
+      .single();
+    if (insErr || !entry) {
+      console.error("[Expenses] cost post failed:", insErr);
+      return null;
+    }
+    await recomputeProject(claim.project_id);
+    return entry.id;
+  } catch (err) {
+    console.error("[Expenses] cost post threw:", err);
+    return null;
+  }
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1316,3 +1316,74 @@ export type SubmitQuizAttemptInput = z.infer<typeof submitQuizAttemptSchema>;
 export type SubmitAssignmentInput = z.infer<typeof submitAssignmentSchema>;
 export type ReviewSubmissionInput = z.infer<typeof reviewSubmissionSchema>;
 export type UpsertCoachUserInput = z.infer<typeof upsertCoachUserSchema>;
+
+// ============================================================================
+// Reimbursement / Petty Cash
+// ============================================================================
+
+// Create an expense claim. Petrol claims carry route + km (amount is computed
+// server-side from km × the chosen vehicle rate — never trust the client's
+// number); standard claims carry an amount directly.
+export const createExpenseSchema = z
+  .object({
+    expense_type_id: z.string().uuid(),
+    project_id: z.string().uuid().nullable().optional(),
+    description: z.string().max(500).nullable().optional(),
+    expense_date: z.string().optional(), // YYYY-MM-DD; server defaults today
+    receipt_url: z.string().nullable().optional(),
+    // standard
+    amount: z.number().nonnegative().optional(),
+    // petrol
+    vehicle_rate_id: z.string().uuid().nullable().optional(),
+    lead_id: z.string().uuid().nullable().optional(),
+    customer_name: z.string().max(200).nullable().optional(),
+    from_location: z.string().max(200).nullable().optional(),
+    to_location: z.string().max(200).nullable().optional(),
+    km: z.number().positive().nullable().optional(),
+  })
+  .refine(
+    (v) =>
+      // petrol path: vehicle + km present  OR  standard path: amount present
+      (v.vehicle_rate_id != null && v.km != null && v.km > 0) ||
+      (v.amount != null && v.amount >= 0),
+    { message: "Provide either (vehicle_rate_id + km) for petrol, or an amount." },
+  );
+
+export const approveExpenseSchema = z.object({
+  note: z.string().max(500).optional(),
+});
+
+export const rejectExpenseSchema = z.object({
+  reason: z.string().min(3, "A reason is required").max(500),
+});
+
+export const topupSchema = z.object({
+  user_id: z.string().uuid(),
+  amount: z.number().positive("Amount must be greater than 0"),
+  note: z.string().max(500).optional(),
+});
+
+export const vehicleRateSchema = z.object({
+  id: z.string().uuid().optional(), // present = update
+  label: z.string().min(1).max(80),
+  per_km_rate: z.number().nonnegative(),
+  active: z.boolean().optional(),
+});
+
+export const expenseTypeSchema = z.object({
+  id: z.string().uuid().optional(), // present = update
+  name: z.string().min(1).max(80),
+  cost_category: z.string().min(1),
+  kind: z.enum(["standard", "petrol"]).optional(),
+  requires_project: z.boolean().optional(),
+  icon: z.string().max(8).nullable().optional(),
+  sort_order: z.number().int().optional(),
+  active: z.boolean().optional(),
+});
+
+export type CreateExpenseInput = z.infer<typeof createExpenseSchema>;
+export type ApproveExpenseInput = z.infer<typeof approveExpenseSchema>;
+export type RejectExpenseInput = z.infer<typeof rejectExpenseSchema>;
+export type TopupInput = z.infer<typeof topupSchema>;
+export type VehicleRateInput = z.infer<typeof vehicleRateSchema>;
+export type ExpenseTypeInput = z.infer<typeof expenseTypeSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2188,3 +2188,102 @@ export interface ProjectBudgetsResponse {
     original: number;
   };
 }
+
+// ============================================================================
+// Reimbursement / Petty Cash
+// ============================================================================
+
+export type ExpenseKind = "standard" | "petrol";
+export type ExpenseClaimStatus = "pending" | "approved" | "rejected";
+
+export interface ExpenseType {
+  id: string;
+  name: string;
+  cost_category: string; // maps to cost_entries.cost_category
+  kind: ExpenseKind;
+  requires_project: boolean;
+  icon: string | null;
+  sort_order: number;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ExpenseVehicleRate {
+  id: string;
+  label: string;
+  per_km_rate: number;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PettyCashTopup {
+  id: string;
+  user_id: string;
+  amount: number;
+  note: string | null;
+  created_by: string | null;
+  created_at: string;
+  // joined
+  user?: { id: string; name: string | null } | null;
+}
+
+export interface ExpenseClaim {
+  id: string;
+  user_id: string;
+  expense_type_id: string;
+  project_id: string | null;
+  amount: number;
+  description: string | null;
+  expense_date: string;
+  receipt_url: string | null;
+  status: ExpenseClaimStatus;
+  // petrol detail
+  vehicle_rate_id: string | null;
+  lead_id: string | null;
+  customer_name: string | null;
+  from_location: string | null;
+  to_location: string | null;
+  km: number | null;
+  per_km_rate_applied: number | null;
+  // workflow
+  approved_by: string | null;
+  approved_at: string | null;
+  reject_reason: string | null;
+  cost_entry_id: string | null;
+  created_at: string;
+  updated_at: string;
+  // joined
+  user?: { id: string; name: string | null } | null;
+  expense_type?: Pick<ExpenseType, "id" | "name" | "kind" | "icon"> | null;
+  project?: { id: string; name: string } | null;
+}
+
+/** A staffer's computed petty-cash position. */
+export interface ExpenseBalance {
+  user_id: string;
+  name: string | null;
+  role: string;
+  topups_total: number;
+  spent_total: number; // pending + approved
+  balance: number; // topups_total - spent_total
+  pending_count: number;
+}
+
+/** GET /api/expenses payload for a submitter (own view). */
+export interface MyExpensesResponse {
+  balance: number;
+  topups_total: number;
+  spent_total: number;
+  claims: ExpenseClaim[];
+  topups: PettyCashTopup[];
+  types: ExpenseType[];
+  vehicleRates: ExpenseVehicleRate[];
+}
+
+/** GET /api/expenses?view=all payload for admins. */
+export interface AllExpensesResponse {
+  balances: ExpenseBalance[];
+  pending: ExpenseClaim[];
+}

--- a/supabase/migrations/20260714120000_expenses.sql
+++ b/supabase/migrations/20260714120000_expenses.sql
@@ -1,0 +1,146 @@
+-- ============================================================================
+-- Reimbursement / Petty Cash module
+--
+-- Field staff hold a petty-cash FLOAT (money transferred to them). They record
+-- expenses against it; the office tops it up (reimburses). Balance is ALWAYS
+-- computed live = Σ top-ups − Σ claims(status in pending|approved); never cached.
+--
+--  expense_types          master: what kinds of spend exist (Petrol, Food, …)
+--  expense_vehicle_rates  master: per-km rate per vehicle (petrol amount = km×rate)
+--  petty_cash_topups      admin credits to a staffer's float
+--  expense_claims         the debits (rich; petrol carries route/km/customer)
+--
+-- Follows the Renewals conventions: TEXT+CHECK enums, shared set_updated_at()
+-- trigger, RLS on with a permissive authenticated-read policy (writes go
+-- through the service-role client in the API, which is the real gate).
+-- ============================================================================
+
+-- shared updated_at helper (idempotent — also defined by earlier migrations)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+-- ---------------------------------------------------------------- masters ----
+
+CREATE TABLE IF NOT EXISTS public.expense_types (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  -- maps to cost_entries.cost_category so approved project expenses post cleanly
+  cost_category TEXT NOT NULL DEFAULT 'miscellaneous'
+    CHECK (cost_category IN ('material','labour','machine','transport','fuel',
+      'loading','unloading','subcontract','repair','overhead','miscellaneous')),
+  kind TEXT NOT NULL DEFAULT 'standard' CHECK (kind IN ('standard','petrol')),
+  requires_project BOOLEAN NOT NULL DEFAULT false,
+  icon TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.expense_vehicle_rates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  label TEXT NOT NULL,
+  per_km_rate NUMERIC NOT NULL DEFAULT 0 CHECK (per_km_rate >= 0),
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------- ledger -----
+
+CREATE TABLE IF NOT EXISTS public.petty_cash_topups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  amount NUMERIC NOT NULL CHECK (amount > 0),
+  note TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_petty_cash_topups_user
+  ON public.petty_cash_topups (user_id);
+
+CREATE TABLE IF NOT EXISTS public.expense_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  expense_type_id UUID NOT NULL REFERENCES public.expense_types(id) ON DELETE RESTRICT,
+  project_id UUID REFERENCES public.projects(id) ON DELETE SET NULL,
+  amount NUMERIC NOT NULL CHECK (amount >= 0),
+  description TEXT,
+  expense_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  receipt_url TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','approved','rejected')),
+  -- petrol trip detail (null for standard expenses)
+  vehicle_rate_id UUID REFERENCES public.expense_vehicle_rates(id) ON DELETE SET NULL,
+  lead_id UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  customer_name TEXT,
+  from_location TEXT,
+  to_location TEXT,
+  km NUMERIC CHECK (km IS NULL OR km >= 0),
+  per_km_rate_applied NUMERIC, -- snapshot of the rate at submit time
+  -- workflow
+  approved_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at TIMESTAMPTZ,
+  reject_reason TEXT,
+  cost_entry_id UUID REFERENCES public.cost_entries(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_expense_claims_user_status
+  ON public.expense_claims (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_expense_claims_pending
+  ON public.expense_claims (created_at) WHERE status = 'pending';
+
+-- ---------------------------------------------------------------- RLS --------
+
+ALTER TABLE public.expense_types ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.expense_vehicle_rates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.petty_cash_topups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.expense_claims ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "auth read expense_types" ON public.expense_types
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read expense_vehicle_rates" ON public.expense_vehicle_rates
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read petty_cash_topups" ON public.petty_cash_topups
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "auth read expense_claims" ON public.expense_claims
+  FOR SELECT TO authenticated USING (true);
+
+-- ---------------------------------------------------------------- triggers ---
+
+DROP TRIGGER IF EXISTS trg_expense_types_updated_at ON public.expense_types;
+CREATE TRIGGER trg_expense_types_updated_at
+  BEFORE UPDATE ON public.expense_types
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_expense_vehicle_rates_updated_at ON public.expense_vehicle_rates;
+CREATE TRIGGER trg_expense_vehicle_rates_updated_at
+  BEFORE UPDATE ON public.expense_vehicle_rates
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_expense_claims_updated_at ON public.expense_claims;
+CREATE TRIGGER trg_expense_claims_updated_at
+  BEFORE UPDATE ON public.expense_claims
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ---------------------------------------------------------------- seeds ------
+
+INSERT INTO public.expense_types (name, cost_category, kind, requires_project, icon, sort_order)
+SELECT * FROM (VALUES
+  ('Petrol / Fuel',       'fuel',          'petrol',   false, '⛽', 10),
+  ('Food & Refreshments', 'miscellaneous', 'standard', false, '🍽️', 20),
+  ('Materials purchase',  'material',      'standard', true,  '🧱', 30),
+  ('Tools & Consumables', 'miscellaneous', 'standard', false, '🔧', 40),
+  ('Toll & Parking',      'transport',     'standard', false, '🅿️', 50),
+  ('Other',               'miscellaneous', 'standard', false, '📌', 60)
+) AS v(name, cost_category, kind, requires_project, icon, sort_order)
+WHERE NOT EXISTS (SELECT 1 FROM public.expense_types);
+
+INSERT INTO public.expense_vehicle_rates (label, per_km_rate)
+SELECT * FROM (VALUES
+  ('Two-wheeler', 4),
+  ('Car / Van',   12)
+) AS v(label, per_km_rate)
+WHERE NOT EXISTS (SELECT 1 FROM public.expense_vehicle_rates);


### PR DESCRIPTION
Field engineers hold a **petty-cash float**; they record expenses against it (with a **petrol** flow that computes the amount from km × a master rate), and the office sees every balance, approves/rejects, and tops up floats. Approved project-linked expenses flow into the existing project cost ledger.

## The balance model
Balance is **computed live, never stored**: `Σ topups − Σ claims(status in pending|approved)`. An expense deducts on **submit** (overspend guard — POST 400s if amount > balance); **approve** is the audit gate; **reject** restores the money.

## Data (migration applied to prod + seeds verified)
`expense_types` (master; kind standard|petrol, cost_category maps to cost_entries), `expense_vehicle_rates` (per-km petrol rates — Two-wheeler ₹4, Car ₹12 seeded), `petty_cash_topups` (admin credits), `expense_claims` (debits; petrol carries vehicle/km/from/to/customer + a `per_km_rate_applied` snapshot). RLS + triggers; private `expense-receipts` bucket.

## Backend `apps/web/app/api/expenses/*`
- GET (own view / `?view=all` admin balances + pending queue), POST (submit)
- **Petrol amount computed server-side** (km × vehicle rate) — client number never trusted
- `[id]/approve` + `/reject` (admin, status-guarded); approve best-effort posts a `cost_entries` row for project-linked claims + `recomputeProject()` (`source='manual'` — that CHECK excludes other values; back-linked via `claim.cost_entry_id`)
- `topups`, `rates`, `types` (masters), `receipts` (multipart upload + signed-URL fetch)
- Push via `expenses-notify.ts` (submitted→admins, approved/rejected/topup→user)

## Web cockpit `/expenses` (founder/owner/accountant)
All-staff balance table, pending-approval queue (approve / reject-with-reason), one-click top-up, and the vehicle-rate master editor. Nav + middleware wired.

## Mobile (submitters: engineer/driver/sales/supervisor)
- `onehub/expenses` — big **balance card** + claims/top-ups list
- `onehub/expenses/new` — type chips → petrol (vehicle + customer[lead picker/free-text] + from/to/km with **live amount preview**) or standard amount → project picker → notes → **receipt camera**
- Admins get an **Expense claims** queue on the shared Approvals screen
- OneHub tile, role-gated

## Roles
`EXPENSE_SUBMITTER_ROLES` = engineer/driver/sales/production_supervisor · `EXPENSE_ADMIN_ROLES` = founder/owner/accountant.

## Testing
- tsc web + native clean; eslint clean on new files; migration applied + seeds confirmed
- Live money-path API test (topup → petrol claim km×rate → approve posts to project cost → reject restores → overspend 400) after this deploys to prod
- Mobile ships via **OTA** (JS-only) — no APK rebuild

No new cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Reimbursements dashboard with tabs for approval queues, petty-cash balances, and vehicle reimbursement rates.
  * Staff can submit claims, upload receipts, view balances, and receive reimbursement updates.
  * Authorized reviewers can approve or reject claims, top up petty cash, and manage vehicle rates and expense types.
  * Added role-based access through the dashboard navigation.
  * Added validation for claim amounts, rejection reasons, receipts, and reimbursement settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->