### PR TITLE
fix(build): unblock Vercel — move EXPENSE_RECEIPT_BUCKET out of route.ts

### DIFF
--- a/apps/web/app/api/expenses/receipts/route.ts
+++ b/apps/web/app/api/expenses/receipts/route.ts
@@ -4,9 +4,11 @@ import { NextRequest } from "next/server";
 import { success, error } from "@/lib/api-utils";
 import { requireAuth, AuthError } from "@/lib/api-helpers";
 import { supabaseAdmin } from "@/lib/supabase-admin";
-import { EXPENSE_ADMIN_ROLES, EXPENSE_SUBMITTER_ROLES } from "@/lib/expenses";
-
-export const EXPENSE_RECEIPT_BUCKET = "expense-receipts";
+import {
+  EXPENSE_ADMIN_ROLES,
+  EXPENSE_RECEIPT_BUCKET,
+  EXPENSE_SUBMITTER_ROLES,
+} from "@/lib/expenses";
 
 const ALLOWED_MIME = [
   "image/jpeg",

--- a/apps/web/src/lib/expenses.ts
+++ b/apps/web/src/lib/expenses.ts
@@ -18,6 +18,11 @@ export const EXPENSE_SUBMITTER_ROLES = [
 ];
 export const EXPENSE_ADMIN_ROLES = ["founder", "owner", "accountant"];
 
+// Private Supabase Storage bucket for receipt uploads. Lives here (not in the
+// route) because a route.ts may only export Next.js route fields — exporting
+// any other const from it fails the production build.
+export const EXPENSE_RECEIPT_BUCKET = "expense-receipts";
+
 const num = (v: unknown): number =>
   typeof v === "number" ? v : Number(v) || 0;
 


### PR DESCRIPTION
## Why prod looked stale

Every web production build has failed since the expenses module (#91) merged, so **Vercel has been frozen on a pre-#91 deployment**. That is why the Plan tab kept showing open orders oldest-first even after #95 merged — the descending-sort fix (and the whole expenses module, native-feel #92, etc.) never actually deployed.

## Root cause

`app/api/expenses/receipts/route.ts` exported a non-route constant:

```
Type error: "EXPENSE_RECEIPT_BUCKET" is not a valid Route export field.
```

Next.js App Router route.ts files may only export framework route fields (GET/POST/dynamic/runtime/maxDuration/...). Any other export fails `next build`. Plain `tsc --noEmit` does NOT catch this — only `next build` runs route-type validation, which is why typecheck stayed green while Vercel builds died.

## Fix

Move `EXPENSE_RECEIPT_BUCKET` to `@/lib/expenses` (next to the role constants) and import it. Swept all other route.ts files — no other illegal exports.

## Verification

- Full local `next build` -> exit 0, route-type check passes, /expenses and all routes emit.
- `tsc --noEmit` clean.

Once merged, Vercel will build green and finally ship #91–#95 (including the newest-first Plan order).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized expense receipt storage configuration to improve consistency across the application.
  * Receipt uploads and retrieval continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->