### PR TITLE
feat(home): role-based Ops Home — stock, cement bags, bank & cash balance

### DIFF
--- a/apps/native/app/(tabs)/index.tsx
+++ b/apps/native/app/(tabs)/index.tsx
@@ -18,6 +18,10 @@ import {
 } from '@/hooks/use-dashboard';
 import { useLeads } from '@/hooks/use-leads';
 import { useMyWork } from '@/hooks/use-my-work';
+import { useMyProfile } from '@/hooks/use-push-settings';
+import { OPS_HOME_ROLES, useOpsSnapshot } from '@/hooks/use-ops-home';
+import { useAuth } from '@/store/auth';
+import { OpsHomePanel } from '@/components/OpsHomePanel';
 import { SkeletonList } from '@/ui';
 
 type CardDef = {
@@ -170,6 +174,14 @@ function MyWorkStrip() {
 
 export default function DashboardScreen() {
   const router = useRouter();
+  const { session } = useAuth();
+  const profile = useMyProfile(session?.user?.id);
+  const role = (profile.data?.data.role as string | undefined) ?? '';
+  // Ops-first home for factory/accounts roles; the server route re-checks the
+  // role, so this flag only decides LAYOUT, never data access.
+  const opsRole = OPS_HOME_ROLES.includes(role);
+  const opsFirst = role === 'production_supervisor' || role === 'accountant';
+  const opsQuery = useOpsSnapshot(opsRole);
   const { data, isLoading, isError, error, refetch, isRefetching } =
     useDashboardStats();
   // Reuses the leads cache shared with the Leads tab (same query key).
@@ -182,6 +194,71 @@ export default function DashboardScreen() {
     () => computeTodayActions(leadsQuery.data?.data ?? []),
     [leadsQuery.data],
   );
+
+  // ── Ops Home (production_supervisor / accountant) ────────────────────
+  // Rajesh runs accounts+production+delivery: his first screen is stock,
+  // cement and money — not the sales funnel.
+  if (opsFirst) {
+    const ops = opsQuery.data?.data;
+    return (
+      <SafeAreaView edges={['bottom']} className="flex-1 bg-canvas">
+        <ScrollView
+          contentContainerClassName="p-4 pb-8"
+          refreshControl={
+            <RefreshControl
+              refreshing={opsQuery.isRefetching}
+              onRefresh={() => void opsQuery.refetch()}
+            />
+          }
+        >
+          <MyWorkStrip />
+          {opsQuery.isLoading ? (
+            <SkeletonList count={5} />
+          ) : !ops ? (
+            <View className="items-center rounded-xl border border-slate-200 bg-white p-4">
+              <Text className="text-center text-sm text-red-500">
+                Couldn't load the ops snapshot — pull down to retry
+              </Text>
+            </View>
+          ) : (
+            <OpsHomePanel data={ops} />
+          )}
+
+          {/* Quick links to the day's workspaces */}
+          <Text className="mb-2 mt-2 text-base font-bold text-ink">🚀 Go to</Text>
+          <View className="flex-row flex-wrap justify-between">
+            {[
+              // Tab targets are role-gated in _layout (href:null) — only show
+              // links this role can actually open.
+              ...(role === 'production_supervisor'
+                ? [
+                    { label: '🏭 Production', path: '/(tabs)/production' },
+                    { label: '🚚 Deliveries', path: '/(tabs)/deliveries' },
+                  ]
+                : [{ label: '📈 Leads', path: '/(tabs)/leads' }]),
+              { label: '👀 Approvals', path: '/onehub/approvals' },
+              { label: '💰 Expenses', path: '/onehub/expenses' },
+            ].map((l) => (
+              <Pressable
+                key={l.path}
+                onPress={() => router.push(l.path as never)}
+                className="mb-3 w-[48.5%] items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70"
+              >
+                <Text className="text-sm font-semibold text-ink">{l.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+
+          {ops?.as_of ? (
+            <Text className="mt-1 text-center text-xs text-slate-400">
+              As of {new Date(ops.as_of).toLocaleTimeString('en-IN')} · pull down
+              to refresh
+            </Text>
+          ) : null}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -283,6 +360,11 @@ export default function DashboardScreen() {
               </Text>
             </View>
           </View>
+        ) : null}
+
+        {/* ── Ops snapshot (founder/owner) ────────────────── */}
+        {opsRole && opsQuery.data?.data ? (
+          <OpsHomePanel data={opsQuery.data.data} compact />
         ) : null}
 
         {/* ── Stat cards ──────────────────────────────────── */}

--- a/apps/native/src/components/OpsHomePanel.tsx
+++ b/apps/native/src/components/OpsHomePanel.tsx
@@ -1,0 +1,92 @@
+import { Text, View } from 'react-native';
+import { formatINR } from '@/hooks/use-dashboard';
+import type { OpsSnapshot } from '@/hooks/use-ops-home';
+
+/**
+ * 🏭 Ops snapshot — the numbers a factory/accounts manager checks first:
+ * bank & cash balances, finished-brick stock and cement on hand.
+ * Full mode is the home screen for production_supervisor/accountant;
+ * compact mode is appended to the founder/owner dashboard.
+ */
+
+const fmtQty = (n: number) => Math.round(n).toLocaleString('en-IN');
+
+export function OpsHomePanel({
+  data,
+  compact = false,
+}: {
+  data: OpsSnapshot;
+  compact?: boolean;
+}) {
+  const { stock, cement, balances } = data;
+
+  return (
+    <View>
+      {/* ── Bank & Cash ─────────────────────────────────── */}
+      <Text className="mb-2 mt-2 text-base font-bold text-ink">💰 Money</Text>
+      {balances ? (
+        <View className="mb-3 rounded-xl bg-ink p-4">
+          <View className="flex-row">
+            <View className="flex-1">
+              <Text className="text-2xl font-bold text-white">
+                {formatINR(balances.bank)}
+              </Text>
+              <Text className="text-xs text-slate-400">Bank balance</Text>
+            </View>
+            <View className="flex-1">
+              <Text className="text-2xl font-bold text-brand">
+                {formatINR(balances.cash)}
+              </Text>
+              <Text className="text-xs text-slate-400">Cash in hand</Text>
+            </View>
+          </View>
+          {!compact && balances.accounts.length > 1 ? (
+            <View className="mt-3 border-t border-slate-700 pt-2">
+              {balances.accounts.map((a) => (
+                <View key={a.name} className="flex-row justify-between py-0.5">
+                  <Text className="text-xs text-slate-300" numberOfLines={1}>
+                    {a.type === 'cash' ? '💵' : '🏦'} {a.name}
+                  </Text>
+                  <Text className="text-xs font-semibold text-slate-200">
+                    {formatINR(a.balance)}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          ) : null}
+        </View>
+      ) : (
+        <View className="mb-3 items-center rounded-xl border border-slate-200 bg-white p-4">
+          <Text className="text-sm text-slate-400">
+            Balances unavailable — Odoo not reachable
+          </Text>
+        </View>
+      )}
+
+      {/* ── Stock ───────────────────────────────────────── */}
+      <Text className="mb-2 text-base font-bold text-ink">🧱 Stock on hand</Text>
+      <View className="flex-row flex-wrap justify-between">
+        {/* Cement first — it's the raw material that stops production. */}
+        <View className="mb-3 w-[48.5%] rounded-xl border border-slate-200 border-l-4 border-l-amber-400 bg-white p-4">
+          <Text className="text-3xl font-bold text-ink">
+            {cement ? fmtQty(cement.bags) : '—'}
+          </Text>
+          <Text className="mt-1 text-sm text-slate-500">
+            Cement bags{cement ? ` (${fmtQty(cement.kg)} kg)` : ''}
+          </Text>
+        </View>
+        {stock.map((s) => (
+          <View
+            key={s.name}
+            className="mb-3 w-[48.5%] rounded-xl border border-slate-200 border-l-4 border-l-sky-400 bg-white p-4"
+          >
+            <Text className="text-3xl font-bold text-ink">{fmtQty(s.qty)}</Text>
+            <Text className="mt-1 text-sm text-slate-500" numberOfLines={2}>
+              {s.name}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/native/src/hooks/use-ops-home.ts
+++ b/apps/native/src/hooks/use-ops-home.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+/** Shape of GET /api/dashboard/ops (see apps/web/app/api/dashboard/ops). */
+export type OpsSnapshot = {
+  stock: { name: string; qty: number }[];
+  stock_synced_at: string | null;
+  cement: { kg: number; bags: number } | null;
+  balances: {
+    bank: number;
+    cash: number;
+    accounts: { name: string; type: 'bank' | 'cash'; balance: number }[];
+  } | null;
+  as_of: string;
+};
+
+/** Roles whose home screen leads with the Ops snapshot. Keep in sync with
+ *  OPS_HOME_ROLES on the server route (which is the real gate). */
+export const OPS_HOME_ROLES = [
+  'production_supervisor',
+  'accountant',
+  'founder',
+  'owner',
+];
+
+export function useOpsSnapshot(enabled: boolean) {
+  return useQuery({
+    queryKey: ['dashboard', 'ops'],
+    queryFn: () => api.get<OpsSnapshot>('/api/dashboard/ops'),
+    enabled,
+    staleTime: 5 * 60 * 1000, // balances/stock don't move minute-to-minute
+  });
+}

--- a/apps/web/app/api/dashboard/ops/route.ts
+++ b/apps/web/app/api/dashboard/ops/route.ts
@@ -1,0 +1,148 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // live Odoo round-trips (stock + balances)
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { odooExecute } from "@/lib/odoo-service";
+
+/**
+ * GET /api/dashboard/ops — the Ops Home snapshot for factory/accounts roles:
+ *   • finished-good stock (mirrored from Odoo into finished_goods by the sync)
+ *   • cement on hand, live from Odoo (kg → 50kg bags)
+ *   • bank & cash balances, live from Odoo posted journal entries
+ *
+ * Balances are sensitive — restrict to the roles that run money/production.
+ * Every Odoo call is best-effort: a slow/unreachable ERP degrades a tile to
+ * null instead of failing the whole home screen.
+ */
+const OPS_HOME_ROLES = ["production_supervisor", "accountant", "founder", "owner"];
+
+const CEMENT_KG_PER_BAG = 50;
+
+type OdooJournal = {
+  id: number;
+  name: string;
+  type: "bank" | "cash";
+  default_account_id: [number, string] | false;
+};
+
+type BalanceGroup = { account_id: [number, string] | false; balance: number };
+
+async function cementFromOdoo(): Promise<{
+  kg: number;
+  bags: number;
+} | null> {
+  const { data: cement } = await supabaseAdmin
+    .from("raw_materials")
+    .select("odoo_product_id")
+    .ilike("name", "%cement%")
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+  if (!cement?.odoo_product_id) return null;
+
+  const products = (await odooExecute(
+    "product.product",
+    "read",
+    [[cement.odoo_product_id]],
+    { fields: ["qty_available"] },
+  )) as { qty_available: number }[];
+  const kg = Number(products?.[0]?.qty_available ?? 0);
+  return { kg, bags: Math.floor(kg / CEMENT_KG_PER_BAG) };
+}
+
+async function balancesFromOdoo(): Promise<{
+  bank: number;
+  cash: number;
+  accounts: { name: string; type: "bank" | "cash"; balance: number }[];
+} | null> {
+  // Bank/cash journals → their default GL accounts → sum of posted lines.
+  const journals = (await odooExecute(
+    "account.journal",
+    "search_read",
+    [[["type", "in", ["bank", "cash"]]]],
+    { fields: ["id", "name", "type", "default_account_id"] },
+  )) as OdooJournal[];
+
+  const accountToJournal = new Map<number, OdooJournal>();
+  for (const j of journals) {
+    if (Array.isArray(j.default_account_id)) {
+      accountToJournal.set(j.default_account_id[0], j);
+    }
+  }
+  const accountIds = [...accountToJournal.keys()];
+  if (!accountIds.length) return { bank: 0, cash: 0, accounts: [] };
+
+  const groups = (await odooExecute(
+    "account.move.line",
+    "read_group",
+    [
+      [["account_id", "in", accountIds], ["parent_state", "=", "posted"]],
+      ["balance"],
+      ["account_id"],
+    ],
+    { lazy: false },
+  )) as BalanceGroup[];
+
+  let bank = 0;
+  let cash = 0;
+  const accounts: { name: string; type: "bank" | "cash"; balance: number }[] = [];
+  for (const g of groups) {
+    const accountId = Array.isArray(g.account_id) ? g.account_id[0] : null;
+    if (!accountId) continue;
+    const journal = accountToJournal.get(accountId);
+    if (!journal) continue;
+    const balance = Number(g.balance ?? 0);
+    if (journal.type === "cash") cash += balance;
+    else bank += balance;
+    accounts.push({ name: journal.name, type: journal.type, balance });
+  }
+  accounts.sort((a, b) => b.balance - a.balance);
+  return { bank, cash, accounts };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!OPS_HOME_ROLES.includes(user.role)) {
+      return error("Not permitted", 403);
+    }
+
+    const [stockRes, cementRes, balancesRes] = await Promise.allSettled([
+      supabaseAdmin
+        .from("finished_goods")
+        .select("name, stock_qty, stock_synced_at")
+        .eq("is_active", true)
+        .eq("plan_excluded", false)
+        .order("stock_qty", { ascending: false }),
+      cementFromOdoo(),
+      balancesFromOdoo(),
+    ]);
+
+    const stockRows =
+      stockRes.status === "fulfilled" ? (stockRes.value.data ?? []) : [];
+    if (cementRes.status === "rejected") {
+      console.error("[OpsHome] cement pull failed:", cementRes.reason);
+    }
+    if (balancesRes.status === "rejected") {
+      console.error("[OpsHome] balances pull failed:", balancesRes.reason);
+    }
+
+    return success({
+      stock: stockRows.map((r) => ({
+        name: (r.name as string).trim(),
+        qty: Number(r.stock_qty ?? 0),
+      })),
+      stock_synced_at: (stockRows[0]?.stock_synced_at as string) ?? null,
+      cement: cementRes.status === "fulfilled" ? cementRes.value : null,
+      balances: balancesRes.status === "fulfilled" ? balancesRes.value : null,
+      as_of: new Date().toISOString(),
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[OpsHome] failed:", err);
+    return error("Failed to load ops snapshot", 500);
+  }
+}


### PR DESCRIPTION
## What

Role-specific home pages in the mobile app.

| Role | Home |
|---|---|
| `production_supervisor` (Rajesh), `accountant` (Nithya) | **Ops Home**: My Work strip + 💰 bank & cash balances (live Odoo, per-account breakdown) + 🧱 stock tiles (cement bags first, then each brick product) + role-aware quick links |
| `founder` / `owner` | Existing dashboard + compact Ops snapshot card after the revenue strip |
| `sales` / `engineer` (Srinivasan) / others | Unchanged sales home |

## Backend

New `GET /api/dashboard/ops`, role-gated to production_supervisor / accountant / founder / owner:
- **Stock** — `finished_goods` (active, planable), already synced from Odoo daily + on Plan-tab sync.
- **Cement** — live `qty_available` from Odoo (product resolved via `raw_materials` name ilike 'cement'), returned as kg + 50 kg-bag count.
- **Bank & cash** — Odoo bank/cash journals → default GL accounts → sum of posted `account.move.line` balances, split by journal type with a per-account list.
- All Odoo calls best-effort (`Promise.allSettled`): a slow ERP nulls a tile, never breaks home.

The client role check only chooses layout — the server route is the actual gate.

## Verification
- web `tsc` ✅, native `tsc` ✅, eslint ✅ on all changed files.
- JS-only change → ships to phones as an **OTA update** after merge (no reinstall).

## Note
Rajesh's login (skannasrk.rk@gmail.com) is currently **deactivated** in Settings → Team — needs reactivation before he can see any of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operations dashboard snapshot endpoint.
  * Provides finished-goods stock, estimated cement bag inventory, and bank/cash balances in a single response.
  * Supports role-based access and gracefully handles unavailable individual data sources.
  * Returns clear errors for authentication failures and unexpected issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->