### PR TITLE
feat(mobile): Daily Report in the app — native briefing + PDF export + share

### DIFF
--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -21,6 +21,7 @@ export default function OneHubLayout() {
         options={{ title: 'Assign Work', presentation: 'modal' }}
       />
       <Stack.Screen name="approvals" options={{ title: '👀 Approvals' }} />
+      <Stack.Screen name="daily-report" options={{ title: '📊 Daily Report' }} />
       <Stack.Screen name="expenses/index" options={{ title: '💰 My Expenses' }} />
       <Stack.Screen
         name="expenses/new"

--- a/apps/native/app/onehub/daily-report.tsx
+++ b/apps/native/app/onehub/daily-report.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import {
+  Linking,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Share,
+  Text,
+  View,
+} from 'react-native';
+import { formatINR } from '@/hooks/use-dashboard';
+import {
+  istToday,
+  useDailyReport,
+  type CountSection,
+  type DailyReport,
+  type SourceStatus,
+} from '@/hooks/use-daily-report';
+import { SkeletonList } from '@/ui';
+
+/**
+ * 📊 Daily Operations Briefing — the web daily report, natively.
+ * "Export PDF" opens the print-styled web page (browser → Save as PDF);
+ * "Share" sends a text summary via WhatsApp/Telegram/anything.
+ */
+
+const WEB_REPORT_URL = 'https://mb.maiyuri.com/daily-report';
+
+const fmtQty = (n: number) => Math.round(n).toLocaleString('en-IN');
+
+const addDays = (dateISO: string, days: number): string => {
+  const d = new Date(`${dateISO}T12:00:00Z`); // noon avoids DST/offset edges
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+};
+
+const prettyDate = (dateISO: string): string =>
+  new Date(`${dateISO}T12:00:00Z`).toLocaleDateString('en-IN', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  });
+
+function StatusDot({ status }: { status: SourceStatus }) {
+  const colour =
+    status === 'live'
+      ? 'bg-green-500'
+      : status === 'error'
+        ? 'bg-red-500'
+        : 'bg-slate-300';
+  return <View className={`h-2 w-2 rounded-full ${colour}`} />;
+}
+
+function Section({
+  title,
+  status,
+  note,
+  children,
+}: {
+  title: string;
+  status: SourceStatus;
+  note?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View className="mb-3 rounded-xl border border-slate-200 bg-white p-4">
+      <View className="mb-2 flex-row items-center justify-between">
+        <Text className="text-base font-bold text-ink">{title}</Text>
+        <StatusDot status={status} />
+      </View>
+      {status === 'live' ? (
+        children
+      ) : (
+        <Text className="text-sm text-slate-400">
+          {note ?? (status === 'error' ? 'Source failed' : 'Not connected yet')}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone?: string }) {
+  return (
+    <View className="flex-1">
+      <Text className={`text-xl font-bold ${tone ?? 'text-ink'}`}>{value}</Text>
+      <Text className="text-xs text-slate-500">{label}</Text>
+    </View>
+  );
+}
+
+function CountTile({ title, section }: { title: string; section: CountSection }) {
+  return (
+    <View className="mb-3 w-[48.5%] rounded-xl border border-slate-200 bg-white p-4">
+      <View className="flex-row items-center justify-between">
+        <Text className="text-sm font-semibold text-ink">{title}</Text>
+        <StatusDot status={section.status} />
+      </View>
+      {section.status === 'live' ? (
+        <Text className="mt-1 text-2xl font-bold text-ink">{section.primary}</Text>
+      ) : (
+        <Text className="mt-1 text-xs text-slate-400">{section.note ?? 'Pending'}</Text>
+      )}
+    </View>
+  );
+}
+
+/** Compact text summary for the share sheet (WhatsApp-friendly). */
+function buildSummary(r: DailyReport): string {
+  const lines = [`📊 Maiyuri Daily Report — ${prettyDate(r.date)}`];
+  if (r.finance.status === 'live') {
+    lines.push(
+      `💰 Invoiced ${formatINR(r.finance.invoiced)} · Expenses ${formatINR(r.finance.expenses)} · Net ${formatINR(r.finance.net)}`,
+    );
+  }
+  if (r.receivables.status === 'live') {
+    lines.push(
+      `🧾 Outstanding ${formatINR(r.receivables.outstanding)} (overdue ${formatINR(r.receivables.overdue)} / ${r.receivables.overdueCount})`,
+    );
+  }
+  if (r.production.status === 'live') {
+    lines.push(
+      `🏭 Production ${fmtQty(r.production.actualUnits)}/${fmtQty(r.production.plannedUnits)} (${r.production.pct}%)`,
+    );
+  }
+  if (r.deliveries.status === 'live') {
+    lines.push(`🚚 Deliveries ${r.deliveries.completed}/${r.deliveries.planned}`);
+  }
+  if (r.leads.status === 'live') {
+    lines.push(
+      `📈 Leads +${r.leads.newLeads} new · ${r.leads.hot} hot · ${r.leads.followupsDue} follow-ups due`,
+    );
+  }
+  lines.push(`\nFull report: ${WEB_REPORT_URL}?date=${r.date}`);
+  return lines.join('\n');
+}
+
+export default function DailyReportScreen() {
+  const [date, setDate] = useState(istToday());
+  const query = useDailyReport(date, true);
+  const report = query.data?.data;
+  const isToday = date === istToday();
+
+  return (
+    <ScrollView
+      className="flex-1 bg-canvas"
+      contentContainerClassName="p-4 pb-10"
+      refreshControl={
+        <RefreshControl
+          refreshing={query.isRefetching}
+          onRefresh={() => void query.refetch()}
+        />
+      }
+    >
+      {/* Date switcher */}
+      <View className="mb-3 flex-row items-center justify-between rounded-xl border border-slate-200 bg-white p-2">
+        <Pressable
+          onPress={() => setDate((d) => addDays(d, -1))}
+          className="h-10 w-10 items-center justify-center rounded-lg active:bg-slate-100"
+        >
+          <Text className="text-lg text-ink">‹</Text>
+        </Pressable>
+        <Text className="text-base font-bold text-ink">
+          {prettyDate(date)}
+          {isToday ? ' · today' : ''}
+        </Text>
+        <Pressable
+          onPress={() => setDate((d) => addDays(d, 1))}
+          disabled={isToday}
+          className={`h-10 w-10 items-center justify-center rounded-lg ${isToday ? 'opacity-30' : 'active:bg-slate-100'}`}
+        >
+          <Text className="text-lg text-ink">›</Text>
+        </Pressable>
+      </View>
+
+      {/* Actions */}
+      <View className="mb-3 flex-row">
+        <Pressable
+          onPress={() => void Linking.openURL(`${WEB_REPORT_URL}?date=${date}`)}
+          className="mr-2 flex-1 items-center rounded-xl bg-ink px-4 py-3 active:opacity-80"
+        >
+          <Text className="text-sm font-semibold text-white">⤓ Export PDF</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => {
+            if (report) void Share.share({ message: buildSummary(report) });
+          }}
+          disabled={!report}
+          className={`flex-1 items-center rounded-xl px-4 py-3 ${report ? 'bg-brand active:opacity-80' : 'bg-slate-200'}`}
+        >
+          <Text className="text-sm font-semibold text-ink">📤 Share summary</Text>
+        </Pressable>
+      </View>
+
+      {query.isLoading ? (
+        <SkeletonList count={6} />
+      ) : !report ? (
+        <View className="items-center rounded-xl border border-slate-200 bg-white p-6">
+          <Text className="text-center text-sm text-red-500">
+            {query.error instanceof Error
+              ? query.error.message
+              : "Couldn't load the report"}
+          </Text>
+          <Pressable
+            onPress={() => void query.refetch()}
+            className="mt-3 rounded-xl bg-brand px-5 py-2.5 active:opacity-80"
+          >
+            <Text className="font-semibold text-ink">Retry</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <>
+          {/* Finance */}
+          <Section title="💰 Finance" status={report.finance.status} note={report.finance.note}>
+            <View className="flex-row">
+              <Metric label="Invoiced" value={formatINR(report.finance.invoiced)} />
+              <Metric label="Expenses" value={formatINR(report.finance.expenses)} />
+              <Metric
+                label="Net"
+                value={formatINR(report.finance.net)}
+                tone={report.finance.net >= 0 ? 'text-green-600' : 'text-red-600'}
+              />
+            </View>
+            {report.finance.topInvoices.length ? (
+              <View className="mt-3 border-t border-slate-100 pt-2">
+                {report.finance.topInvoices.slice(0, 3).map((inv) => (
+                  <View key={inv.ref} className="flex-row justify-between py-0.5">
+                    <Text className="flex-1 pr-2 text-xs text-slate-500" numberOfLines={1}>
+                      {inv.ref} · {inv.party}
+                    </Text>
+                    <Text className="text-xs font-semibold text-ink">
+                      {formatINR(inv.amount)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </Section>
+
+          {/* Receivables */}
+          <Section
+            title="🧾 Receivables"
+            status={report.receivables.status}
+            note={report.receivables.note}
+          >
+            <View className="flex-row">
+              <Metric label="Outstanding" value={formatINR(report.receivables.outstanding)} />
+              <Metric
+                label={`Overdue (${report.receivables.overdueCount})`}
+                value={formatINR(report.receivables.overdue)}
+                tone="text-red-600"
+              />
+            </View>
+            {report.receivables.topDebtors.length ? (
+              <View className="mt-3 border-t border-slate-100 pt-2">
+                {report.receivables.topDebtors.slice(0, 3).map((d) => (
+                  <View key={d.customer} className="flex-row justify-between py-0.5">
+                    <Text className="flex-1 pr-2 text-xs text-slate-500" numberOfLines={1}>
+                      {d.customer} · {d.oldestDays}d
+                    </Text>
+                    <Text className="text-xs font-semibold text-ink">{formatINR(d.due)}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </Section>
+
+          {/* Production */}
+          <Section
+            title="🏭 Production"
+            status={report.production.status}
+            note={report.production.note}
+          >
+            <View className="flex-row">
+              <Metric label="Planned" value={fmtQty(report.production.plannedUnits)} />
+              <Metric label="Actual" value={fmtQty(report.production.actualUnits)} />
+              <Metric
+                label="Achieved"
+                value={`${report.production.pct}%`}
+                tone={report.production.pct >= 90 ? 'text-green-600' : 'text-amber-600'}
+              />
+            </View>
+          </Section>
+
+          {/* Deliveries */}
+          <Section
+            title="🚚 Deliveries"
+            status={report.deliveries.status}
+            note={report.deliveries.note}
+          >
+            <View className="flex-row">
+              <Metric label="Planned" value={String(report.deliveries.planned)} />
+              <Metric label="Completed" value={String(report.deliveries.completed)} />
+              <Metric label="Rolled over" value={String(report.deliveries.rolledOver)} />
+            </View>
+            {report.deliveries.tripKm > 0 ? (
+              <Text className="mt-2 text-xs text-slate-500">
+                {fmtQty(report.deliveries.tripKm)} km driven · diesel{' '}
+                {formatINR(report.deliveries.dieselCost)}
+              </Text>
+            ) : null}
+          </Section>
+
+          {/* Leads */}
+          <Section title="📈 Leads" status={report.leads.status} note={report.leads.note}>
+            <View className="flex-row">
+              <Metric label="New" value={String(report.leads.newLeads)} />
+              <Metric label="Hot" value={String(report.leads.hot)} tone="text-red-600" />
+              <Metric label="Follow-ups due" value={String(report.leads.followupsDue)} />
+            </View>
+          </Section>
+
+          {/* Small tiles */}
+          <View className="flex-row flex-wrap justify-between">
+            <CountTile title="📞 Calls" section={report.calls} />
+            <CountTile title="💬 WhatsApp" section={report.whatsapp} />
+            <CountTile title="✅ Tasks" section={report.tasks} />
+          </View>
+
+          <Text className="mt-1 text-center text-xs text-slate-400">
+            Generated {new Date(report.generatedAt).toLocaleTimeString('en-IN')} ·
+            pull down to refresh
+          </Text>
+        </>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/onehub/index.tsx
+++ b/apps/native/app/onehub/index.tsx
@@ -5,6 +5,7 @@ import {
   WORK_ADMIN_ROLES,
   useMyRole,
 } from '@/hooks/use-approvals';
+import { DAILY_REPORT_ROLES } from '@/hooks/use-daily-report';
 import {
   EXPENSE_ADMIN_ROLES,
   EXPENSE_SUBMITTER_ROLES,
@@ -74,6 +75,7 @@ export default function OneHubHome() {
     TICKET_APPROVER_ROLES.includes(role) || WORK_ADMIN_ROLES.includes(role);
   const showExpenses =
     EXPENSE_SUBMITTER_ROLES.includes(role) || EXPENSE_ADMIN_ROLES.includes(role);
+  const showDailyReport = DAILY_REPORT_ROLES.includes(role);
   const counts = new Map<string, number>();
   for (const sop of data?.data ?? []) {
     counts.set(sop.department, (counts.get(sop.department) ?? 0) + 1);
@@ -126,6 +128,16 @@ export default function OneHubHome() {
           title="Approvals"
           subtitle="Tickets, work & expenses awaiting you"
           onPress={() => go('/onehub/approvals')}
+        />
+      ) : null}
+
+      {showDailyReport ? (
+        <NavRow
+          icon="stats-chart-outline"
+          tint="#0ea5e9"
+          title="Daily Report"
+          subtitle="Finance, receivables, production — export PDF"
+          onPress={() => go('/onehub/daily-report')}
         />
       ) : null}
 

--- a/apps/native/src/hooks/use-daily-report.ts
+++ b/apps/native/src/hooks/use-daily-report.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+/**
+ * GET /api/daily-report?date= — the Daily Operations Briefing as JSON.
+ * Shapes mirror apps/web/src/lib/daily-report/aggregate.ts (keep in sync).
+ */
+
+export type SourceStatus = 'live' | 'pending' | 'error';
+type Base = { status: SourceStatus; note?: string };
+
+export type FinanceSection = Base & {
+  invoiced: number;
+  invoiceCount: number;
+  expenses: number;
+  expenseCount: number;
+  net: number;
+  topInvoices: { ref: string; party: string; amount: number }[];
+  topExpenses: { label: string; amount: number }[];
+};
+
+export type ReceivablesSection = Base & {
+  outstanding: number;
+  overdue: number;
+  overdueCount: number;
+  topDebtors: { customer: string; due: number; oldestDays: number }[];
+};
+
+export type PlanActualSection = Base & {
+  plannedUnits: number;
+  actualUnits: number;
+  pct: number;
+  byProduct: { name: string; planned: number; actual: number }[];
+};
+
+export type DeliverySection = Base & {
+  planned: number;
+  completed: number;
+  rolledOver: number;
+  tripKm: number;
+  dieselCost: number;
+};
+
+export type LeadsSection = Base & {
+  newLeads: number;
+  hot: number;
+  followupsDue: number;
+};
+
+export type CountSection = Base & {
+  primary: number;
+  metrics: { label: string; value: string }[];
+};
+
+export type DailyReport = {
+  date: string;
+  generatedAt: string;
+  finance: FinanceSection;
+  receivables: ReceivablesSection;
+  production: PlanActualSection;
+  deliveries: DeliverySection;
+  leads: LeadsSection;
+  calls: CountSection;
+  whatsapp: CountSection;
+  tasks: CountSection;
+};
+
+/** Roles allowed to open the briefing (server re-checks). */
+export const DAILY_REPORT_ROLES = ['founder', 'owner', 'accountant'];
+
+/** Today in IST as YYYY-MM-DD — the factory's clock, matching the server. */
+export function istToday(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' });
+}
+
+export function useDailyReport(date: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['daily-report', date],
+    // The aggregate fans out to Odoo + GA4 and can exceed the client's default
+    // 20s timeout — allow the server's full 60s window (minus a safety margin).
+    queryFn: () =>
+      api.get<DailyReport>('/api/daily-report', { date }, { timeoutMs: 55_000 }),
+    enabled,
+    staleTime: 5 * 60 * 1000, // expensive — don't refetch on every focus
+  });
+}

--- a/apps/native/src/lib/api.ts
+++ b/apps/native/src/lib/api.ts
@@ -57,7 +57,7 @@ function buildUrl(path: string, params?: QueryParams): string {
 async function request<T>(
   method: string,
   path: string,
-  opts: { params?: QueryParams; body?: unknown } = {},
+  opts: { params?: QueryParams; body?: unknown; timeoutMs?: number } = {},
 ): Promise<ApiResult<T>> {
   const headers: Record<string, string> = {
     Accept: 'application/json',
@@ -71,7 +71,7 @@ async function request<T>(
   // NOTE: manual AbortController — `AbortSignal.timeout()` does not exist in
   // React Native's Hermes runtime (learned the hard way: it broke every call).
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 20_000);
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 20_000);
 
   let res: Response;
   try {
@@ -126,8 +126,8 @@ async function request<T>(
 }
 
 export const api = {
-  get: <T>(path: string, params?: QueryParams) =>
-    request<T>('GET', path, { params }),
+  get: <T>(path: string, params?: QueryParams, opts?: { timeoutMs?: number }) =>
+    request<T>('GET', path, { params, ...opts }),
   post: <T>(path: string, body?: unknown) =>
     request<T>('POST', path, { body }),
   patch: <T>(path: string, body?: unknown) =>

--- a/apps/web/app/api/daily-report/route.ts
+++ b/apps/web/app/api/daily-report/route.ts
@@ -1,0 +1,39 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // Odoo + GA4 round-trips (same as the web page)
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { getDailyReport } from "@/lib/daily-report/aggregate";
+
+/**
+ * GET /api/daily-report?date=YYYY-MM-DD — the Daily Operations Briefing as
+ * JSON for the mobile app. Same aggregator as the web page; management only
+ * (it carries finance and receivables figures).
+ */
+const REPORT_ROLES = ["founder", "owner", "accountant"];
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Today in IST as YYYY-MM-DD (the factory's clock).
+const istToday = (): string =>
+  new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!REPORT_ROLES.includes(user.role)) {
+      return error("Not permitted", 403);
+    }
+
+    const raw = new URL(request.url).searchParams.get("date");
+    const date = raw && DATE_RE.test(raw) ? raw : istToday();
+
+    const report = await getDailyReport(date);
+    return success(report);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[DailyReport] API failed:", err);
+    return error("Failed to build the daily report", 500);
+  }
+}


### PR DESCRIPTION
## What

The Daily Operations Briefing was web-only; the APK had no way to view or download it. This adds it to the app.

- **New `GET /api/daily-report?date=`** — same `getDailyReport` aggregate as the web page, as JSON. Role-gated to founder/owner/accountant (finance + receivables figures).
- **New OneHub screen `/onehub/daily-report`** — date switcher (IST today by default, ‹ › to browse back), sections for Finance, Receivables, Production plan-vs-actual, Deliveries (incl. km/diesel), Leads, plus Calls/WhatsApp/Tasks tiles. Each section shows its source status (live / pending / error) exactly like the web tiles.
  - **⤓ Export PDF** — opens the print-styled web report in the browser → Save as PDF. No new native modules → whole feature ships **OTA**, no reinstall.
  - **📤 Share summary** — WhatsApp-friendly text digest via the Android share sheet (built-in RN `Share`).
- **OneHub tile** "Daily Report", visible to founder/owner/accountant only.
- **api client**: optional per-request `timeoutMs` — the aggregate fans out to Odoo + GA4 and can exceed the global 20s cap; the hook allows 55s (server `maxDuration` is 60).

## Verification
- web `tsc` ✅, native `tsc` ✅.
- eslint ✅ on changed files (two pre-existing `require()` asset-import errors in `onehub/index.tsx` exist on main unchanged).
- JS-only → OTA after merge.