### PR TITLE
feat(golden-hour): AI pre-call brief (GH2) — rate-card pricing, objection prep, Tamil opener

### DIFF
--- a/apps/native/app/onehub/_layout.tsx
+++ b/apps/native/app/onehub/_layout.tsx
@@ -24,6 +24,7 @@ export default function OneHubLayout() {
       <Stack.Screen name="daily-report" options={{ title: '📊 Daily Report' }} />
       <Stack.Screen name="ceo" options={{ title: '👑 CEO Command Center' }} />
       <Stack.Screen name="pnl" options={{ title: '📑 Profit & Loss' }} />
+      <Stack.Screen name="brief/[leadId]" options={{ title: '🧠 Pre-call Brief' }} />
       <Stack.Screen name="expenses/index" options={{ title: '💰 My Expenses' }} />
       <Stack.Screen
         name="expenses/new"

--- a/apps/native/app/onehub/brief/[leadId].tsx
+++ b/apps/native/app/onehub/brief/[leadId].tsx
@@ -1,0 +1,130 @@
+import { useLocalSearchParams } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { api } from '@/lib/api';
+import { SkeletonList } from '@/ui';
+
+/**
+ * 🧠 Pre-call brief (Golden Hour GH2) — everything the rep needs to sound
+ * fully prepared, generated seconds before the call: who/what, rate-card
+ * pricing for their distance, the likely objection + answer, and an opening
+ * line in Tamil.
+ */
+
+type Brief = {
+  lead_id: string;
+  lead_name: string | null;
+  who: string;
+  situation: string;
+  distance_note: string;
+  price_guidance: string[];
+  likely_objection: string;
+  objection_answer: string;
+  opening_line_ta: string;
+  opening_line_en: string;
+  generated_at: string;
+};
+
+function Block({ title, tone, children }: { title: string; tone?: string; children: React.ReactNode }) {
+  return (
+    <View className={`mb-3 rounded-xl border p-4 ${tone ?? 'border-slate-200 bg-white'}`}>
+      <Text className="mb-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+        {title}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+export default function PreCallBriefScreen() {
+  const { leadId } = useLocalSearchParams<{ leadId: string }>();
+  const query = useQuery({
+    queryKey: ['lead-brief', leadId],
+    queryFn: () =>
+      api.get<Brief>(`/api/leads/${leadId}/brief`, undefined, { timeoutMs: 55_000 }),
+    enabled: !!leadId,
+    staleTime: 10 * 60 * 1000,
+  });
+  const b = query.data?.data;
+
+  return (
+    <ScrollView
+      className="flex-1 bg-canvas"
+      contentContainerClassName="p-4 pb-10"
+      refreshControl={
+        <RefreshControl
+          refreshing={query.isRefetching}
+          onRefresh={() => void query.refetch()}
+        />
+      }
+    >
+      {query.isLoading ? (
+        <>
+          <Text className="mb-3 text-center text-sm text-slate-400">
+            🧠 Preparing your brief…
+          </Text>
+          <SkeletonList count={5} />
+        </>
+      ) : !b ? (
+        <View className="items-center rounded-xl border border-slate-200 bg-white p-6">
+          <Text className="text-center text-sm text-red-500">
+            {query.error instanceof Error ? query.error.message : "Couldn't build the brief"}
+          </Text>
+          <Pressable
+            onPress={() => void query.refetch()}
+            className="mt-3 rounded-xl bg-brand px-5 py-2.5 active:opacity-80"
+          >
+            <Text className="font-semibold text-ink">Retry</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <>
+          <Text className="mb-3 text-xl font-bold text-ink">
+            🧠 {b.lead_name ?? 'Lead'} — pre-call brief
+          </Text>
+
+          <Block title="Who">
+            <Text className="text-base leading-6 text-ink">{b.who}</Text>
+          </Block>
+
+          <Block title="Where things stand">
+            <Text className="text-sm leading-6 text-slate-700">{b.situation}</Text>
+            {b.distance_note ? (
+              <Text className="mt-2 text-xs text-slate-500">📍 {b.distance_note}</Text>
+            ) : null}
+          </Block>
+
+          <Block title="💰 What to quote" tone="border-green-200 bg-green-50">
+            {b.price_guidance.map((line) => (
+              <Text key={line} className="mb-1 text-sm font-semibold leading-6 text-green-900">
+                {line}
+              </Text>
+            ))}
+          </Block>
+
+          <Block title="⚔️ Likely objection" tone="border-amber-200 bg-amber-50">
+            <Text className="text-sm font-semibold text-amber-900">
+              “{b.likely_objection}”
+            </Text>
+            <Text className="mt-1 text-sm leading-6 text-amber-800">
+              → {b.objection_answer}
+            </Text>
+          </Block>
+
+          <Block title="🎤 Opening line" tone="border-slate-700 bg-ink">
+            <Text className="text-base font-semibold leading-7 text-white">
+              {b.opening_line_ta}
+            </Text>
+            <Text className="mt-1 text-xs leading-5 text-slate-400">
+              {b.opening_line_en}
+            </Text>
+          </Block>
+
+          <Text className="mt-1 text-center text-xs text-slate-400">
+            Prices from the rate card · distance is an estimate — confirm on the call
+          </Text>
+        </>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/src/components/TaskFirstHome.tsx
+++ b/apps/native/src/components/TaskFirstHome.tsx
@@ -117,6 +117,17 @@ function TaskCard({ item, overdue }: { item: WorkItem; overdue: boolean }) {
         </Text>
       ) : null}
 
+      {item.related_lead_id ? (
+        <Pressable
+          onPress={() => router.push(`/onehub/brief/${item.related_lead_id}` as never)}
+          className="mt-3 items-center rounded-2xl border-2 border-sky-300 bg-sky-50 px-4 py-3 active:opacity-80"
+        >
+          <Text className="text-base font-bold text-sky-700">
+            🧠  அழைப்பதற்கு முன் படி · Pre-call brief
+          </Text>
+        </Pressable>
+      ) : null}
+
       {item.status === 'pending' || item.status === 'returned' ? (
         <BigButton
           tone="start"

--- a/apps/web/app/api/leads/[id]/brief/route.ts
+++ b/apps/web/app/api/leads/[id]/brief/route.ts
@@ -1,0 +1,128 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { z } from "zod";
+import { success, error, notFound } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { getRateCard } from "@/lib/pricing";
+import { GEMINI_DEFAULT_MODEL } from "@/lib/ai/models";
+
+/**
+ * GET /api/leads/[id]/brief — the AI pre-call brief (Golden Hour GH2).
+ * One screen the rep reads before dialling: who this is, what they want,
+ * what to quote (from the rate card), the likely objection with its answer,
+ * and an opening line in Tamil. Makes a 30-minute callback sound like a
+ * week of preparation.
+ */
+const briefSchema = z.object({
+  who: z.string().default(""),
+  situation: z.string().default(""),
+  distance_note: z.string().default(""),
+  price_guidance: z.array(z.string()).default([]),
+  likely_objection: z.string().default(""),
+  objection_answer: z.string().default(""),
+  opening_line_ta: z.string().default(""),
+  opening_line_en: z.string().default(""),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    await requireAuth(request);
+    const { id } = await params;
+
+    const [{ data: lead }, { data: lastCall }, rateCard, { data: factory }] =
+      await Promise.all([
+        supabaseAdmin.from("leads").select("*").eq("id", id).single(),
+        supabaseAdmin
+          .from("call_recordings")
+          .select("ai_summary, transcription_text, created_at")
+          .eq("lead_id", id)
+          .eq("processing_status", "completed")
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        getRateCard(),
+        supabaseAdmin
+          .from("factory_settings")
+          .select("address")
+          .limit(1)
+          .maybeSingle(),
+      ]);
+
+    if (!lead) return notFound("Lead not found");
+
+    const apiKey = process.env.GOOGLE_AI_API_KEY;
+    if (!apiKey) return error("AI not configured", 503);
+
+    const rateLines = rateCard.products
+      .map((p) => {
+        const bands = rateCard.entries.filter((e) => e.product_id === p.id);
+        if (!bands.length) return `- ${p.name}: ₹${p.base_price}/${p.unit} (base)`;
+        return `- ${p.name}: ${bands
+          .map((b) => `${b.km_from}-${b.km_to}km ₹${b.unit_price}`)
+          .join(", ")} per ${p.unit} (delivered)`;
+      })
+      .join("\n");
+
+    const prompt = `You are the sales coach for Maiyuri Bricks (CSEB/interlocking bricks, factory at ${factory?.address ?? "Red Hills, Chennai"}). A rep is about to CALL this lead in the next few minutes. Write their pre-call brief.
+
+LEAD
+Name: ${lead.name} · Phone: ${lead.contact}
+Type: ${lead.lead_type ?? "?"} · Classification: ${lead.classification ?? "?"} · Requirement: ${lead.requirement_type ?? "?"}
+Site: ${[lead.site_location, lead.site_region].filter(Boolean).join(", ") || "unknown"}
+Stage: ${lead.pipeline_stage} · Temperature: ${lead.lead_temperature ?? "?"} · Source: ${lead.source ?? "?"}
+Estimated quantity: ${lead.estimated_quantity ?? "unknown"} · Next action on file: ${lead.next_action ?? "none"}
+
+LAST CALL SUMMARY (may be empty):
+${lastCall?.ai_summary ?? "No call recorded yet."}
+
+DELIVERED RATE CARD (price depends on distance from the factory):
+${rateLines}
+
+TASK — respond with ONLY a JSON code block:
+\`\`\`json
+{
+  "who": "1 line: who this person is and what they're building",
+  "situation": "2-3 lines: where things stand, what they said, what they need to hear next",
+  "distance_note": "Estimate the road distance from the factory (${factory?.address ?? "Red Hills, Chennai"}) to their site using your knowledge of Tamil Nadu geography. Format: 'Site ~35km away (estimate — confirm on call)'. If site unknown: 'Ask for the site location to fix the price band.'",
+  "price_guidance": ["1-3 lines: the exact prices to quote for THEIR likely products at THEIR estimated distance band, from the rate card above. Quote delivered prices. If quantity known, include the order total."],
+  "likely_objection": "the single most likely objection from THIS lead (price/trust/technical)",
+  "objection_answer": "the 2-line answer, using the wall-cost logic (no plastering, less cement, faster build) where relevant",
+  "opening_line_ta": "a warm, natural opening line in Tamil for this specific person",
+  "opening_line_en": "the same opening line in English"
+}
+\`\`\``;
+
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({
+      model: GEMINI_DEFAULT_MODEL,
+      generationConfig: { temperature: 0.4, maxOutputTokens: 1024 },
+    });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text();
+    const jsonMatch =
+      text.match(/```json\s*([\s\S]*?)\s*```/) || text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return error("Brief generation failed", 502);
+
+    const parsed = briefSchema.safeParse(JSON.parse(jsonMatch[1] ?? jsonMatch[0]));
+    if (!parsed.success) return error("Brief generation failed", 502);
+
+    return success({
+      ...parsed.data,
+      lead_id: id,
+      lead_name: lead.name,
+      generated_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[Brief] failed:", err);
+    return error("Failed to generate the pre-call brief", 500);
+  }
+}


### PR DESCRIPTION
**GET `/api/leads/[id]/brief`** — Gemini composes the rep pre-call one-pager from the lead record + latest call summary + the **live rate card**:
- who this is + where things stand
- estimated km from the factory (flagged as an estimate; asks for site location when unknown)
- **exact delivered prices to quote** for their products at their distance band (+ order total when quantity known)
- the most likely objection with the 2-line wall-cost answer
- a warm opening line in **Tamil** + English

**Mobile** `/onehub/brief/[leadId]` + a "🧠 Pre-call brief" button on every task card carrying a lead — the ⚡30-min SLA task and 📞 next-action tasks both link straight into it.

Flow: lead arrives → phone buzzes → tap task → tap brief → 10 seconds of reading → dial sounding like a week of prep.

tsc + eslint clean. Mobile rides the next OTA.