### PR TITLE
feat(golden-hour): auto-drafted Smart Quote + rate-card pricing in the customer estimate (GH3)

### DIFF
--- a/apps/web/app/api/smart-quotes/generate/route.ts
+++ b/apps/web/app/api/smart-quotes/generate/route.ts
@@ -37,21 +37,33 @@ export async function POST(request: NextRequest) {
 
     const { lead_id, regenerate } = parsed.data;
 
-    // Get authenticated user — cookie (web) OR Bearer token (mobile)
-    const user = await getUserFromRequest(request);
+    // Machine caller (call-recording pipeline auto-draft, GH3): the
+    // service-role/CRON bearer is a trusted internal identity with no user
+    // session — skip the per-user access check below.
+    const authHeader = request.headers.get("authorization");
+    const isMachine =
+      (!!process.env.SUPABASE_SERVICE_ROLE_KEY &&
+        authHeader === `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`) ||
+      (!!process.env.CRON_SECRET &&
+        authHeader === `Bearer ${process.env.CRON_SECRET}`);
 
-    if (!user) {
+    // Get authenticated user — cookie (web) OR Bearer token (mobile)
+    const user = isMachine ? null : await getUserFromRequest(request);
+
+    if (!user && !isMachine) {
       return error("Authentication required", 401);
     }
 
     // Check user role (must be founder or have access to lead)
-    const { data: userData } = await supabaseAdmin
-      .from("users")
-      .select("role")
-      .eq("id", user.id)
-      .single();
+    const { data: userData } = user
+      ? await supabaseAdmin
+          .from("users")
+          .select("role")
+          .eq("id", user.id)
+          .single()
+      : { data: null };
 
-    if (!userData) {
+    if (user && !userData) {
       return error("User not found", 404);
     }
 
@@ -68,12 +80,14 @@ export async function POST(request: NextRequest) {
       return notFound("Lead not found");
     }
 
-    // Check access (founders have full access, others need assignment)
-    const isFounder = userData.role === "founder";
+    // Check access (founders + the machine pipeline have full access,
+    // others need assignment)
+    const isFounder = userData?.role === "founder";
     const hasAccess =
+      isMachine ||
       isFounder ||
-      lead.assigned_staff === user.id ||
-      lead.created_by === user.id;
+      (user != null &&
+        (lead.assigned_staff === user.id || lead.created_by === user.id));
 
     if (!hasAccess) {
       return forbidden("You don't have access to this lead");

--- a/apps/web/app/api/sq/[slug]/estimate/route.ts
+++ b/apps/web/app/api/sq/[slug]/estimate/route.ts
@@ -8,6 +8,7 @@ import {
   type SmartQuotePricingConfig,
 } from "@maiyuri/shared";
 import { computeEstimate } from "@/lib/pricing/compute-estimate";
+import { resolveUnitPrice } from "@/lib/pricing";
 
 /**
  * POST /api/sq/[slug]/estimate
@@ -62,6 +63,27 @@ export async function POST(
       .limit(1)
       .single();
 
+    // Rate card first (GH0/GH3): when a km band covers this distance, the
+    // customer sees the true DELIVERED price — no separate transport line,
+    // exactly how the business actually quotes. Falls back to the legacy
+    // base_price + per-km transport when no band matches.
+    const resolved = await resolveUnitPrice(product.id, distance_km ?? null);
+    if (resolved && resolved.source === "band") {
+      const subtotal = resolved.unit_price * quantity;
+      return success({
+        product: { id: product.id, name: product.name, unit: product.unit },
+        quantity,
+        distance_km: distance_km ?? null,
+        unit_price: resolved.unit_price,
+        subtotal,
+        transport_cost: 0,
+        transport_included: true,
+        total: subtotal,
+        pricing_source: "rate_card",
+        band: resolved.band,
+      });
+    }
+
     const includeTransport = pricing.show_transport !== false;
     const breakdown = computeEstimate(
       [
@@ -84,6 +106,7 @@ export async function POST(
       product: { id: product.id, name: product.name, unit: product.unit },
       quantity,
       distance_km: includeTransport ? (distance_km ?? null) : null,
+      pricing_source: "base",
       ...breakdown,
     });
   } catch (err) {

--- a/apps/web/src/lib/call-recording/processor.ts
+++ b/apps/web/src/lib/call-recording/processor.ts
@@ -30,6 +30,7 @@ import {
   triggerLeadAnalysis,
   triggerCallRecordingNudge,
   triggerObjectionNudge,
+  triggerAutoQuote,
 } from "./triggers";
 import type { CallRecording, ExtractedLeadDetails, ProcessingStatus } from "./types";
 
@@ -386,6 +387,15 @@ export async function processRecording(
             });
           }
         }
+      }
+
+      // GH3: the call revealed WHAT they want -> draft the smart quote now
+      // so the rep only reviews and sends (the qualified->quoted leak).
+      if (
+        extractedDetails.product_interests.length > 0 ||
+        extractedDetails.estimated_quantity
+      ) {
+        await triggerAutoQuote(effectiveLeadId, id);
       }
 
       // Turn the next action into a REAL task in My Work so the whole

--- a/apps/web/src/lib/call-recording/triggers.ts
+++ b/apps/web/src/lib/call-recording/triggers.ts
@@ -257,3 +257,44 @@ export async function triggerObjectionNudge(
     return false;
   }
 }
+
+/**
+ * Golden Hour GH3: auto-draft the Smart Quote when a call reveals product
+ * interest — the rep reviews and taps Send instead of composing from scratch
+ * (attacks the funnel's biggest leak: 33 qualified but only 6 quoted).
+ * Best-effort; the generate route dedupes (regenerate=false keeps existing).
+ */
+export async function triggerAutoQuote(
+  leadId: string,
+  recordingId: string,
+): Promise<boolean> {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) return false;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 60000);
+  try {
+    logProgress(recordingId, "Auto-drafting smart quote", { leadId });
+    const response = await fetch(`${BASE_URL}/api/smart-quotes/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${serviceRoleKey}`,
+        "X-Recording-ID": recordingId,
+      },
+      body: JSON.stringify({ lead_id: leadId, regenerate: false }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      logError(`Auto-quote failed: HTTP ${response.status}`, { leadId });
+      return false;
+    }
+    logProgress(recordingId, "Smart quote drafted", { leadId });
+    return true;
+  } catch (err) {
+    clearTimeout(timeoutId);
+    logError("Auto-quote trigger failed (ignored)", err);
+    return false;
+  }
+}


### PR DESCRIPTION
Two halves of GH3:

1. **Customer-facing pricing from the rate card** — `sq/[slug]/estimate` resolves the km band FIRST: the customer sees the true **delivered** price (no separate transport line, exactly how the business quotes). Falls back to legacy base+per-km when no band matches; `pricing_source` flags which path served.
2. **Auto-drafted quote** — after call processing, when the call revealed product interest or a quantity, `triggerAutoQuote()` drafts the Smart Quote via the generate route (`regenerate=false` → existing quotes untouched). The rep reviews and taps Send instead of composing — attacking the funnel leak (33 qualified, only 6 quoted).
3. `smart-quotes/generate` accepts the pipeline machine bearer (service-role/CRON); human access checks unchanged.

tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart Quotes can now be generated automatically when call recordings identify product interests or estimated quantities.
  * Distance-based rate-card pricing is now applied automatically when a matching kilometer band is available.
  * Estimates clearly indicate whether pricing comes from a rate card or the standard base calculation.
* **Bug Fixes**
  * Improved Smart Quote access handling for automated quote-generation requests and authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->