### PR TITLE
feat(ceo): monthly P&L from the Odoo GL with journal-entry drill-down

### DIFF
--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -23,6 +23,7 @@ export default function OneHubLayout() {
       <Stack.Screen name="approvals" options={{ title: '👀 Approvals' }} />
       <Stack.Screen name="daily-report" options={{ title: '📊 Daily Report' }} />
       <Stack.Screen name="ceo" options={{ title: '👑 CEO Command Center' }} />
+      <Stack.Screen name="pnl" options={{ title: '📑 Profit & Loss' }} />
       <Stack.Screen name="expenses/index" options={{ title: '💰 My Expenses' }} />
       <Stack.Screen
         name="expenses/new"

--- a/apps/native/app/onehub/ceo.tsx
+++ b/apps/native/app/onehub/ceo.tsx
@@ -1,4 +1,5 @@
-import { RefreshControl, ScrollView, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 import { formatINR } from '@/hooks/use-dashboard';
 import { useCeoBriefing, type CeoProduct } from '@/hooks/use-ceo';
 import { SkeletonList } from '@/ui';
@@ -61,6 +62,7 @@ function ProductRow({ p }: { p: CeoProduct }) {
 }
 
 export default function CeoScreen() {
+  const router = useRouter();
   const query = useCeoBriefing(true);
   const b = query.data?.data;
 
@@ -154,7 +156,17 @@ export default function CeoScreen() {
           )}
 
           {/* 📈 Profit */}
-          <SectionTitle>📈 Profit (invoiced − bills)</SectionTitle>
+          <View className="mt-3 flex-row items-center justify-between">
+            <Text className="mb-2 text-base font-bold text-ink">
+              📈 Profit (invoiced − bills)
+            </Text>
+            <Pressable
+              onPress={() => router.push('/onehub/pnl' as never)}
+              className="mb-2 rounded-lg bg-ink px-3 py-1.5 active:opacity-80"
+            >
+              <Text className="text-xs font-semibold text-white">📑 Full P&L →</Text>
+            </Pressable>
+          </View>
           {b.profit.map((p) => (
             <View
               key={p.label}

--- a/apps/native/app/onehub/pnl.tsx
+++ b/apps/native/app/onehub/pnl.tsx
@@ -1,0 +1,240 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { formatINR } from '@/hooks/use-dashboard';
+import {
+  usePnl,
+  usePnlLines,
+  type PnlAccount,
+} from '@/hooks/use-ceo';
+import { SkeletonList } from '@/ui';
+
+/**
+ * 📑 Monthly P&L from the Odoo general ledger — every income/expense account,
+ * tappable down to the individual journal entries. Founder/owner only
+ * (the API enforces it).
+ */
+
+const istMonth = (): string =>
+  new Date()
+    .toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' })
+    .slice(0, 7);
+
+const addMonths = (month: string, delta: number): string => {
+  const [y, m] = month.split('-').map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return d.toISOString().slice(0, 7);
+};
+
+const prettyMonth = (month: string): string =>
+  new Date(`${month}-01T12:00:00Z`).toLocaleDateString('en-IN', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+const prettyDay = (iso: string): string =>
+  new Date(`${iso}T12:00:00Z`).toLocaleDateString('en-IN', {
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+  });
+
+/** One account row; expands to its journal entries on tap. */
+function AccountRow({
+  acc,
+  month,
+  kind,
+  tone,
+}: {
+  acc: PnlAccount;
+  month: string;
+  kind: 'income' | 'expense';
+  tone: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const lines = usePnlLines(open ? acc.account_id : null, month, kind);
+
+  return (
+    <View className="mb-2 overflow-hidden rounded-xl border border-slate-200 bg-white">
+      <Pressable
+        onPress={() => setOpen((o) => !o)}
+        className="flex-row items-center p-4 active:opacity-70"
+      >
+        <Text className="mr-2 text-xs text-slate-400">{open ? '▼' : '▶'}</Text>
+        <View className="flex-1 pr-2">
+          <Text className="text-sm font-semibold text-ink" numberOfLines={1}>
+            {acc.account}
+          </Text>
+          <Text className="text-xs text-slate-400">
+            {acc.entry_count} entr{acc.entry_count === 1 ? 'y' : 'ies'}
+          </Text>
+        </View>
+        <Text className={`text-sm font-bold ${tone}`}>{formatINR(acc.amount)}</Text>
+      </Pressable>
+
+      {open ? (
+        <View className="border-t border-slate-100 bg-slate-50 px-4 py-2">
+          {lines.isLoading ? (
+            <ActivityIndicator color="#f97316" className="my-3" />
+          ) : (lines.data?.data ?? []).length === 0 ? (
+            <Text className="py-2 text-xs text-slate-400">No entries</Text>
+          ) : (
+            (lines.data?.data ?? []).map((l, i) => (
+              <View
+                key={`${l.move}-${i}`}
+                className="flex-row items-start border-b border-slate-100 py-2 last:border-b-0"
+              >
+                <View className="flex-1 pr-2">
+                  <Text className="text-xs font-semibold text-ink" numberOfLines={1}>
+                    {l.move}
+                    {l.partner ? ` · ${l.partner}` : ''}
+                  </Text>
+                  <Text className="text-xs text-slate-500" numberOfLines={1}>
+                    {prettyDay(l.date)}
+                    {l.label ? ` — ${l.label}` : ''}
+                  </Text>
+                </View>
+                <Text
+                  className={`text-xs font-bold ${l.amount < 0 ? 'text-green-600' : 'text-ink'}`}
+                >
+                  {formatINR(l.amount)}
+                </Text>
+              </View>
+            ))
+          )}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export default function PnlScreen() {
+  const [month, setMonth] = useState(istMonth());
+  const query = usePnl(month);
+  const pnl = query.data?.data;
+  const isCurrent = month === istMonth();
+
+  return (
+    <ScrollView
+      className="flex-1 bg-canvas"
+      contentContainerClassName="p-4 pb-10"
+      refreshControl={
+        <RefreshControl
+          refreshing={query.isRefetching}
+          onRefresh={() => void query.refetch()}
+        />
+      }
+    >
+      {/* Month switcher */}
+      <View className="mb-3 flex-row items-center justify-between rounded-xl border border-slate-200 bg-white p-2">
+        <Pressable
+          onPress={() => setMonth((m) => addMonths(m, -1))}
+          className="h-10 w-10 items-center justify-center rounded-lg active:bg-slate-100"
+        >
+          <Text className="text-lg text-ink">‹</Text>
+        </Pressable>
+        <Text className="text-base font-bold text-ink">{prettyMonth(month)}</Text>
+        <Pressable
+          onPress={() => setMonth((m) => addMonths(m, 1))}
+          disabled={isCurrent}
+          className={`h-10 w-10 items-center justify-center rounded-lg ${isCurrent ? 'opacity-30' : 'active:bg-slate-100'}`}
+        >
+          <Text className="text-lg text-ink">›</Text>
+        </Pressable>
+      </View>
+
+      {query.isLoading ? (
+        <SkeletonList count={6} />
+      ) : !pnl ? (
+        <View className="items-center rounded-xl border border-slate-200 bg-white p-6">
+          <Text className="text-center text-sm text-red-500">
+            {query.error instanceof Error
+              ? query.error.message
+              : "Couldn't load the P&L"}
+          </Text>
+          <Pressable
+            onPress={() => void query.refetch()}
+            className="mt-3 rounded-xl bg-brand px-5 py-2.5 active:opacity-80"
+          >
+            <Text className="font-semibold text-ink">Retry</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <>
+          {/* Headline */}
+          <View className="mb-3 rounded-2xl bg-ink p-4">
+            <View className="flex-row">
+              <View className="flex-1">
+                <Text className="text-lg font-bold text-white">
+                  {formatINR(pnl.revenue.total)}
+                </Text>
+                <Text className="text-xs text-slate-400">Revenue</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-lg font-bold text-white">
+                  {formatINR(pnl.expenses.total)}
+                </Text>
+                <Text className="text-xs text-slate-400">Expenses</Text>
+              </View>
+              <View className="flex-1">
+                <Text
+                  className={`text-lg font-bold ${pnl.net >= 0 ? 'text-green-400' : 'text-red-400'}`}
+                >
+                  {formatINR(pnl.net)}
+                </Text>
+                <Text className="text-xs text-slate-400">
+                  {pnl.net >= 0 ? 'Profit' : 'Loss'}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Income accounts */}
+          <Text className="mb-2 text-base font-bold text-ink">💵 Income</Text>
+          {pnl.revenue.accounts.length === 0 ? (
+            <Text className="mb-2 text-sm text-slate-400">No income entries</Text>
+          ) : (
+            pnl.revenue.accounts.map((a) => (
+              <AccountRow
+                key={a.account_id}
+                acc={a}
+                month={month}
+                kind="income"
+                tone="text-green-600"
+              />
+            ))
+          )}
+
+          {/* Expense accounts */}
+          <Text className="mb-2 mt-3 text-base font-bold text-ink">
+            💸 Expenses — tap to see journal entries
+          </Text>
+          {pnl.expenses.accounts.length === 0 ? (
+            <Text className="text-sm text-slate-400">No expense entries</Text>
+          ) : (
+            pnl.expenses.accounts.map((a) => (
+              <AccountRow
+                key={a.account_id}
+                acc={a}
+                month={month}
+                kind="expense"
+                tone="text-red-600"
+              />
+            ))
+          )}
+
+          <Text className="mt-3 text-center text-xs text-slate-400">
+            Posted journal entries only · {pnl.from} → {pnl.to}
+          </Text>
+        </>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/src/hooks/use-ceo.ts
+++ b/apps/native/src/hooks/use-ceo.ts
@@ -60,6 +60,60 @@ export type CeoBriefing = {
 
 export const CEO_ROLES = ['founder', 'owner'];
 
+// ---- P&L (shapes mirror apps/web/src/lib/ceo/pnl.ts) ----
+
+export type PnlAccount = {
+  account_id: number;
+  account: string;
+  amount: number;
+  entry_count: number;
+};
+
+export type PnlStatement = {
+  month: string;
+  from: string;
+  to: string;
+  revenue: { total: number; accounts: PnlAccount[] };
+  expenses: { total: number; accounts: PnlAccount[] };
+  net: number;
+};
+
+export type PnlLine = {
+  date: string;
+  move: string;
+  partner: string | null;
+  label: string | null;
+  amount: number;
+};
+
+export function usePnl(month: string) {
+  return useQuery({
+    queryKey: ['ceo-pnl', month],
+    queryFn: () =>
+      api.get<PnlStatement>('/api/ceo/pnl', { month }, { timeoutMs: 55_000 }),
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+/** Journal entries behind one account row — fetched lazily on expand. */
+export function usePnlLines(
+  accountId: number | null,
+  month: string,
+  kind: 'income' | 'expense',
+) {
+  return useQuery({
+    queryKey: ['ceo-pnl-lines', accountId, month],
+    queryFn: () =>
+      api.get<PnlLine[]>(
+        '/api/ceo/pnl/lines',
+        { account_id: accountId, month, kind },
+        { timeoutMs: 55_000 },
+      ),
+    enabled: accountId != null,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
 export function useCeoBriefing(enabled: boolean) {
   return useQuery({
     queryKey: ['ceo-briefing'],

--- a/apps/web/app/api/ceo/pnl/lines/route.ts
+++ b/apps/web/app/api/ceo/pnl/lines/route.ts
@@ -1,0 +1,36 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { pnlAccountLines } from "@/lib/ceo/pnl";
+
+/**
+ * GET /api/ceo/pnl/lines?account_id=&month=YYYY-MM&kind=income|expense —
+ * the journal entries behind one P&L account row. Founder/owner only.
+ */
+const CEO_ROLES = ["founder", "owner"];
+const MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!CEO_ROLES.includes(user.role)) return error("Not permitted", 403);
+
+    const params = new URL(request.url).searchParams;
+    const accountId = Number(params.get("account_id"));
+    const month = params.get("month") ?? "";
+    const kind = params.get("kind") === "income" ? "income" : "expense";
+    if (!Number.isInteger(accountId) || accountId <= 0) {
+      return error("account_id required", 400);
+    }
+    if (!MONTH_RE.test(month)) return error("month must be YYYY-MM", 400);
+
+    return success(await pnlAccountLines(accountId, month, kind));
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[CEO] pnl lines failed:", err);
+    return error("Failed to load journal entries", 500);
+  }
+}

--- a/apps/web/app/api/ceo/pnl/route.ts
+++ b/apps/web/app/api/ceo/pnl/route.ts
@@ -1,0 +1,35 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { pnlForMonth } from "@/lib/ceo/pnl";
+
+/**
+ * GET /api/ceo/pnl?month=YYYY-MM — monthly P&L from Odoo's GL, grouped by
+ * account. Founder/owner only.
+ */
+const CEO_ROLES = ["founder", "owner"];
+const MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+const istMonth = (): string =>
+  new Date()
+    .toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" })
+    .slice(0, 7);
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!CEO_ROLES.includes(user.role)) return error("Not permitted", 403);
+
+    const raw = new URL(request.url).searchParams.get("month");
+    const month = raw && MONTH_RE.test(raw) ? raw : istMonth();
+
+    return success(await pnlForMonth(month));
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[CEO] pnl failed:", err);
+    return error("Failed to build the P&L", 500);
+  }
+}

--- a/apps/web/src/lib/ceo/pnl.ts
+++ b/apps/web/src/lib/ceo/pnl.ts
@@ -1,0 +1,145 @@
+/**
+ * Monthly Profit & Loss straight from Odoo's general ledger — grouped by
+ * P&L account, drillable down to the individual posted journal entries.
+ *
+ * Sign conventions (Odoo stores balance = debit − credit):
+ *   income accounts carry credit balances (negative)  → shown as -balance
+ *   expense accounts carry debit balances (positive)  → shown as +balance
+ */
+import { odooExecute } from "@/lib/odoo-service";
+
+const num = (v: unknown): number => (typeof v === "number" ? v : Number(v) || 0);
+
+const INCOME_TYPES = ["income", "income_other"];
+const EXPENSE_TYPES = ["expense", "expense_depreciation", "expense_direct_cost"];
+
+export type PnlAccount = {
+  account_id: number;
+  account: string;
+  amount: number; // positive, display-ready
+  entry_count: number;
+};
+
+export type PnlStatement = {
+  month: string; // YYYY-MM
+  from: string;
+  to: string;
+  revenue: { total: number; accounts: PnlAccount[] };
+  expenses: { total: number; accounts: PnlAccount[] };
+  net: number;
+};
+
+export type PnlLine = {
+  date: string;
+  move: string; // journal entry ref (BILL/2026/07/0012, MISC/…)
+  partner: string | null;
+  label: string | null;
+  amount: number;
+};
+
+/** Month bounds: "2026-07" → { from: 2026-07-01, to: 2026-07-31 }. */
+export function monthBounds(month: string): { from: string; to: string } {
+  const [y, m] = month.split("-").map(Number);
+  const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  return {
+    from: `${month}-01`,
+    to: `${month}-${String(lastDay).padStart(2, "0")}`,
+  };
+}
+
+async function groupByAccount(
+  accountTypes: string[],
+  from: string,
+  to: string,
+  flipSign: boolean,
+): Promise<PnlAccount[]> {
+  const groups = (await odooExecute(
+    "account.move.line",
+    "read_group",
+    [
+      [
+        ["account_id.account_type", "in", accountTypes],
+        ["parent_state", "=", "posted"],
+        ["date", ">=", from],
+        ["date", "<=", to],
+      ],
+      ["balance"],
+      ["account_id"],
+    ],
+    { lazy: false },
+  )) as { account_id: [number, string] | false; balance: number; __count: number }[];
+
+  return groups
+    .filter((g) => Array.isArray(g.account_id))
+    .map((g) => ({
+      account_id: (g.account_id as [number, string])[0],
+      account: (g.account_id as [number, string])[1],
+      amount: flipSign ? -num(g.balance) : num(g.balance),
+      entry_count: num(g.__count),
+    }))
+    .sort((a, b) => b.amount - a.amount);
+}
+
+export async function pnlForMonth(month: string): Promise<PnlStatement> {
+  const { from, to } = monthBounds(month);
+  const [income, expenses] = await Promise.all([
+    groupByAccount(INCOME_TYPES, from, to, true),
+    groupByAccount(EXPENSE_TYPES, from, to, false),
+  ]);
+  const revenueTotal = income.reduce((s, a) => s + a.amount, 0);
+  const expenseTotal = expenses.reduce((s, a) => s + a.amount, 0);
+  return {
+    month,
+    from,
+    to,
+    revenue: { total: revenueTotal, accounts: income },
+    expenses: { total: expenseTotal, accounts: expenses },
+    net: revenueTotal - expenseTotal,
+  };
+}
+
+/**
+ * Drill-down: every posted journal line on one account in the month.
+ * `kind` fixes the sign so refunds/credit-notes show as negatives instead of
+ * being flattened by an abs().
+ */
+export async function pnlAccountLines(
+  accountId: number,
+  month: string,
+  kind: "income" | "expense",
+): Promise<PnlLine[]> {
+  const { from, to } = monthBounds(month);
+  const lines = (await odooExecute(
+    "account.move.line",
+    "search_read",
+    [
+      [
+        ["account_id", "=", accountId],
+        ["parent_state", "=", "posted"],
+        ["date", ">=", from],
+        ["date", "<=", to],
+      ],
+    ],
+    {
+      fields: ["date", "move_id", "partner_id", "name", "balance"],
+      order: "date desc, id desc",
+      limit: 300,
+    },
+  )) as {
+    date: string;
+    move_id: [number, string] | false;
+    partner_id: [number, string] | false;
+    name: string | false;
+    balance: number;
+  }[];
+
+  return lines.map((l) => ({
+    date: l.date,
+    move: Array.isArray(l.move_id) ? l.move_id[1] : "—",
+    partner: Array.isArray(l.partner_id) ? l.partner_id[1] : null,
+    label: l.name || null,
+    // Natural sign per section: expenses debit-positive, income
+    // credit-positive; refunds/credit notes come out negative.
+    amount: kind === "income" ? -num(l.balance) : num(l.balance),
+  }));
+}


### PR DESCRIPTION
## What

A real monthly **Profit & Loss** built from Odoo's general ledger (posted journal items only), drillable from account level down to **individual journal entries**.

- **`GET /api/ceo/pnl?month=YYYY-MM`** — posted `account.move.line` grouped by P&L account: income (`income`, `income_other`) vs expenses (`expense`, `expense_depreciation`, `expense_direct_cost`), correct sign conventions (income credit-positive, expenses debit-positive), entry counts per account.
- **`GET /api/ceo/pnl/lines?account_id=&month=&kind=`** — the journal entries behind one account row: date, move ref (BILL/…, MISC/…), partner, label, amount. Refunds/credit notes show as negatives instead of being flattened.
- **Mobile `/onehub/pnl`** — month switcher (‹ ›), Revenue/Expenses/Net headline card, then income & expense accounts as **accordion rows — tap any account to lazily load its journal entries**. Linked from the CEO Command Center via a "📑 Full P&L →" button on the profit section.
- Founder/owner only (both routes enforce it).

## Verification
- web `tsc` ✅ native `tsc` ✅ eslint ✅
- JS-only mobile → ships via the one-click OTA after merge.