### PR TITLE
ci(telegram-say): getWebhookInfo in info mode

### DIFF
--- a/.github/workflows/telegram-say.yml
+++ b/.github/workflows/telegram-say.yml
@@ -41,3 +41,4 @@ jobs:
           echo "--- getChat ---";                curl -s "$base/getChat?chat_id=$cid"; echo
           echo "--- getChatMemberCount ---";     curl -s "$base/getChatMemberCount?chat_id=$cid"; echo
           echo "--- getChatAdministrators ---";  curl -s "$base/getChatAdministrators?chat_id=$cid"; echo
+          echo "--- getWebhookInfo ---";         curl -s "$base/getWebhookInfo"; echo


### PR DESCRIPTION
Adds getWebhookInfo to the info mode output — shows pending_update_count and last_error_message, needed to diagnose why voice notes from the new recordings group are not reaching the webhook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook information to the Telegram “info” workflow output.
  * Existing “say” mode behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->