### PR TITLE
feat(ops): daily heartbeat — one green/red system-health message at 08:00 IST

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -1,0 +1,93 @@
+name: Daily heartbeat
+
+# One message every morning at 08:00 IST: is the whole system healthy?
+# Green = safe to ignore. Anything else = act. Exists because failures here
+# were SILENT — a broken deploy froze prod for a week and a dead Gemini key
+# stopped transcription, and nobody was told.
+
+on:
+  schedule:
+    - cron: "30 2 * * *" # 08:00 IST
+  workflow_dispatch: {}
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Gather control-plane status (deploy + crons)
+        id: control
+        env:
+          GH_API: https://api.github.com/repos/${{ github.repository }}
+          AUTH: "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          sha=$(curl -s -H "$AUTH" "$GH_API/commits/main" | python3 -c "import sys,json;print(json.load(sys.stdin)['sha'])")
+          deploy=$(curl -s -H "$AUTH" "$GH_API/commits/$sha/status" | python3 -c "
+          import sys,json
+          d=json.load(sys.stdin)
+          print(next((s['state'] for s in d['statuses'] if s['context']=='Vercel'),'none'))")
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
+
+          crons=""
+          for wf in odoo-sync.yml my-work-generate.yml my-work-nudges.yml db-backup.yml; do
+            c=$(curl -s -H "$AUTH" "$GH_API/actions/workflows/$wf/runs?per_page=1&status=completed" \
+              | python3 -c "
+          import sys,json
+          d=json.load(sys.stdin).get('workflow_runs',[])
+          print(d[0]['conclusion'] if d else 'never')")
+            crons="$crons $wf:$c"
+          done
+          echo "crons=$crons" >> "$GITHUB_OUTPUT"
+
+      - name: Gather data-plane status (app heartbeat)
+        id: app
+        run: |
+          status=$(curl -s -o /tmp/hb.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://mb.maiyuri.com/api/health/heartbeat")
+          echo "HTTP $status"; cat /tmp/hb.json
+          echo "http=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Compose and send
+        env:
+          DEPLOY: ${{ steps.control.outputs.deploy }}
+          CRONS: ${{ steps.control.outputs.crons }}
+          APP_HTTP: ${{ steps.app.outputs.http }}
+        run: |
+          python3 - <<'EOF' > /tmp/msg.txt
+          import json, os, datetime
+
+          lines, all_ok = [], True
+          def add(ok, text):
+              global all_ok
+              all_ok = all_ok and ok
+              lines.append(("✅ " if ok else "❌ ") + text)
+
+          add(os.environ["DEPLOY"] == "success", f"Web deploy: {os.environ['DEPLOY']}")
+
+          bad = [c for c in os.environ["CRONS"].split() if not c.endswith(":success")]
+          add(not bad, "Crons: all green" if not bad else "Crons: " + ", ".join(bad))
+
+          if os.environ["APP_HTTP"] == "200":
+              hb = json.load(open("/tmp/hb.json"))["data"]
+              for c in hb["checks"].values():
+                  add(c["ok"], c["line"])
+          else:
+              add(False, f"App heartbeat unreachable (HTTP {os.environ['APP_HTTP']})")
+
+          today = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=5, minutes=30))).strftime("%a %d %b")
+          head = ("💓 Maiyuri heartbeat — " + today) if all_ok else ("🚨 MAIYURI NEEDS ATTENTION — " + today)
+          print(head + "\n" + "\n".join(lines))
+          EOF
+          cat /tmp/msg.txt
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            --data-urlencode text@/tmp/msg.txt
+
+      - name: Alert on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ ${{ github.workflow }} itself failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/apps/web/app/api/health/heartbeat/route.ts
+++ b/apps/web/app/api/health/heartbeat/route.ts
@@ -1,0 +1,164 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest } from "next/server";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { GEMINI_MODEL } from "@/lib/ai/models";
+
+/**
+ * GET/POST /api/health/heartbeat — the app-side half of the daily heartbeat
+ * (CRON_SECRET bearer). Checks the DATA plane: is Odoo data fresh, is the
+ * Gemini key alive (the silent-quota-death check), are recordings flowing,
+ * is the work engine generating. The GitHub workflow half checks the CONTROL
+ * plane (deploy status, cron run conclusions) and composes the one daily
+ * Telegram message from both.
+ *
+ * Design rule: every check is isolated and returns ok/warn/fail + a short
+ * human line — a broken check reports itself, it never breaks the heartbeat.
+ */
+const CRON_SECRET = process.env.CRON_SECRET;
+
+type Check = { ok: boolean; line: string };
+
+const hoursAgo = (iso: string | null): number | null =>
+  iso ? Math.round((Date.now() - new Date(iso).getTime()) / 3_600_000) : null;
+
+async function checkOdooFreshness(): Promise<Check> {
+  try {
+    const [{ data: order }, { data: good }] = await Promise.all([
+      supabaseAdmin
+        .from("sales_order_cache")
+        .select("synced_at")
+        .order("synced_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabaseAdmin
+        .from("finished_goods")
+        .select("stock_synced_at")
+        .not("stock_synced_at", "is", null)
+        .order("stock_synced_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+    const ordersH = hoursAgo((order?.synced_at as string) ?? null);
+    const stockH = hoursAgo((good?.stock_synced_at as string) ?? null);
+    // Nightly sync + manual syncs → anything beyond ~30h means the sync died.
+    const ok = ordersH != null && ordersH <= 30 && stockH != null && stockH <= 30;
+    return {
+      ok,
+      line: `Odoo data: orders ${ordersH ?? "?"}h · stock ${stockH ?? "?"}h ago`,
+    };
+  } catch (e) {
+    return { ok: false, line: `Odoo data check failed: ${String(e).slice(0, 80)}` };
+  }
+}
+
+async function checkGemini(): Promise<Check> {
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) return { ok: false, line: "Gemini: no API key configured" };
+  try {
+    const model = new GoogleGenerativeAI(apiKey).getGenerativeModel({
+      model: GEMINI_MODEL.FLASH_LITE,
+      generationConfig: { maxOutputTokens: 5 },
+    });
+    await model.generateContent("Reply with: ok");
+    return { ok: true, line: "Gemini AI: live" };
+  } catch (e) {
+    // The exact failure that silently killed transcription on 2026-07-19
+    // (429 prepaid balance exhausted) — surface the reason loudly.
+    return { ok: false, line: `Gemini AI DOWN: ${String(e).slice(0, 120)}` };
+  }
+}
+
+async function checkRecordings(): Promise<Check> {
+  try {
+    const dayStart = new Date(Date.now() - 24 * 3_600_000).toISOString();
+    const [{ count: processed }, { count: stuck }] = await Promise.all([
+      supabaseAdmin
+        .from("call_recordings")
+        .select("id", { count: "exact", head: true })
+        .eq("processing_status", "completed")
+        .gte("updated_at", dayStart),
+      supabaseAdmin
+        .from("call_recordings")
+        .select("id", { count: "exact", head: true })
+        .in("processing_status", ["pending", "failed"]),
+    ]);
+    // Stuck items are only a warning-level failure if they exist at all —
+    // the nightly run should drain the queue.
+    return {
+      ok: (stuck ?? 0) === 0,
+      line: `Recordings: ${processed ?? 0} processed / 24h · ${stuck ?? 0} stuck`,
+    };
+  } catch (e) {
+    return { ok: false, line: `Recordings check failed: ${String(e).slice(0, 80)}` };
+  }
+}
+
+async function checkWorkEngine(): Promise<Check> {
+  try {
+    const istToday = new Date().toLocaleDateString("en-CA", {
+      timeZone: "Asia/Kolkata",
+    });
+    const [{ count: generated }, { count: overdue }] = await Promise.all([
+      supabaseAdmin
+        .from("work_items")
+        .select("id", { count: "exact", head: true })
+        .eq("scheduled_date", istToday)
+        .not("template_id", "is", null),
+      supabaseAdmin
+        .from("work_items")
+        .select("id", { count: "exact", head: true })
+        .in("status", ["pending", "in_progress", "returned"])
+        .lt("due_at", new Date().toISOString()),
+    ]);
+    // Generation count of 0 is legitimate on days with no recurring templates
+    // due — treat as informational, not failure. Overdue is an ops pulse.
+    return {
+      ok: true,
+      line: `Work: ${generated ?? 0} generated today · ${overdue ?? 0} overdue open`,
+    };
+  } catch (e) {
+    return { ok: false, line: `Work check failed: ${String(e).slice(0, 80)}` };
+  }
+}
+
+async function heartbeat() {
+  const [odoo, gemini, recordings, work] = await Promise.all([
+    checkOdooFreshness(),
+    checkGemini(),
+    checkRecordings(),
+    checkWorkEngine(),
+  ]);
+  const checks = { odoo, gemini, recordings, work };
+  return {
+    all_ok: Object.values(checks).every((c) => c.ok),
+    checks,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+async function handle(request: NextRequest) {
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return error("Unauthorized", 401);
+    }
+  }
+  try {
+    return success(await heartbeat());
+  } catch (err) {
+    console.error("[Heartbeat] failed:", err);
+    return error("Heartbeat failed", 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return handle(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handle(request);
+}


### PR DESCRIPTION
Every recent failure was silent (week-long frozen deploys, dead Gemini key, misrouted alerts). This makes the system report itself daily.

**`/api/health/heartbeat`** (CRON_SECRET): Odoo data freshness (orders+stock <30h), **Gemini liveness** (tiny generateContent — catches quota death with the reason), recordings flow (processed/24h + stuck), work engine (generated today + overdue).

**`heartbeat.yml`** (08:00 IST + workflow_dispatch): Vercel deploy state of main + latest conclusions of odoo-sync / my-work-generate / my-work-nudges / db-backup via GitHub API, then composes ONE Telegram message — `💓 Maiyuri heartbeat` when all green, `🚨 MAIYURI NEEDS ATTENTION` with ✅/❌ lines otherwise.

Green = safe to ignore. tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily health monitoring for deployments, scheduled processes, and core application services.
  * Added checks for data freshness, AI availability, recording processing, and work generation.
  * Added secure health-check access and structured status reporting.
  * Added Telegram notifications for daily status summaries and workflow failures.

* **Reliability**
  * Health monitoring now identifies failed or unavailable services and provides actionable alerts with run details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->