### PR TITLE
fix(ceo+onehub): true per-brick cost (BOM batch qty) + OneHub layout fixes

### DIFF
--- a/apps/native/app/onehub/index.tsx
+++ b/apps/native/app/onehub/index.tsx
@@ -47,7 +47,11 @@ function NavRow({
 }) {
   return (
     <Touchable onPress={onPress} className="mb-3">
-      <Card className={`flex-row items-center ${accent ? 'bg-ink' : ''}`}>
+      <Card
+        className="flex-row items-center"
+        // style (not className) so it can't lose to Card's own bg-white.
+        style={accent ? { backgroundColor: '#0f172a' } : undefined}
+      >
         <View
           className="mr-4 h-12 w-12 items-center justify-center rounded-2xl"
           style={{ backgroundColor: accent ? 'rgba(255,255,255,0.12)' : `${tint}1a` }}
@@ -178,7 +182,7 @@ export default function OneHubHome() {
           <Touchable
             key={d.key}
             onPress={() => go(`/onehub/department/${d.key}`)}
-            className="mb-3 w-[48.5%]"
+            containerClassName="mb-3 w-[48.5%]"
           >
             <Card>
               <View

--- a/apps/native/src/ui/Card.tsx
+++ b/apps/native/src/ui/Card.tsx
@@ -9,19 +9,27 @@ export function Card({
   children,
   className,
   padded = true,
+  style,
   ...rest
 }: ViewProps & { children: ReactNode; className?: string; padded?: boolean }) {
   return (
     <View
       className={`rounded-2xl bg-white ${padded ? 'p-4' : ''} ${className ?? ''}`}
-      style={{
-        // Cross-platform soft shadow (iOS) + elevation (Android).
-        shadowColor: '#0f172a',
-        shadowOpacity: 0.06,
-        shadowRadius: 12,
-        shadowOffset: { width: 0, height: 4 },
-        elevation: 2,
-      }}
+      // Passed style is MERGED after the shadow so callers can reliably
+      // override e.g. backgroundColor — a `bg-ink` in className can lose the
+      // conflict with our own `bg-white` depending on compiled class order
+      // (this made the OneHub "My Work" accent card render white-on-white).
+      style={[
+        {
+          // Cross-platform soft shadow (iOS) + elevation (Android).
+          shadowColor: '#0f172a',
+          shadowOpacity: 0.06,
+          shadowRadius: 12,
+          shadowOffset: { width: 0, height: 4 },
+          elevation: 2,
+        },
+        style,
+      ]}
       {...rest}
     >
       {children}

--- a/apps/native/src/ui/Touchable.tsx
+++ b/apps/native/src/ui/Touchable.tsx
@@ -20,6 +20,7 @@ import { haptic } from './haptics';
 export function Touchable({
   children,
   className,
+  containerClassName,
   onPress,
   haptics = true,
   rippleColor = 'rgba(15,23,42,0.12)',
@@ -28,6 +29,13 @@ export function Touchable({
 }: PressableProps & {
   children: ReactNode;
   className?: string;
+  /**
+   * Layout classes (width/margins) must go HERE, not on className: the outer
+   * Animated.View is what the parent flexbox lays out — a `w-[48.5%]` on the
+   * inner Pressable measures against the already-collapsed wrapper (this is
+   * what broke the OneHub SOP grid into skinny columns).
+   */
+  containerClassName?: string;
   haptics?: boolean;
   rippleColor?: string;
 }) {
@@ -35,7 +43,7 @@ export function Touchable({
   const animStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
 
   return (
-    <Animated.View style={animStyle}>
+    <Animated.View style={animStyle} className={containerClassName}>
       <Pressable
         className={`overflow-hidden ${className ?? ''}`}
         disabled={disabled}

--- a/apps/web/src/lib/ceo/briefing.ts
+++ b/apps/web/src/lib/ceo/briefing.ts
@@ -93,7 +93,7 @@ export async function productEconomics(): Promise<ProductEconomics[]> {
   const [{ data: goods }, { data: boms }, { data: mats }] = await Promise.all([
     supabaseAdmin
       .from("finished_goods")
-      .select("id, name, odoo_product_id, stock_qty")
+      .select("id, name, odoo_product_id, stock_qty, bom_quantity")
       .eq("is_active", true)
       .eq("plan_excluded", false),
     supabaseAdmin
@@ -121,6 +121,10 @@ export async function productEconomics(): Promise<ProductEconomics[]> {
   return (goods ?? [])
     .map((g) => {
       const lines = (boms ?? []).filter((b) => b.finished_good_id === g.id);
+      // A BOM in Odoo describes ONE BATCH, not one brick — e.g. CIB-10*8*5's
+      // recipe (90kg sand + 10kg cement + …) yields bom_quantity = 7.5 bricks.
+      // Divide by the batch output or every cost is inflated ~7×.
+      const batchQty = num((g as { bom_quantity?: unknown }).bom_quantity) || 1;
       const breakdown = lines
         .map((b) => {
           const mat = matById.get(b.raw_material_id as string);
@@ -129,7 +133,7 @@ export async function productEconomics(): Promise<ProductEconomics[]> {
             : 0;
           return {
             material: (mat?.name as string) ?? "?",
-            amount: num(b.quantity_per_bom) * unitPrice,
+            amount: (num(b.quantity_per_bom) * unitPrice) / batchQty,
           };
         })
         .sort((a, b) => b.amount - a.amount);


### PR DESCRIPTION
1. **CEO product cost was ~7× too high** — an Odoo BOM is a BATCH recipe (CIB-10*8*5: 90kg sand + 10kg cement yields `bom_quantity` = **7.5 bricks**, ~12kg each). `productEconomics()` now divides every cost line by `finished_goods.bom_quantity` (defaults to 1 when unset).
2. **Invisible "My Work" title on OneHub** — `Card` hardcodes `bg-white`; the accent `bg-ink` class can lose the compiled-class-order conflict → white text on a white card. `Card` now merges a passed `style` after its shadow, and `NavRow` sets the accent background via `style` — deterministic.
3. **SOP grid collapsed into skinny columns** — `Touchable` wraps children in an outer `Animated.View` that the parent flexbox lays out; `w-[48.5%]` on the inner Pressable measured against the collapsed wrapper. New `containerClassName` prop applies layout classes to the outer view; SOP grid uses it.

Verified: web+native `tsc` ✅, eslint ✅ on changed files (the two pre-existing `require()` asset-import errors on `onehub/index.tsx` are untouched).