### PR TITLE
ci: cron-kick workflow (manual trigger for CRON_SECRET endpoints)

### DIFF
--- a/.github/workflows/cron-kick.yml
+++ b/.github/workflows/cron-kick.yml
@@ -1,0 +1,26 @@
+name: Cron kick
+
+# Manually trigger one of the app's CRON_SECRET-protected endpoints out of
+# schedule (e.g. process a stuck call recording immediately instead of waiting
+# for the nightly run). workflow_dispatch only — repo write access required.
+
+on:
+  workflow_dispatch:
+    inputs:
+      path:
+        description: "API path to POST (e.g. /api/recordings/process)"
+        required: true
+        default: "/api/recordings/process"
+
+jobs:
+  kick:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Call endpoint
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com${{ github.event.inputs.path }}")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi


### PR DESCRIPTION
workflow_dispatch with a path input; POSTs to mb.maiyuri.com with the CRON_SECRET bearer. Needed to run the recordings processor immediately (user asked to transcribe the stuck recording now instead of waiting for the nightly cron). Reusable for any protected cron endpoint.