### PR TITLE
feat(leads): founder push on every new lead & meaningful update, incl. Telegram-call leads

### DIFF
--- a/apps/web/app/api/leads/[id]/route.ts
+++ b/apps/web/app/api/leads/[id]/route.ts
@@ -163,6 +163,34 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         const newAssignee = (lead.assigned_staff as string | null) ?? null;
         const leadName = lead.name || "Lead";
 
+        // The change summary, computed once — used for both the rep ping and
+        // the leadership ping below.
+        const changes: string[] = [];
+        if (
+          updateData.pipeline_stage &&
+          updateData.pipeline_stage !== currentLead.pipeline_stage
+        ) {
+          changes.push(`Stage → ${prettyLabel(updateData.pipeline_stage)}`);
+        }
+        if (
+          updateData.lead_status &&
+          updateData.lead_status !== currentLead.lead_status
+        ) {
+          changes.push(`Status → ${prettyLabel(updateData.lead_status)}`);
+        }
+        if (
+          updateData.lead_temperature &&
+          updateData.lead_temperature !== currentLead.lead_temperature
+        ) {
+          changes.push(`${prettyLabel(updateData.lead_temperature)} lead`);
+        }
+        if (
+          updateData.follow_up_date &&
+          updateData.follow_up_date !== currentLead.follow_up_date
+        ) {
+          changes.push("Follow-up rescheduled");
+        }
+
         // Case 1: reassignment (skip self-assignment ping).
         if (newAssignee && newAssignee !== prevAssignee && newAssignee !== editorId) {
           await notifyLeadPush([newAssignee], {
@@ -174,34 +202,31 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
         // Case 2: meaningful field change → notify the (unchanged) owner.
         // Require a known editor and skip if the editor IS the owner.
-        if (newAssignee && newAssignee === prevAssignee && editorId && newAssignee !== editorId) {
-          const changes: string[] = [];
-          if (
-            updateData.pipeline_stage &&
-            updateData.pipeline_stage !== currentLead.pipeline_stage
-          ) {
-            changes.push(`Stage → ${prettyLabel(updateData.pipeline_stage)}`);
-          }
-          if (
-            updateData.lead_status &&
-            updateData.lead_status !== currentLead.lead_status
-          ) {
-            changes.push(`Status → ${prettyLabel(updateData.lead_status)}`);
-          }
-          if (
-            updateData.lead_temperature &&
-            updateData.lead_temperature !== currentLead.lead_temperature
-          ) {
-            changes.push(`${prettyLabel(updateData.lead_temperature)} lead`);
-          }
-          if (
-            updateData.follow_up_date &&
-            updateData.follow_up_date !== currentLead.follow_up_date
-          ) {
-            changes.push("Follow-up rescheduled");
-          }
-          if (changes.length > 0) {
-            await notifyLeadPush([newAssignee], {
+        if (
+          newAssignee &&
+          newAssignee === prevAssignee &&
+          editorId &&
+          newAssignee !== editorId &&
+          changes.length > 0
+        ) {
+          await notifyLeadPush([newAssignee], {
+            title: `✏️ ${leadName} updated`,
+            body: changes.join(" · "),
+            leadId: lead.id,
+          });
+        }
+
+        // Case 3: leadership visibility — the founder asked to hear about
+        // every meaningful lead change. Exclude the editor (no self-pings)
+        // and the assignee (already pinged above); respect push_leads.
+        if (changes.length > 0) {
+          const leadership = await getUserIdsByRoles(["founder", "owner"]);
+          const others = leadership.filter(
+            (uid) => uid !== editorId && uid !== newAssignee,
+          );
+          const recipients = await filterByPushPref(others, "push_leads");
+          if (recipients.length > 0) {
+            await notifyLeadPush(recipients, {
               title: `✏️ ${leadName} updated`,
               body: changes.join(" · "),
               leadId: lead.id,

--- a/apps/web/app/api/leads/extract-from-audio/route.ts
+++ b/apps/web/app/api/leads/extract-from-audio/route.ts
@@ -7,6 +7,11 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  filterByPushPref,
+  getUserIdsByRoles,
+  notifyLeadPush,
+} from "@/lib/push/fcm";
 
 interface ExtractedLeadInfo {
   name: string | null;
@@ -75,6 +80,33 @@ export async function POST(request: NextRequest) {
           .from("call_recordings")
           .update({ lead_id: lead.id })
           .eq("id", recording_id);
+      }
+
+      // Push the founder/owner a lead summary — Telegram-uploaded calls used
+      // to create leads silently; leadership specifically asked to hear about
+      // these. Best-effort: a push failure must never fail the creation.
+      try {
+        const leadership = await getUserIdsByRoles(["founder", "owner"]);
+        const recipients = await filterByPushPref(leadership, "push_leads");
+        const summary = [
+          extractedInfo.lead_type,
+          extractedInfo.requirement_type?.replace(/_/g, " "),
+          extractedInfo.site_location ?? extractedInfo.site_region,
+          extractedInfo.next_action,
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        await notifyLeadPush(recipients, {
+          title: `🎙️ New lead from call: ${lead.name ?? lead.contact}`,
+          body:
+            `${summary || lead.contact} (${extractedInfo.confidence}% confidence)`.slice(
+              0,
+              180,
+            ),
+          leadId: lead.id,
+        });
+      } catch (pushErr) {
+        console.error("[Extract Lead] push failed (ignored):", pushErr);
       }
 
       return NextResponse.json({

--- a/apps/web/app/api/leads/route.ts
+++ b/apps/web/app/api/leads/route.ts
@@ -11,7 +11,11 @@ import {
   sanitizeSearchTerm,
 } from "@/lib/api-utils";
 import { notifyNewLeadDetailed } from "@/lib/telegram";
-import { notifyLeadPush } from "@/lib/push/fcm";
+import {
+  filterByPushPref,
+  getUserIdsByRoles,
+  notifyLeadPush,
+} from "@/lib/push/fcm";
 import {
   createLeadSchema,
   paginationSchema,
@@ -20,18 +24,17 @@ import {
 } from "@maiyuri/shared";
 
 /**
- * Resolve which users should receive a "new lead" push:
- * the assigned rep if set, otherwise leadership (founder/owner).
+ * Resolve which users should receive a "new lead" push: leadership
+ * (founder/owner) ALWAYS — the founder asked to hear about every new lead —
+ * plus the assigned rep when set. Respects the push_leads opt-out.
  */
 async function resolveNewLeadRecipients(
   assignedStaff: string | null,
 ): Promise<string[]> {
-  if (assignedStaff) return [assignedStaff];
-  const { data } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .in("role", ["founder", "owner"]);
-  return (data ?? []).map((u) => u.id);
+  const leadership = await getUserIdsByRoles(["founder", "owner"]);
+  const ids = new Set(leadership);
+  if (assignedStaff) ids.add(assignedStaff);
+  return filterByPushPref([...ids], "push_leads");
 }
 
 // GET /api/leads - List all leads with filtering and pagination


### PR DESCRIPTION
Closes the notification gaps the founder hit:

1. **New lead** — push recipients were assignee OR leadership; now **leadership always** + assignee (deduped, push_leads pref respected).
2. **Telegram-audio leads** (`extract-from-audio`) — were created **silently**; now leadership gets a summary push: `🎙️ New lead from call: <name>` with type · requirement · location · next action + confidence %.
3. **Lead updates** — change summary (stage/status/temperature/follow-up) previously went only to the assigned rep; now **also to leadership**, excluding the editor (no self-pings) and the already-notified assignee.

tsc + eslint clean. Deep links open the lead in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notifications for meaningful lead updates, including a summary of the changes.
  * Leadership can now receive notifications when leads are updated, subject to lead notification preferences.
  * Added notifications when a lead is automatically created from a call transcription.
  * New lead notifications now reach relevant leadership and assigned representatives who have enabled lead notifications.
* **Bug Fixes**
  * Improved notification consistency by preventing unnecessary updates when no meaningful changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->