### PR TITLE
ci: telegram-say workflow (dispatch-only bot message to a chosen chat)

### DIFF
--- a/.github/workflows/telegram-say.yml
+++ b/.github/workflows/telegram-say.yml
@@ -1,0 +1,28 @@
+name: Telegram say
+
+# Manually send a message from the Maiyuri bot to a specific chat.
+# Used for ops/admin checks (e.g. identifying a chat by posting into it).
+# workflow_dispatch only — requires repo write access to trigger.
+
+on:
+  workflow_dispatch:
+    inputs:
+      chat_id:
+        description: "Target chat id (e.g. -5116644495)"
+        required: true
+      text:
+        description: "Message text"
+        required: true
+
+jobs:
+  say:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send message
+        run: |
+          resp=$(curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ github.event.inputs.chat_id }}" \
+            --data-urlencode text="${{ github.event.inputs.text }}")
+          echo "$resp"
+          echo "$resp" | grep -q '"ok":true' || exit 1


### PR DESCRIPTION
Tiny admin utility: workflow_dispatch with chat_id + text inputs, sends via the TELEGRAM_BOT_TOKEN secret. Needed to post an identification message into the recordings intake group (-5116644495); reusable for future ops checks. Trigger requires repo write access.