### PR TITLE
feat(accountability): task-first home + escalating nags + boss escalation + evening chaser + weekly scorecard

### DIFF
--- a/.github/workflows/my-work-nudges.yml
+++ b/.github/workflows/my-work-nudges.yml
@@ -1,0 +1,54 @@
+name: My Work accountability nudges
+
+# Three schedules, one route (mode picked from which cron fired):
+#   nag       — every 2h, 09:30–17:30 IST (04:00–12:00 UTC): re-push open
+#               items due today/overdue until acted on; >4h overdue escalates
+#               once to founder/owner + Telegram.
+#   evening   — 18:00 IST (12:30 UTC): "not finished today" summary per person.
+#   scorecard — Monday 08:00 IST (02:30 UTC Mon): weekly completion % → Telegram.
+
+on:
+  schedule:
+    - cron: "0 4,6,8,10,12 * * *" # nag (work hours IST)
+    - cron: "30 12 * * *" # evening chaser 6pm IST
+    - cron: "30 2 * * 1" # scorecard Monday 8am IST
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "nag | evening | scorecard"
+        required: true
+        default: "nag"
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Pick mode from trigger
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ github.event.inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "30 12 * * *" ]; then
+            echo "mode=evening" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "30 2 * * 1" ]; then
+            echo "mode=scorecard" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=nag" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run nudges
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/my-work/nudges?mode=${{ steps.mode.outputs.mode }}")
+          echo "HTTP $status (mode=${{ steps.mode.outputs.mode }})"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/apps/native/app/(tabs)/index.tsx
+++ b/apps/native/app/(tabs)/index.tsx
@@ -22,6 +22,7 @@ import { useMyProfile } from '@/hooks/use-push-settings';
 import { OPS_HOME_ROLES, useOpsSnapshot } from '@/hooks/use-ops-home';
 import { useAuth } from '@/store/auth';
 import { OpsHomePanel } from '@/components/OpsHomePanel';
