### PR TITLE
feat(golden-hour): 2-hour "quote opened → call now" hot task (GH4)

### DIFF
--- a/apps/web/app/api/sq/[slug]/events/route.ts
+++ b/apps/web/app/api/sq/[slug]/events/route.ts
@@ -4,6 +4,7 @@ import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
 import { success, notFound, error, parseBody } from "@/lib/api-utils";
 import { smartQuoteEventSchema } from "@maiyuri/shared";
+import { createQuoteOpenCallback } from "@/lib/golden-hour";
 
 interface RouteParams {
   params: Promise<{ slug: string }>;
@@ -65,6 +66,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       console.error("[SmartQuoteEvents] Insert error:", insertError);
       // Don't fail the request for analytics errors
       // Just log and return success
+    }
+
+    // GH4: a page 'view' means the customer OPENED their quote — spin up the
+    // 2-hour "call now" task (deduped/cooled-down inside). Fire-and-forget;
+    // must never delay the customer's page.
+    if (event_type === "view") {
+      void createQuoteOpenCallback(quote.id);
     }
 
     return success({ tracked: true });

--- a/apps/web/src/lib/golden-hour.ts
+++ b/apps/web/src/lib/golden-hour.ts
@@ -83,3 +83,83 @@ export async function createFirstResponseTask(lead: {
     console.error("[GoldenHour] createFirstResponseTask failed (ignored):", err);
   }
 }
+
+/**
+ * GH4: the customer just OPENED their quote — the single hottest moment in the
+ * funnel. Create a 2-hour "call now" task so the rep reaches them while the
+ * numbers are on their screen. Deduped with a cooldown so repeated page views
+ * don't spawn a task each time.
+ */
+const QUOTE_OPEN_CALLBACK_HOURS = 2;
+const QUOTE_OPEN_COOLDOWN_MS = 6 * 60 * 60 * 1000; // one hot task per 6h of views
+
+export async function createQuoteOpenCallback(smartQuoteId: string): Promise<void> {
+  try {
+    const { data: quote } = await supabaseAdmin
+      .from("smart_quotes")
+      .select("lead_id")
+      .eq("id", smartQuoteId)
+      .maybeSingle();
+    if (!quote?.lead_id) return;
+    const leadId = quote.lead_id as string;
+
+    const { data: lead } = await supabaseAdmin
+      .from("leads")
+      .select("name, contact, assigned_staff")
+      .eq("id", leadId)
+      .maybeSingle();
+    if (!lead) return;
+
+    // Cooldown: skip if an open callback task already exists for this lead, or
+    // a very recent one was created (repeat views within the window).
+    const { data: recent } = await supabaseAdmin
+      .from("work_items")
+      .select("id, status, created_at")
+      .eq("related_lead_id", leadId)
+      .eq("source_module", "quote_open")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (recent) {
+      const openStates = ["pending", "in_progress", "returned"];
+      const isOpen = openStates.includes(recent.status as string);
+      const fresh =
+        Date.now() - new Date(recent.created_at as string).getTime() <
+        QUOTE_OPEN_COOLDOWN_MS;
+      if (isOpen || fresh) return;
+    }
+
+    const assignee = await resolveAssignee(
+      (lead.assigned_staff as string | null) ?? null,
+    );
+    if (!assignee) return;
+
+    const label = (lead.name as string) || (lead.contact as string) || "Lead";
+    const { data: item, error } = await supabaseAdmin
+      .from("work_items")
+      .insert({
+        title: `🔥 Quote OPENED — call ${label} now`.slice(0, 200),
+        description: `${label} is looking at their quote right now — call within ${QUOTE_OPEN_CALLBACK_HOURS} hours while it's hot. இப்போது கோட் பார்க்கிறார்கள் — உடனே அழையுங்கள்!`,
+        activity_type: "simple",
+        status: "pending",
+        priority: "urgent",
+        assigned_user_id: assignee,
+        due_at: new Date(
+          Date.now() + QUOTE_OPEN_CALLBACK_HOURS * 3_600_000,
+        ).toISOString(),
+        related_lead_id: leadId,
+        related_label: label,
+        source_module: "quote_open",
+      })
+      .select("*")
+      .single();
+
+    if (error || !item) {
+      console.error("[GoldenHour] quote-open task insert failed:", error);
+      return;
+    }
+    await notifyWorkAssigned(item as WorkItem);
+  } catch (err) {
+    console.error("[GoldenHour] createQuoteOpenCallback failed (ignored):", err);
+  }
+}


### PR DESCRIPTION
The hottest moment in the funnel — the customer opens their Smart Quote. On the first page `view` event, `createQuoteOpenCallback()` creates an **URGENT** work item **"🔥 Quote OPENED — call <lead> now"** (EN+Tamil), due in **2 hours**, assigned to the rep — so the callback lands while the numbers are on their screen (the playbooks highest-leverage move).

- Deduped: skipped if an open quote_open task already exists, or one was created in the last 6h (repeat views dont spam)
- Fire-and-forget from the public events route — never delays the customer page
- Complements the existing never-viewed / viewed-no-submission Telegram nudges with a fast, personal, task-based response

Gold Hour series complete: GH0 rate card · GH1 30-min SLA · GH2 pre-call brief · GH3 auto-quote · **GH4 quote-open callback**.

tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opening a Smart Quote now automatically initiates a follow-up workflow.
  * An urgent task is assigned to the appropriate staff member with a two-hour due time.
  * Staff receive a notification when the follow-up task is created.
  * Duplicate open tasks and recently created follow-ups are automatically avoided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->