### PR TITLE
feat(calls): fool-proof next-action + due-date extraction into a real My Work task

### DIFF
--- a/.github/workflows/cron-kick.yml
+++ b/.github/workflows/cron-kick.yml
@@ -1,0 +1,26 @@
+name: Cron kick
+
+# Manually trigger one of the app's CRON_SECRET-protected endpoints out of
+# schedule (e.g. process a stuck call recording immediately instead of waiting
+# for the nightly run). workflow_dispatch only — repo write access required.
+
+on:
+  workflow_dispatch:
+    inputs:
+      path:
+        description: "API path to POST (e.g. /api/recordings/process)"
+        required: true
+        default: "/api/recordings/process"
+
+jobs:
+  kick:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Call endpoint
+        run: |
+          status=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com${{ github.event.inputs.path }}")
+          echo "HTTP $status"; cat /tmp/r.json
+          if [ "$status" -ge 400 ]; then exit 1; fi

--- a/apps/web/src/lib/call-recording/analysis.ts
+++ b/apps/web/src/lib/call-recording/analysis.ts
@@ -154,6 +154,7 @@ Extract lead information from this call in JSON format:
   "site_region": "Chennai|Coimbatore|Madurai|Salem|Trichy|Tirupur|Erode|Vellore|Thanjavur|Other",
   "site_location": "specific location/area if mentioned",
   "next_action": "recommended next step",
+  "follow_up_date": "YYYY-MM-DD or null",
   "estimated_quantity": null or number of bricks if mentioned,
   "notes": "any important context about the customer's requirements"
 }
@@ -176,6 +177,7 @@ Guidelines:
 - site_region: Tamil Nadu district/city if mentioned
 - site_location: Specific area, street, or village name if mentioned
 - next_action: What should sales team do next? (e.g., "Schedule site visit", "Send quotation", "Call back next week")