+import { TaskFirstHome } from '@/components/TaskFirstHome';
 import { SkeletonList } from '@/ui';
 
 type CardDef = {
@@ -181,6 +182,8 @@ export default function DashboardScreen() {
   // role, so this flag only decides LAYOUT, never data access.
   const opsRole = OPS_HOME_ROLES.includes(role);
   const opsFirst = role === 'production_supervisor' || role === 'accountant';
+  // Field staff who should see WORK, not dashboards — giant one-tap task cards.
+  const taskFirst = role === 'engineer' || role === 'sales';
   const opsQuery = useOpsSnapshot(opsRole);
   const { data, isLoading, isError, error, refetch, isRefetching } =
     useDashboardStats();
@@ -198,6 +201,10 @@ export default function DashboardScreen() {
   // ── Ops Home (production_supervisor / accountant) ────────────────────
   // Rajesh runs accounts+production+delivery: his first screen is stock,
   // cement and money — not the sales funnel.
+  if (taskFirst) {
+    return <TaskFirstHome />;
+  }
+
   if (opsFirst) {
     const ops = opsQuery.data?.data;
     return (

--- a/apps/native/src/components/TaskFirstHome.tsx
+++ b/apps/native/src/components/TaskFirstHome.tsx
@@ -1,0 +1,258 @@
+import type { Lead } from '@maiyuri/shared';
+import type { WorkItem } from '@maiyuri/shared';
+import { useRouter } from 'expo-router';
+import {
+  Alert,
+  Linking,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useCompleteWork, useMyWork, useStartWork } from '@/hooks/use-my-work';
+import { useLeads } from '@/hooks/use-leads';
+import { SkeletonList } from '@/ui';
+
+/**
+ * 🎯 Task-first home — for staff who should see WORK, not dashboards.
+ * Giant cards, Tamil + English, one thumb-tap to start/finish. Built for the
+ * least tech-savvy person on the team: if he can use WhatsApp, he can use this.
+ */
+
+const fmtTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString('en-IN', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'Asia/Kolkata',
+  });
+
+/** A task can be finished in one tap only when nothing else is mandatory. */
+const isOneTap = (w: WorkItem) =>
+  !w.checklist_instance_id && !w.requires_photo && !w.requires_note;
+
+function BigButton({
+  label,
+  onPress,
+  tone,
+  disabled,
+}: {
+  label: string;
+  onPress: () => void;
+  tone: 'start' | 'done' | 'open';
+  disabled?: boolean;
+}) {
+  const bg =
+    tone === 'done'
+      ? 'bg-green-600'
+      : tone === 'start'
+        ? 'bg-brand'
+        : 'bg-ink';
+  const text = tone === 'start' ? 'text-ink' : 'text-white';
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      className={`mt-3 items-center rounded-2xl px-4 py-4 ${bg} ${disabled ? 'opacity-50' : 'active:opacity-80'}`}
+    >
+      <Text className={`text-lg font-bold ${text}`}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function TaskCard({ item, overdue }: { item: WorkItem; overdue: boolean }) {
+  const router = useRouter();
+  const start = useStartWork(item.id);
+  const complete = useCompleteWork(item.id);
+  const busy = start.isPending || complete.isPending;
+  const openDetail = () => router.push(`/onehub/my-work/${item.id}` as never);
+
+  const finish = () => {
+    complete.mutate(
+      {},
+      {
+        onError: (e) => {
+          // Missing photo/note etc. — send him into the task screen where the
+          // camera/note lives instead of showing a wall of text.
+          Alert.alert(
+            'இன்னும் கொஞ்சம் · Almost there',
+            e instanceof Error ? e.message : 'Open the task to finish it',
+            [{ text: 'Open · திற', onPress: openDetail }],
+          );
+        },
+      },
+    );
+  };
+
+  return (
+    <Pressable
+      onPress={openDetail}
+      className={`mb-3 rounded-2xl border-2 bg-white p-4 ${overdue ? 'border-red-400' : 'border-slate-200'}`}
+    >
+      <View className="flex-row items-start justify-between">
+        <Text className="flex-1 pr-2 text-xl font-bold leading-7 text-ink">
+          {item.title}
+        </Text>
+        {overdue ? (
+          <View className="rounded-full bg-red-100 px-2.5 py-1">
+            <Text className="text-xs font-bold text-red-600">தாமதம்!</Text>
+          </View>
+        ) : item.due_at ? (
+          <View className="rounded-full bg-amber-100 px-2.5 py-1">
+            <Text className="text-xs font-bold text-amber-700">
+              ⏰ {fmtTime(item.due_at)}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+      {item.related_label ? (
+        <Text className="mt-1 text-sm text-slate-500" numberOfLines={1}>
+          📍 {item.related_label}
+        </Text>
+      ) : null}
+      {item.description ? (
+        <Text className="mt-1 text-base text-slate-600" numberOfLines={2}>
+          {item.description}
+        </Text>
+      ) : null}
+
+      {item.status === 'pending' || item.status === 'returned' ? (
+        <BigButton
+          tone="start"
+          label="▶️  வேலையை தொடங்கு · Start"
+          onPress={() => start.mutate()}
+          disabled={busy}
+        />
+      ) : isOneTap(item) ? (
+        <BigButton
+          tone="done"
+          label="✅  முடிந்தது · Done"
+          onPress={finish}
+          disabled={busy}
+        />
+      ) : (
+        <BigButton
+          tone="open"
+          label={`📷  பணியை திற · Open task${item.requires_photo ? ' (photo)' : ''}`}
+          onPress={openDetail}
+          disabled={busy}
+        />
+      )}
+    </Pressable>
+  );
+}
+
+function FollowUpRow({ lead }: { lead: Lead }) {
+  const router = useRouter();
+  return (
+    <Pressable
+      onPress={() => router.push(`/leads/${lead.id}` as never)}
+      className="mb-2 flex-row items-center rounded-2xl border border-slate-200 bg-white p-4 active:opacity-70"
+    >
+      <View className="min-w-0 flex-1 pr-2">
+        <Text className="text-base font-bold text-ink" numberOfLines={1}>
+          {lead.name}
+        </Text>
+        {lead.next_action ? (
+          <Text className="mt-0.5 text-sm text-slate-500" numberOfLines={1}>
+            → {lead.next_action}
+          </Text>
+        ) : null}
+      </View>
+      <Pressable
+        onPress={() => Linking.openURL(`tel:${lead.contact}`)}
+        className="h-14 w-14 items-center justify-center rounded-full bg-green-600 active:opacity-80"
+      >
+        <Text className="text-xl">📞</Text>
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const OPEN_EXCLUDED = new Set(['order_won', 'closed_lost']);
+
+export function TaskFirstHome() {
+  const work = useMyWork();
+  const leadsQuery = useLeads({ limit: 100 });
+  const q = work.data?.data;
+
+  const endOfToday = new Date();
+  endOfToday.setHours(23, 59, 59, 999);
+  const dueLeads = (leadsQuery.data?.data ?? [])
+    .filter(
+      (l) =>
+        !OPEN_EXCLUDED.has(l.pipeline_stage) &&
+        l.follow_up_date &&
+        new Date(l.follow_up_date) <= endOfToday,
+    )
+    .slice(0, 6);
+
+  const tasks = q ? [...q.attention, ...q.today] : [];
+  const doneToday = q?.completed_today.length ?? 0;
+
+  return (
+    <SafeAreaView edges={['bottom']} className="flex-1 bg-canvas">
+      <ScrollView
+        contentContainerClassName="p-4 pb-10"
+        refreshControl={
+          <RefreshControl
+            refreshing={work.isRefetching || leadsQuery.isRefetching}
+            onRefresh={() => {
+              void work.refetch();
+              void leadsQuery.refetch();
+            }}
+          />
+        }
+      >
+        {/* Big, warm, unmissable header */}
+        <View className="mb-4 rounded-3xl bg-ink p-5">
+          <Text className="text-2xl font-bold text-white">
+            🙏 வணக்கம்!
+          </Text>
+          <Text className="mt-1 text-base text-slate-300">
+            {tasks.length > 0
+              ? `இன்று உங்கள் வேலை: ${tasks.length} · Today's tasks: ${tasks.length}`
+              : 'இன்று வேலை இல்லை · No tasks today'}
+          </Text>
+          {doneToday > 0 ? (
+            <Text className="mt-1 text-sm font-semibold text-green-400">
+              இன்று முடித்தது {doneToday} ✅ · {doneToday} finished today
+            </Text>
+          ) : null}
+        </View>
+
+        {work.isLoading ? (
+          <SkeletonList count={4} />
+        ) : tasks.length === 0 ? (
+          <View className="mb-3 items-center rounded-2xl border border-slate-200 bg-white p-6">
+            <Text className="text-4xl">🎉</Text>
+            <Text className="mt-2 text-lg font-bold text-ink">
+              எல்லாம் முடிந்தது! · All done!
+            </Text>
+          </View>
+        ) : (
+          tasks.map((w) => (
+            <TaskCard
+              key={w.id}
+              item={w}
+              overdue={q?.attention.some((a) => a.id === w.id) ?? false}
+            />
+          ))
+        )}
+
+        {/* Follow-up calls due — his sales side, same one-tap treatment */}
+        {dueLeads.length > 0 ? (
+          <>
+            <Text className="mb-2 mt-2 text-lg font-bold text-ink">
+              📞 இன்று அழைக்க வேண்டியவை · Calls due today
+            </Text>
+            {dueLeads.map((l) => (
+              <FollowUpRow key={l.id} lead={l} />
+            ))}
+          </>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/apps/web/app/api/my-work/nudges/route.ts
+++ b/apps/web/app/api/my-work/nudges/route.ts
@@ -1,0 +1,204 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  notifyEveningChaser,
+  notifyWorkEscalated,
+  notifyWorkNudge,
+} from "@/lib/my-work-notify";
+import { sendTelegramMessage } from "@/lib/telegram";
+
+/**
+ * POST /api/my-work/nudges?mode=nag|evening|scorecard — the accountability
+ * engine (GitHub Actions cron, Bearer CRON_SECRET).
+ *
+ *  • nag       — every ~2h in work hours: re-push every open item due today or
+ *                overdue until the assignee acts (SR2). Items >4h overdue get
+ *                escalated ONCE to founder/owner + Telegram (SR3).
+ *  • evening   — 6pm IST: one "not finished today" summary per assignee (SR4).
+ *  • scorecard — Monday 8am IST: 7-day completion % per staffer → Telegram (SR5).
+ */
+const CRON_SECRET = process.env.CRON_SECRET;
+
+const OPEN_STATUSES = ["pending", "in_progress", "returned"];
+const NAG_COOLDOWN_MS = 90 * 60 * 1000; // don't re-nag within 90 min
+const ESCALATE_AFTER_MS = 4 * 60 * 60 * 1000; // boss hears after 4h overdue
+
+import type { WorkItemStatus } from "@maiyuri/shared";
+
+type Row = {
+  id: string;
+  title: string;
+  status: WorkItemStatus;
+  assigned_user_id: string;
+  due_at: string | null;
+  last_nudged_at: string | null;
+  nudge_count: number;
+  escalated_at: string | null;
+};
+
+/** End of the current IST day, as a UTC ISO string. */
+function istEndOfToday(): string {
+  const istDate = new Date().toLocaleDateString("en-CA", {
+    timeZone: "Asia/Kolkata",
+  });
+  return new Date(`${istDate}T23:59:59.999+05:30`).toISOString();
+}
+
+async function openItemsDueToday(): Promise<Row[]> {
+  const { data, error: qErr } = await supabaseAdmin
+    .from("work_items")
+    .select(
+      "id, title, status, assigned_user_id, due_at, last_nudged_at, nudge_count, escalated_at",
+    )
+    .in("status", OPEN_STATUSES)
+    .not("due_at", "is", null)
+    .lte("due_at", istEndOfToday());
+  if (qErr) throw new Error(`work_items query failed: ${qErr.message}`);
+  return (data ?? []) as Row[];
+}
+
+async function userNames(ids: string[]): Promise<Map<string, string>> {
+  if (!ids.length) return new Map();
+  const { data } = await supabaseAdmin
+    .from("users")
+    .select("id, name")
+    .in("id", ids);
+  return new Map((data ?? []).map((u) => [u.id as string, u.name as string]));
+}
+
+async function runNag(): Promise<{ nudged: number; escalated: number }> {
+  const items = await openItemsDueToday();
+  const now = Date.now();
+  let nudged = 0;
+  let escalated = 0;
+
+  const names = await userNames([
+    ...new Set(items.map((i) => i.assigned_user_id)),
+  ]);
+
+  for (const item of items) {
+    const overdueMs = item.due_at ? now - new Date(item.due_at).getTime() : 0;
+
+    // SR3 — one-time escalation to management once it's badly overdue.
+    if (overdueMs > ESCALATE_AFTER_MS && !item.escalated_at) {
+      await notifyWorkEscalated(
+        item,
+        names.get(item.assigned_user_id) ?? "A team member",
+        Math.floor(overdueMs / 3_600_000),
+      );
+      void sendTelegramMessage(
+        `🚨 Work escalation: ${names.get(item.assigned_user_id) ?? "?"} — "${item.title}" is ${Math.floor(overdueMs / 3_600_000)}h overdue and not done.`,
+      );
+      await supabaseAdmin
+        .from("work_items")
+        .update({ escalated_at: new Date().toISOString() })
+        .eq("id", item.id);
+      escalated += 1;
+    }
+
+    // SR2 — the repeating nag, with a cooldown so back-to-back runs don't spam.
+    const last = item.last_nudged_at
+      ? new Date(item.last_nudged_at).getTime()
+      : 0;
+    if (now - last < NAG_COOLDOWN_MS) continue;
+
+    await notifyWorkNudge(item, item.nudge_count + 1, overdueMs > 0);
+    await supabaseAdmin
+      .from("work_items")
+      .update({
+        last_nudged_at: new Date().toISOString(),
+        nudge_count: item.nudge_count + 1,
+      })
+      .eq("id", item.id);
+    nudged += 1;
+  }
+
+  return { nudged, escalated };
+}
+
+async function runEvening(): Promise<{ users: number }> {
+  const items = await openItemsDueToday();
+  const byUser = new Map<string, string[]>();
+  for (const i of items) {
+    const arr = byUser.get(i.assigned_user_id) ?? [];
+    arr.push(i.title);
+    byUser.set(i.assigned_user_id, arr);
+  }
+  for (const [userId, titles] of byUser) {
+    await notifyEveningChaser(userId, titles);
+  }
+  return { users: byUser.size };
+}
+
+async function runScorecard(): Promise<{ staff: number }> {
+  const since = new Date(Date.now() - 7 * 86_400_000).toISOString();
+  const { data, error: qErr } = await supabaseAdmin
+    .from("work_items")
+    .select("assigned_user_id, status, due_at, completed_at, created_at")
+    .gte("created_at", since);
+  if (qErr) throw new Error(`scorecard query failed: ${qErr.message}`);
+
+  type Tally = { total: number; done: number; overdueOpen: number };
+  const byUser = new Map<string, Tally>();
+  const now = Date.now();
+  for (const w of data ?? []) {
+    const t = byUser.get(w.assigned_user_id) ?? {
+      total: 0,
+      done: 0,
+      overdueOpen: 0,
+    };
+    t.total += 1;
+    if (w.status === "completed" || w.status === "approved") t.done += 1;
+    else if (
+      OPEN_STATUSES.includes(w.status) &&
+      w.due_at &&
+      new Date(w.due_at).getTime() < now
+    ) {
+      t.overdueOpen += 1;
+    }
+    byUser.set(w.assigned_user_id, t);
+  }
+  if (!byUser.size) return { staff: 0 };
+
+  const names = await userNames([...byUser.keys()]);
+  const rows = [...byUser.entries()]
+    .map(([id, t]) => ({
+      name: names.get(id) ?? "?",
+      pct: t.total ? Math.round((t.done / t.total) * 100) : 0,
+      ...t,
+    }))
+    .sort((a, b) => b.pct - a.pct);
+
+  const lines = rows.map(
+    (r, i) =>
+      `${i + 1}. ${r.name} — ${r.done}/${r.total} done (${r.pct}%)${r.overdueOpen ? ` · ⚠️ ${r.overdueOpen} overdue open` : ""}`,
+  );
+  await sendTelegramMessage(
+    `📊 Weekly Work Scorecard (last 7 days)\n${lines.join("\n")}`,
+  );
+  return { staff: rows.length };
+}
+
+export async function POST(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+
+  const mode = new URL(request.url).searchParams.get("mode") ?? "nag";
+  try {
+    if (mode === "nag") return success(await runNag());
+    if (mode === "evening") return success(await runEvening());
+    if (mode === "scorecard") return success(await runScorecard());
+    return error(`Unknown mode: ${mode}`, 400);
+  } catch (err) {
+    console.error(`[MyWork] nudges mode=${mode} failed:`, err);
+    return error("Nudge run failed", 500);
+  }
+}

--- a/apps/web/src/lib/my-work-notify.ts
+++ b/apps/web/src/lib/my-work-notify.ts
@@ -85,3 +85,67 @@ export async function notifyWorkReturned(
     data: { url: itemUrl(item.id) },
   });
 }
+
+/**
+ * Escalating nag (SR2) — repeats every cron run until the task moves.
+ * Tone hardens with the nudge count; Tamil + English so the least
+ * tech-savvy staffer can't misread it.
+ */
+export async function notifyWorkNudge(
+  item: Pick<WorkItem, "id" | "title" | "assigned_user_id" | "status">,
+  nudgeNo: number,
+  overdue: boolean,
+): Promise<void> {
+  const title = overdue
+    ? "🔴 வேலை தாமதம்! · Task overdue!"
+    : nudgeNo <= 1
+      ? "⏰ நினைவூட்டல் · Reminder"
+      : "⏰ இன்னும் காத்திருக்கிறது · Still waiting";
+  const action =
+    item.status === "pending"
+      ? "தொடங்கவும் · please start"
+      : "முடிக்கவும் · please finish";
+  await safeSend([item.assigned_user_id], {
+    title,
+    body: `${item.title} — ${action}`.slice(0, 180),
+    data: { url: itemUrl(item.id) },
+  });
+}
+
+/** Escalation (SR3) — the boss finds out. Sent ONCE per item. */
+export async function notifyWorkEscalated(
+  item: Pick<WorkItem, "id" | "title" | "due_at">,
+  assigneeName: string,
+  hoursOverdue: number,
+): Promise<void> {
+  try {
+    const admins = await getUserIdsByRoles(["founder", "owner"]);
+    await safeSend(admins, {
+      title: "🚨 Work not done — escalation",
+      body: `${assigneeName}: "${item.title}" is ${hoursOverdue}h overdue`.slice(
+        0,
+        180,
+      ),
+      data: { url: itemUrl(item.id) },
+    });
+  } catch (err) {
+    console.error("[MyWork] escalation push failed (ignored):", err);
+  }
+}
+
+/** Evening chaser (SR4) — one summary per assignee at 6pm IST. */
+export async function notifyEveningChaser(
+  userId: string,
+  titles: string[],
+): Promise<void> {
+  const head = titles.slice(0, 3).join(", ");
+  const extra = titles.length > 3 ? ` +${titles.length - 3}` : "";
+  await safeSend([userId], {
+    title: `🌆 இன்று முடிக்காதவை: ${titles.length} · Not finished today`,
+    body: `${head}${extra} — நாளைக்கு விடாதீர்கள் · don't leave it for tomorrow`.slice(
+      0,
+      180,
+    ),
+    data: { url: "/onehub/my-work" },
+  });
+}

--- a/supabase/migrations/20260718120000_work_item_nudges.sql
+++ b/supabase/migrations/20260718120000_work_item_nudges.sql
@@ -1,0 +1,12 @@
+-- Accountability nudges for My Work (SR2/SR3):
+-- track when an open item was last nagged and whether it was escalated to
+-- management, so the cron can re-notify on a schedule without spamming.
+ALTER TABLE public.work_items
+  ADD COLUMN IF NOT EXISTS last_nudged_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS nudge_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS escalated_at TIMESTAMPTZ;
+
+-- The nag cron scans open, due items every run.
+CREATE INDEX IF NOT EXISTS idx_work_items_open_due
+  ON public.work_items (due_at)
+  WHERE status IN ('pending', 'in_progress', 'returned');


### PR DESCRIPTION
## Why

Srinivasan (engineer — sales & projects) isn't tech-savvy and assigned work was getting ignored. Notifications alone are ignorable; this package makes the task the whole app and makes ignoring it visible to management.

## The five pieces

**SR1 — Task-first home** (roles `engineer`, `sales`): app opens straight into giant Tamil+English task cards — one-tap **▶ தொடங்கு Start** / **✅ முடிந்தது Done**. Server still validates photo/note requirements: a 422 pops "Almost there" and routes into the task screen where the camera lives. Due-lead follow-ups below with a big 📞 call button. Zero navigation required.

**SR2 — Escalating nag engine**: `POST /api/my-work/nudges?mode=nag` (CRON_SECRET bearer) every 2h during IST work hours (09:30–17:30). Re-pushes every open item due today/overdue until acted on; 90-min cooldown; tone hardens with `nudge_count`. Migration (already applied to prod) adds `last_nudged_at` / `nudge_count` / `escalated_at` + a partial index on open items.

**SR3 — Boss escalation**: item >4h overdue and untouched → ONE-time push to founder/owner + Telegram: "🚨 X — task is Nh overdue and not done". Silent non-compliance becomes impossible.

**SR4 — Evening chaser** (`mode=evening`, 6pm IST): one per-assignee "🌆 இன்று முடிக்காதவை / not finished today" summary push.

**SR5 — Weekly scorecard** (`mode=scorecard`, Monday 8am IST): per-staffer 7-day completion % + overdue-open count → Telegram group. Peer pressure does what reminders can't.

One workflow (`my-work-nudges.yml`) drives all three modes from its cron schedule; `workflow_dispatch` takes a `mode` input for manual test runs.

## Verification
- web `tsc` ✅ native `tsc` ✅ eslint ✅ (changed files)
- Migration applied to prod via Supabase.
- Auth: route requires `Bearer CRON_SECRET`; middleware machine-bearer bypass covers it (same as `/api/my-work/generate`).
- Mobile part ships in the pending OTA (together with #98/#99).