### PR TITLE
feat(golden-hour): 30-minute first-response SLA task on every new lead (GH1)

### DIFF
--- a/apps/web/app/api/leads/extract-from-audio/route.ts
+++ b/apps/web/app/api/leads/extract-from-audio/route.ts
@@ -12,6 +12,7 @@ import {
   getUserIdsByRoles,
   notifyLeadPush,
 } from "@/lib/push/fcm";
+import { createFirstResponseTask } from "@/lib/golden-hour";
 
 interface ExtractedLeadInfo {
   name: string | null;
@@ -81,6 +82,9 @@ export async function POST(request: NextRequest) {
           .update({ lead_id: lead.id })
           .eq("id", recording_id);
       }
+
+      // Golden Hour: 30-min first-response task for the fresh lead.
+      await createFirstResponseTask(lead);
 
       // Push the founder/owner a lead summary — Telegram-uploaded calls used
       // to create leads silently; leadership specifically asked to hear about

--- a/apps/web/app/api/leads/route.ts
+++ b/apps/web/app/api/leads/route.ts
@@ -16,6 +16,7 @@ import {
   getUserIdsByRoles,
   notifyLeadPush,
 } from "@/lib/push/fcm";
+import { createFirstResponseTask } from "@/lib/golden-hour";
 import {
   createLeadSchema,
   paginationSchema,
@@ -136,6 +137,9 @@ export async function POST(request: NextRequest) {
     }).catch((err) => {
       console.error("Failed to send Telegram notification:", err);
     });
+
+    // Golden Hour: first-response task due in 30 min (awaited; never throws).
+    await createFirstResponseTask(lead);
 
     // Native push for the new lead (awaited before response so Vercel doesn't kill it).
     const recipients = await resolveNewLeadRecipients(

--- a/apps/web/app/api/telegram/webhook/route.ts
+++ b/apps/web/app/api/telegram/webhook/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase-admin";
 import { sendTelegramMessage } from "@/lib/telegram";
+import { createFirstResponseTask } from "@/lib/golden-hour";
 import {
   extractFromFilename,
   normalizePhoneNumber,
@@ -274,6 +275,8 @@ export async function POST(request: NextRequest) {
         console.warn(
           `[Telegram Webhook] Auto-created lead: ${newLead.id} for ${extractedName}`,
         );
+        // Golden Hour: 30-min first-response task for the fresh lead.
+        await createFirstResponseTask(newLead);
       }
     }
 

--- a/apps/web/src/lib/call-recording/processor.ts
+++ b/apps/web/src/lib/call-recording/processor.ts
@@ -24,6 +24,7 @@ import {
   getUserIdsByRoles,
   notifyLeadPush,
 } from "@/lib/push/fcm";
+import { createFirstResponseTask } from "@/lib/golden-hour";
 import { logError, logProgress } from "./logger";
 import {
   triggerLeadAnalysis,
@@ -676,6 +677,9 @@ async function findOrCreateLeadForRecording(
       .update({ lead_id: lead.id })
       .eq("id", recordingId);
     logProgress(recordingId, "Auto-created lead from call", { lead_id: lead.id });
+
+    // Golden Hour: 30-min first-response task for the fresh lead.
+    await createFirstResponseTask({ ...lead, contact: last10, source: "Telegram" });
 
     // Founder push with the call summary (same contract as extract-from-audio).
     try {

--- a/apps/web/src/lib/golden-hour.ts
+++ b/apps/web/src/lib/golden-hour.ts
@@ -1,0 +1,85 @@
+/**
+ * Golden First Hour (GH1): every new lead gets a first-response task due in
+ * 30 MINUTES, assigned to the lead's rep (fallback: first active sales →
+ * engineer → founder). The accountability engine takes it from there — task
+ * card on the rep's home, 2h nags, founder escalation, evening chaser.
+ *
+ * Speed-to-lead is the single biggest conversion lever in this market: a
+ * callback inside 30 minutes beats next-day by multiples.
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { notifyWorkAssigned } from "@/lib/my-work-notify";
+import type { WorkItem } from "@maiyuri/shared";
+
+const FIRST_RESPONSE_SLA_MINUTES = 30;
+
+async function resolveAssignee(assignedStaff: string | null): Promise<string | null> {
+  if (assignedStaff) return assignedStaff;
+  const { data } = await supabaseAdmin
+    .from("users")
+    .select("id, role")
+    .eq("is_active", true)
+    .in("role", ["sales", "engineer", "founder", "owner"]);
+  const byRole = (r: string) => data?.find((u) => u.role === r)?.id;
+  return (
+    byRole("sales") ?? byRole("engineer") ?? byRole("founder") ?? byRole("owner") ?? null
+  );
+}
+
+/**
+ * Fire-and-forget from every lead-creation path. Never throws; a failed SLA
+ * task must not fail lead creation. One open golden-hour task per lead.
+ */
+export async function createFirstResponseTask(lead: {
+  id: string;
+  name: string | null;
+  contact?: string | null;
+  assigned_staff?: string | null;
+  source?: string | null;
+}): Promise<void> {
+  try {
+    // Dedupe — webhook + processor can both fire for the same new lead.
+    const { data: existing } = await supabaseAdmin
+      .from("work_items")
+      .select("id")
+      .eq("related_lead_id", lead.id)
+      .eq("source_module", "golden_hour")
+      .in("status", ["pending", "in_progress", "returned"])
+      .limit(1)
+      .maybeSingle();
+    if (existing) return;
+
+    const assignee = await resolveAssignee(lead.assigned_staff ?? null);
+    if (!assignee) return;
+
+    const dueAt = new Date(
+      Date.now() + FIRST_RESPONSE_SLA_MINUTES * 60_000,
+    ).toISOString();
+    const label = lead.name || lead.contact || "New lead";
+
+    const { data: item, error } = await supabaseAdmin
+      .from("work_items")
+      .insert({
+        title: `⚡ First call in 30 min — ${label}`.slice(0, 200),
+        description: `New lead${lead.source ? ` from ${lead.source}` : ""}. Call within ${FIRST_RESPONSE_SLA_MINUTES} minutes — speed wins the order. முதல் அழைப்பு 30 நிமிடத்தில்!`,
+        activity_type: "simple",
+        status: "pending",
+        priority: "urgent",
+        assigned_user_id: assignee,
+        due_at: dueAt,
+        related_lead_id: lead.id,
+        related_label: label,
+        source_module: "golden_hour",
+      })
+      .select("*")
+      .single();
+
+    if (error || !item) {
+      console.error("[GoldenHour] SLA task insert failed:", error);
+      return;
+    }
+    await notifyWorkAssigned(item as WorkItem);
+  } catch (err) {
+    console.error("[GoldenHour] createFirstResponseTask failed (ignored):", err);
+  }
+}


### PR DESCRIPTION
`createFirstResponseTask()` fires from ALL four lead-creation paths (manual/API, Telegram webhook auto-create, recording-processor auto-create, extract-from-audio):

- **"⚡ First call in 30 min — <lead>"** — urgent priority, due now+30min, EN+Tamil description
- Assigned to the lead rep (fallback sales → engineer → founder → owner), instant assignment push
- The accountability engine owns it from there: task-first home card → 2h nags → **founder escalation at 4h** → evening chaser → Monday scorecard
- Deduped (one open golden_hour task per lead) and never-throws (a failed task cannot fail lead creation)

tsc + eslint clean.