### PR TITLE
feat(golden-hour): rate card — delivered price per product per km band (GH0)

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -59,6 +59,7 @@ const navigation: NavItem[] = [
   { name: "Plan", href: "/planning", icon: ProductionIcon, key: "planning" },
   { name: "Projects", href: "/projects", icon: ProductionIcon, key: "projects" },
   { name: "Reimbursements", href: "/expenses", icon: KPIIcon, key: "expenses" },
+  { name: "Rate Card", href: "/rate-card", icon: KPIIcon, key: "rate-card" },
   {
     name: "Approvals",
     href: "/approvals",
@@ -92,6 +93,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
     "coaching",
     "projects",
     "expenses",
+    "rate-card",
   ],
   engineer: [
     "dashboard",

--- a/apps/web/app/(dashboard)/rate-card/page.tsx
+++ b/apps/web/app/(dashboard)/rate-card/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+/**
+ * 💰 Rate Card — delivered price per product per km band (Golden Hour GH0).
+ * The auto-quote and the AI pre-call brief price from this table; when a
+ * distance has no band the product's base price is used as fallback.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+type Product = { id: string; name: string; unit: string; base_price: number };
+type Entry = {
+  id: string;
+  product_id: string;
+  km_from: number;
+  km_to: number;
+  unit_price: number;
+};
+type RateCard = { products: Product[]; entries: Entry[] };
+type BandDraft = { km_from: string; km_to: string; unit_price: string };
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data as T;
+}
+async function putJson(url: string, payload: unknown) {
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data;
+}
+
+function ProductBands({
+  product,
+  initial,
+}: {
+  product: Product;
+  initial: Entry[];
+}) {
+  const queryClient = useQueryClient();
+  // Initialized from props; the parent remounts this component (key includes
+  // the server data hash) whenever fresh bands arrive, so no sync effect.
+  const [bands, setBands] = useState<BandDraft[]>(() =>
+    initial.map((e) => ({
+      km_from: String(e.km_from),
+      km_to: String(e.km_to),
+      unit_price: String(e.unit_price),
+    })),
+  );
+  const [dirty, setDirty] = useState(false);
+
+  const save = useMutation({
+    mutationFn: () =>
+      putJson("/api/rate-card", {
+        product_id: product.id,
+        bands: bands.map((b) => ({
+          km_from: Number(b.km_from),
+          km_to: Number(b.km_to),
+          unit_price: Number(b.unit_price),
+        })),
+      }),
+    onSuccess: () => {
+      setDirty(false);
+      void queryClient.invalidateQueries({ queryKey: ["rate-card"] });
+    },
+  });
+
+  const set = (i: number, key: keyof BandDraft, value: string) => {
+    setBands((prev) => prev.map((b, j) => (j === i ? { ...b, [key]: value } : b)));
+    setDirty(true);
+  };
+  const addBand = () => {
+    const lastTo = bands.length ? bands[bands.length - 1].km_to : "0";
+    setBands((prev) => [
+      ...prev,
+      { km_from: lastTo, km_to: "", unit_price: "" },
+    ]);
+    setDirty(true);
+  };
+  const removeBand = (i: number) => {
+    setBands((prev) => prev.filter((_, j) => j !== i));
+    setDirty(true);
+  };
+
+  const invalid = bands.some(
+    (b) =>
+      b.km_from === "" ||
+      b.km_to === "" ||
+      b.unit_price === "" ||
+      Number(b.km_to) <= Number(b.km_from),
+  );
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold text-slate-900">{product.name}</h3>
+          <p className="text-xs text-slate-500">
+            per {product.unit} · fallback base price ₹{product.base_price}
+          </p>
+        </div>
+        <button
+          onClick={() => save.mutate()}
+          disabled={!dirty || invalid || save.isPending}
+          className="rounded-lg bg-slate-900 px-4 py-1.5 text-sm font-semibold text-white disabled:opacity-40"
+        >
+          {save.isPending ? "Saving…" : dirty ? "Save" : "Saved ✓"}
+        </button>
+      </div>
+
+      {save.isError ? (
+        <p className="mb-2 text-sm text-red-600">
+          {save.error instanceof Error ? save.error.message : "Save failed"}
+        </p>
+      ) : null}
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+            <th className="py-1">From km</th>
+            <th className="py-1">To km</th>
+            <th className="py-1">₹ / {product.unit} (delivered)</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {bands.map((b, i) => (
+            <tr key={i} className="border-t border-slate-100">
+              {(["km_from", "km_to", "unit_price"] as const).map((key) => (
+                <td key={key} className="py-1.5 pr-3">
+                  <input
+                    type="number"
+                    min={0}
+                    step={key === "unit_price" ? "0.25" : "1"}
+                    value={b[key]}
+                    onChange={(e) => set(i, key, e.target.value)}
+                    className="w-28 rounded-lg border border-slate-200 px-2 py-1"
+                  />
+                </td>
+              ))}
+              <td className="py-1.5 text-right">
+                <button
+                  onClick={() => removeBand(i)}
+                  className="text-xs text-red-500 hover:underline"
+                >
+                  remove
+                </button>
+              </td>
+            </tr>
+          ))}
+          {bands.length === 0 ? (
+            <tr>
+              <td colSpan={4} className="py-3 text-sm text-slate-400">
+                No bands — quotes fall back to the base price. Add the first
+                band (e.g. 0 → 20 km).
+              </td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+
+      <button
+        onClick={addBand}
+        className="mt-2 text-sm font-medium text-orange-600 hover:underline"
+      >
+        + Add km band
+      </button>
+    </div>
+  );
+}
+
+export default function RateCardPage() {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["rate-card"],
+    queryFn: () => getJson<RateCard>("/api/rate-card"),
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">💰 Rate Card</h1>
+        <p className="text-sm text-slate-500">
+          Delivered price per product by distance band. Used by auto-quotes and
+          the sales pre-call brief — keep it current and quoting stays
+          hands-free.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-slate-400">Loading…</p>
+      ) : isError ? (
+        <p className="text-sm text-red-600">
+          {error instanceof Error ? error.message : "Failed to load"}
+        </p>
+      ) : (
+        (data?.products ?? []).map((p) => {
+          const mine = (data?.entries ?? []).filter(
+            (e) => e.product_id === p.id,
+          );
+          // Key carries the server state → editor remounts on fresh data.
+          const hash = mine
+            .map((e) => `${e.km_from}-${e.km_to}-${e.unit_price}`)
+            .join("|");
+          return <ProductBands key={`${p.id}:${hash}`} product={p} initial={mine} />;
+        })
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/api/rate-card/route.ts
+++ b/apps/web/app/api/rate-card/route.ts
@@ -1,0 +1,92 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { getRateCard } from "@/lib/pricing";
+
+/**
+ * Rate card (product × km-band delivered prices).
+ *   GET  — products + active bands (any authenticated staff; reps quote from it)
+ *   PUT  — replace ALL bands for ONE product (management only)
+ */
+const ADMIN_ROLES = ["founder", "owner", "accountant"];
+
+const putSchema = z.object({
+  product_id: z.string().uuid(),
+  bands: z
+    .array(
+      z.object({
+        km_from: z.number().min(0),
+        km_to: z.number().positive(),
+        unit_price: z.number().min(0),
+      }),
+    )
+    .max(20),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+    return success(await getRateCard());
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[RateCard] GET failed:", err);
+    return error("Failed to load rate card", 500);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!ADMIN_ROLES.includes(user.role)) return error("Not permitted", 403);
+
+    const parsed = await parseBody(request, putSchema);
+    if (parsed.error) return parsed.error;
+    const { product_id, bands } = parsed.data;
+
+    // Validate: bands must not overlap and each must be a real range.
+    const sorted = [...bands].sort((a, b) => a.km_from - b.km_from);
+    for (let i = 0; i < sorted.length; i++) {
+      if (sorted[i].km_to <= sorted[i].km_from) {
+        return error(`Band ${i + 1}: "to km" must be greater than "from km"`, 422);
+      }
+      if (i > 0 && sorted[i].km_from < sorted[i - 1].km_to) {
+        return error(
+          `Bands overlap: ${sorted[i - 1].km_from}-${sorted[i - 1].km_to} and ${sorted[i].km_from}-${sorted[i].km_to}`,
+          422,
+        );
+      }
+    }
+
+    // Replace-all per product: simplest mental model for the editor, and the
+    // unique constraint stays meaningful.
+    const { error: delErr } = await supabaseAdmin
+      .from("rate_card_entries")
+      .delete()
+      .eq("product_id", product_id);
+    if (delErr) return error(`Failed to clear old bands: ${delErr.message}`, 500);
+
+    if (sorted.length > 0) {
+      const { error: insErr } = await supabaseAdmin
+        .from("rate_card_entries")
+        .insert(
+          sorted.map((b) => ({
+            product_id,
+            km_from: b.km_from,
+            km_to: b.km_to,
+            unit_price: b.unit_price,
+          })),
+        );
+      if (insErr) return error(`Failed to save bands: ${insErr.message}`, 500);
+    }
+
+    return success(await getRateCard());
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[RateCard] PUT failed:", err);
+    return error("Failed to save rate card", 500);
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -24,6 +24,7 @@ const protectedRoutes = [
   "/planning",
   "/projects",
   "/expenses",
+  "/rate-card",
   "/approvals",
   "/production",
   "/deliveries",

--- a/apps/web/src/lib/pricing.ts
+++ b/apps/web/src/lib/pricing.ts
@@ -1,0 +1,108 @@
+/**
+ * Rate-card pricing (Golden Hour GH0).
+ *
+ * The business sells DELIVERED: one price per product per distance band
+ * (e.g. CIB 8" · 0-20km → ₹18/pc · 20-50km → ₹19.50/pc). Bands live in
+ * rate_card_entries, managed by leadership on the web Rate Card page.
+ *
+ * resolveUnitPrice() is the single source of truth used by the auto-quote
+ * and the AI pre-call brief. Fallback when no band covers the distance:
+ * products.base_price (+ a flag so callers can say "price on request").
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const num = (v: unknown): number => (typeof v === "number" ? v : Number(v) || 0);
+
+export type RateCardEntry = {
+  id: string;
+  product_id: string;
+  km_from: number;
+  km_to: number;
+  unit_price: number;
+  is_active: boolean;
+};
+
+export type ResolvedPrice = {
+  product_id: string;
+  product_name: string;
+  unit: string;
+  unit_price: number;
+  /** "band" = matched a rate-card band; "base" = fell back to base_price. */
+  source: "band" | "base";
+  band?: { km_from: number; km_to: number };
+};
+
+/** All active bands for all active products (one query, for editors/briefs). */
+export async function getRateCard(): Promise<{
+  products: { id: string; name: string; unit: string; base_price: number }[];
+  entries: RateCardEntry[];
+}> {
+  const [{ data: products }, { data: entries }] = await Promise.all([
+    supabaseAdmin
+      .from("products")
+      .select("id, name, unit, base_price")
+      .eq("is_active", true)
+      .order("name"),
+    supabaseAdmin
+      .from("rate_card_entries")
+      .select("id, product_id, km_from, km_to, unit_price, is_active")
+      .eq("is_active", true)
+      .order("km_from"),
+  ]);
+  return {
+    products: (products ?? []).map((p) => ({
+      id: p.id as string,
+      name: p.name as string,
+      unit: p.unit as string,
+      base_price: num(p.base_price),
+    })),
+    entries: (entries ?? []).map((e) => ({
+      id: e.id as string,
+      product_id: e.product_id as string,
+      km_from: num(e.km_from),
+      km_to: num(e.km_to),
+      unit_price: num(e.unit_price),
+      is_active: !!e.is_active,
+    })),
+  };
+}
+
+/**
+ * Delivered unit price for one product at a distance. Band match is
+ * inclusive-from / exclusive-to (0-20 covers 0..19.9; 20-50 starts at 20).
+ */
+export async function resolveUnitPrice(
+  productId: string,
+  distanceKm: number | null,
+): Promise<ResolvedPrice | null> {
+  const { products, entries } = await getRateCard();
+  const product = products.find((p) => p.id === productId);
+  if (!product) return null;
+
+  if (distanceKm != null && Number.isFinite(distanceKm)) {
+    const band = entries.find(
+      (e) =>
+        e.product_id === productId &&
+        distanceKm >= e.km_from &&
+        distanceKm < e.km_to,
+    );
+    if (band) {
+      return {
+        product_id: product.id,
+        product_name: product.name,
+        unit: product.unit,
+        unit_price: band.unit_price,
+        source: "band",
+        band: { km_from: band.km_from, km_to: band.km_to },
+      };
+    }
+  }
+
+  return {
+    product_id: product.id,
+    product_name: product.name,
+    unit: product.unit,
+    unit_price: product.base_price,
+    source: "base",
+  };
+}

--- a/supabase/migrations/20260719150000_rate_card.sql
+++ b/supabase/migrations/20260719150000_rate_card.sql
@@ -1,0 +1,29 @@
+-- Rate card (Golden Hour GH0): the business prices DELIVERED, per product,
+-- by distance band (e.g. CIB 8" · 0-20km → ₹18/pc · 20-50km → ₹19.5/pc).
+-- Bands are configurable by management; the auto-quote and AI pre-call brief
+-- resolve prices from here, falling back to products.base_price when no band
+-- covers the distance.
+CREATE TABLE IF NOT EXISTS public.rate_card_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  km_from NUMERIC(6, 1) NOT NULL CHECK (km_from >= 0),
+  km_to NUMERIC(6, 1) NOT NULL CHECK (km_to > km_from),
+  unit_price NUMERIC(10, 2) NOT NULL CHECK (unit_price >= 0),
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (product_id, km_from, km_to)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_card_product
+  ON public.rate_card_entries (product_id) WHERE is_active;
+
+ALTER TABLE public.rate_card_entries ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "rate_card_read" ON public.rate_card_entries;
+CREATE POLICY "rate_card_read" ON public.rate_card_entries
+  FOR SELECT TO authenticated USING (true);
+
+DROP TRIGGER IF EXISTS set_rate_card_updated_at ON public.rate_card_entries;
+CREATE TRIGGER set_rate_card_updated_at
+  BEFORE UPDATE ON public.rate_card_entries
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
Foundation for the Golden First Hour package, per the founder: pricing is product-wise AND km-range-wise (delivered).

- **`rate_card_entries`** (product x km_from..km_to -> unit_price), RLS read, replace-all-per-product writes. **Migration applied to prod.**
- **`lib/pricing.ts`**: `resolveUnitPrice(product, distanceKm)` — the single pricing source of truth for the upcoming auto-quote (GH3) and AI pre-call brief (GH2). Inclusive-from/exclusive-to band match; falls back to `products.base_price`.
- **`PUT /api/rate-card`** validates non-overlapping bands (422 with a readable message); GET open to all staff.
- **Web editor at `/rate-card`** (founder/owner/accountant): per-product band table, add/remove/save. Nav + middleware wired.

Next in the series: GH1 30-min SLA task, GH2 AI pre-call brief, GH3 auto-quote draft, GH4 drip follow-ups — all consuming this card.

tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Rate Card section to the dashboard for managing product pricing by delivery-distance bands.
  * Authorized staff can add, edit, and remove distance-based pricing bands for each product.
  * Pricing automatically uses the applicable distance band or falls back to the product’s base price.
* **Bug Fixes**
  * Added validation to prevent invalid, overlapping, or negative pricing ranges before saving.
  * Updated pricing results after successful rate card changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->