### PR TITLE
ci(telegram-say): info mode — chat title, member count, admin list

### DIFF
--- a/.github/workflows/telegram-say.yml
+++ b/.github/workflows/telegram-say.yml
@@ -11,8 +11,13 @@ on:
         description: "Target chat id (e.g. -5116644495)"
         required: true
       text:
-        description: "Message text"
-        required: true
+        description: "Message text (mode=say only)"
+        required: false
+        default: ""
+      mode:
+        description: "say = send text · info = chat title/member count/admins"
+        required: false
+        default: "say"
 
 jobs:
   say:
@@ -20,9 +25,19 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Send message
+        if: ${{ github.event.inputs.mode != 'info' }}
         run: |
           resp=$(curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ github.event.inputs.chat_id }}" \
             --data-urlencode text="${{ github.event.inputs.text }}")
           echo "$resp"
           echo "$resp" | grep -q '"ok":true' || exit 1
+
+      - name: Chat info (title, member count, admins)
+        if: ${{ github.event.inputs.mode == 'info' }}
+        run: |
+          base="https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}"
+          cid="${{ github.event.inputs.chat_id }}"
+          echo "--- getChat ---";                curl -s "$base/getChat?chat_id=$cid"; echo
+          echo "--- getChatMemberCount ---";     curl -s "$base/getChatMemberCount?chat_id=$cid"; echo
+          echo "--- getChatAdministrators ---";  curl -s "$base/getChatAdministrators?chat_id=$cid"; echo


### PR DESCRIPTION
Adds mode=info to the telegram-say utility: getChat + getChatMemberCount + getChatAdministrators for a chat id. Needed to identify who is in the recordings group (-5116644495) — the hi message was delivered (ok:true) but Ram does not see it, so we need the member/admin names.