+- follow_up_date: WHEN should the next_action happen, as YYYY-MM-DD. Today (IST) is ${new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" })}. Resolve relative timing from the call ("call me Monday", "after two weeks", "next month"). If the call clearly needs a follow-up but no timing was mentioned, use tomorrow's date. Use null ONLY when no follow-up is needed at all.
 - estimated_quantity: Number of bricks if customer mentioned (e.g., "10000 bricks" -> 10000)
 - notes: Key requirements, timeline, special requests
 
@@ -212,6 +214,7 @@ ${transcript}`;
       site_region: null,
       site_location: null,
       next_action: "Follow up with customer",
+      follow_up_date: null,
       estimated_quantity: null,
       notes: null,
     };
@@ -290,6 +293,7 @@ function parseLeadDetailsResponse(response: string): ExtractedLeadDetails {
         typeof parsed.site_location === "string" ? parsed.site_location : null,
       next_action:
         typeof parsed.next_action === "string" ? parsed.next_action : null,
+      follow_up_date: sanitizeFollowUpDate(parsed.follow_up_date),
       estimated_quantity:
         typeof parsed.estimated_quantity === "number"
           ? parsed.estimated_quantity
@@ -307,10 +311,38 @@ function parseLeadDetailsResponse(response: string): ExtractedLeadDetails {
       site_region: null,
       site_location: null,
       next_action: null,
+      follow_up_date: null,
       estimated_quantity: null,
       notes: null,
     };
   }
+}
+
+/** Today (IST) as YYYY-MM-DD. */
+function istToday(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+}
+
+/**
+ * Fool-proof the AI's follow-up date: must be a real YYYY-MM-DD; anything in
+ * the past clamps to tomorrow (the model sometimes echoes a date the customer
+ * SAID, e.g. "I called you last Monday"); anything more than a year out is
+ * discarded as a hallucination.
+ */
+function sanitizeFollowUpDate(value: unknown): string | null {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const today = istToday();
+  const tomorrow = new Date(`${today}T12:00:00Z`);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const tomorrowISO = tomorrow.toISOString().slice(0, 10);
+
+  if (value < today) return tomorrowISO;
+  const yearOut = new Date(`${today}T12:00:00Z`);
+  yearOut.setUTCFullYear(yearOut.getUTCFullYear() + 1);
+  if (value > yearOut.toISOString().slice(0, 10)) return null;
+  return value;
 }
 
 function ensureStringArray(value: unknown): string[] | undefined {

--- a/apps/web/src/lib/call-recording/processor.ts
+++ b/apps/web/src/lib/call-recording/processor.ts
@@ -264,7 +264,7 @@ export async function processRecording(
       const { data: currentLead } = await supabase
         .from("leads")
         .select(
-          "lead_type, classification, requirement_type, product_interests, site_region, site_location, next_action, estimated_quantity, notes",
+          "lead_type, classification, requirement_type, product_interests, site_region, site_location, next_action, follow_up_date, estimated_quantity, notes",
         )
         .eq("id", lead_id)
         .single();
@@ -300,8 +300,25 @@ export async function processRecording(
         if (!currentLead.site_location && extractedDetails.site_location) {
           updates.site_location = extractedDetails.site_location;
         }
-        if (!currentLead.next_action && extractedDetails.next_action) {
+        // Next action: the LATEST call always wins — a stale "send quotation"
+        // from last week must not survive a call that agreed on a site visit.
+        if (
+          extractedDetails.next_action &&
+          extractedDetails.next_action !== currentLead.next_action
+        ) {
           updates.next_action = extractedDetails.next_action;
+        }
+        // Follow-up date: set when empty; when one exists, only ever PULL IT
+        // EARLIER (a call can add urgency, never silently postpone). If the
+        // call needs a follow-up but gave no timing, the extractor already
+        // defaulted to tomorrow.
+        if (extractedDetails.follow_up_date) {
+          const existing = currentLead.follow_up_date
+            ? String(currentLead.follow_up_date).slice(0, 10)
+            : null;
+          if (!existing || extractedDetails.follow_up_date < existing) {
+            updates.follow_up_date = extractedDetails.follow_up_date;
+          }
         }
         if (!currentLead.estimated_quantity && extractedDetails.estimated_quantity) {
           updates.estimated_quantity = extractedDetails.estimated_quantity;
@@ -331,6 +348,20 @@ export async function processRecording(
             });
           }
         }
+      }
+
+      // Turn the next action into a REAL task in My Work so the whole
+      // accountability machine (task-first home, 2h nags, founder escalation,
+      // evening chaser) owns it — a lead field alone can be ignored.
+      if (extractedDetails.next_action && extractedDetails.follow_up_date) {
+        await upsertNextActionTask(
+          lead_id,
+          lead?.name ?? phone_number,
+          (lead?.assigned_staff as string | null) ?? null,
+          extractedDetails.next_action,
+          extractedDetails.follow_up_date,
+          id,
+        );
       }
     }
 
@@ -434,5 +465,101 @@ export async function processRecording(
     }
 
     throw error;
+  }
+}
+
+/**
+ * Turn a call's extracted next action into a My Work task so the
+ * accountability engine (task-first home, 2h nags, >4h founder escalation,
+ * 6pm chaser) chases it. One OPEN task per lead from this source — a newer
+ * call updates it (and re-arms the nag counters) instead of stacking
+ * duplicates. Best-effort: never fails the recording pipeline.
+ */
+async function upsertNextActionTask(
+  leadId: string,
+  leadName: string,
+  assignedStaff: string | null,
+  nextAction: string,
+  followUpDate: string, // YYYY-MM-DD (IST)
+  recordingId: string,
+): Promise<void> {
+  try {
+    const supabase = getSupabaseAdmin();
+
+    // Assignee: the lead's rep, else the first active sales/engineer, else
+    // leadership — a task nobody owns nags nobody.
+    let assignee = assignedStaff;
+    if (!assignee) {
+      const { data: fallback } = await supabase
+        .from("users")
+        .select("id, role")
+        .eq("is_active", true)
+        .in("role", ["sales", "engineer", "founder", "owner"])
+        .order("role", { ascending: false }) // sales > owner > founder > engineer alphabetically reversed — good enough tiebreak
+        .limit(10);
+      const byRole = (r: string) => fallback?.find((u) => u.role === r)?.id;
+      assignee =
+        byRole("sales") ?? byRole("engineer") ?? byRole("founder") ?? byRole("owner") ?? null;
+    }
+    if (!assignee) return;
+
+    const title = `📞 ${nextAction} — ${leadName}`.slice(0, 200);
+    const dueAt = new Date(`${followUpDate}T10:00:00+05:30`).toISOString();
+
+    // One open call-task per lead: update it if it exists, create otherwise.
+    const { data: existing } = await supabase
+      .from("work_items")
+      .select("id")
+      .eq("related_lead_id", leadId)
+      .eq("source_module", "call_recording")
+      .in("status", ["pending", "in_progress", "returned"])
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) {
+      await supabase
+        .from("work_items")
+        .update({
+          title,
+          due_at: dueAt,
+          assigned_user_id: assignee,
+          source_record_id: recordingId,
+          // Re-arm the nag engine for the fresh action/date.
+          last_nudged_at: null,
+          nudge_count: 0,
+          escalated_at: null,
+        })
+        .eq("id", existing.id);
+      logProgress(recordingId, "Next-action task updated", { task: title });
+      return;
+    }
+
+    const { data: item, error: insErr } = await supabase
+      .from("work_items")
+      .insert({
+        title,
+        description: `Auto-created from the call recording. Next action agreed on the call: ${nextAction}`,
+        activity_type: "simple",
+        status: "pending",
+        priority: "high",
+        assigned_user_id: assignee,
+        due_at: dueAt,
+        related_lead_id: leadId,
+        related_label: leadName,
+        source_module: "call_recording",
+        source_record_id: recordingId,
+      })
+      .select("*")
+      .single();
+
+    if (insErr || !item) {
+      logError("Next-action task insert failed", insErr);
+      return;
+    }
+    logProgress(recordingId, "Next-action task created", { task: title });
+    const { notifyWorkAssigned } = await import("@/lib/my-work-notify");
+    await notifyWorkAssigned(item as never);
+  } catch (err) {
+    logError("upsertNextActionTask failed (ignored)", err);
   }
 }

--- a/apps/web/src/lib/call-recording/types.ts
+++ b/apps/web/src/lib/call-recording/types.ts
@@ -77,6 +77,8 @@ export interface ExtractedLeadDetails {
   site_region: string | null;
   site_location: string | null;
   next_action: string | null;
+  /** YYYY-MM-DD (IST) the next action is due — resolved from the call. */
+  follow_up_date: string | null;
   estimated_quantity: number | null;
   notes: string | null;
 }


### PR DESCRIPTION
Every processed call recording now produces an actionable, chased task:

- **Gemini extracts `follow_up_date`** (prompt includes today in IST so relative timing resolves — "call me Monday", "after 2 weeks"; defaults to tomorrow when follow-up is needed but no timing was said). `sanitizeFollowUpDate` fool-proofs it: invalid → null, past → tomorrow, >1yr → discarded.
- **Lead fields**: `next_action` always refreshes from the latest call (was only-if-empty → stale actions survived); `follow_up_date` sets when empty and can only move EARLIER.
- **Auto My Work task**: `📞 <action> — <lead>`, priority high, due 10:00 IST, assigned to the lead rep (fallback sales/engineer). One open task per lead from this source — a newer call updates it and re-arms the nag counters. Assignee gets a push.

Result: the extracted next action lands in the task-first home, gets the 2h nags, escalates to the founder at 4h overdue, and appears in the 6pm chaser + Monday scorecard.

tsc + eslint clean.