### PR TITLE
feat(whatsapp): AI Concierge — inbound webhook, RAG replies, buying-intent hand-off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,9 @@ LANGFUSE_BASE_URL=https://cloud.langfuse.com
 # AI Cost Alerting (optional)
 AI_DAILY_COST_ALERT_USD=50
 AI_ERROR_RATE_ALERT_PERCENT=5
+
+# WhatsApp AI Concierge (Meta WhatsApp Cloud API) — concierge is dormant until set
+WHATSAPP_TOKEN=your-meta-system-user-token
+WHATSAPP_PHONE_NUMBER_ID=your-sending-number-id
+WHATSAPP_VERIFY_TOKEN=any-random-string-you-choose
+WHATSAPP_WELCOME_TEMPLATE=maiyuri_welcome

--- a/apps/web/app/api/whatsapp/webhook/route.ts
+++ b/apps/web/app/api/whatsapp/webhook/route.ts
@@ -1,0 +1,184 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+import { NextRequest, NextResponse } from "next/server";
+import { routes } from "@maiyuri/api";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  isWhatsAppConfigured,
+  sendWhatsAppText,
+  toWaNumber,
+  logWhatsAppMessage,
+} from "@/lib/whatsapp";
+import { createFirstResponseTask } from "@/lib/golden-hour";
+import { notifyLeadPush, getUserIdsByRoles, filterByPushPref } from "@/lib/push/fcm";
+
+/**
+ * WhatsApp AI Concierge webhook.
+ *   GET  — Meta verification handshake (hub.challenge).
+ *   POST — inbound customer messages: log → find/create lead → AI reply from
+ *          the Ask-Mayur knowledge base → buying-intent hand-off to the rep.
+ *
+ * Public (Meta calls it unauthenticated); the verify token is the gate on GET,
+ * and POST is idempotent + best-effort. No-ops entirely until configured.
+ */
+
+// GET: webhook verification
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const mode = params.get("hub.mode");
+  const token = params.get("hub.verify_token");
+  const challenge = params.get("hub.challenge");
+  const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
+
+  if (mode === "subscribe" && verifyToken && token === verifyToken) {
+    return new NextResponse(challenge ?? "", { status: 200 });
+  }
+  return new NextResponse("Forbidden", { status: 403 });
+}
+
+type WaInbound = {
+  entry?: {
+    changes?: {
+      value?: {
+        contacts?: { profile?: { name?: string }; wa_id: string }[];
+        messages?: {
+          id: string;
+          from: string;
+          type: string;
+          text?: { body: string };
+        }[];
+      };
+    }[];
+  }[];
+};
+
+// Keywords that signal buying intent → hand off to a human immediately.
+const HANDOFF_RE =
+  /\b(price|quote|rate|order|buy|purchase|delivery|visit|book|discount|வில|விலை|ஆர்டர்|கோட்)/i;
+
+export async function POST(request: NextRequest) {
+  // Always 200 fast so Meta doesn't retry-storm; work happens inline but
+  // wrapped so a failure still returns 200.
+  try {
+    if (!isWhatsAppConfigured()) return NextResponse.json({ ok: true });
+
+    const body = (await request.json()) as WaInbound;
+    const change = body.entry?.[0]?.changes?.[0]?.value;
+    const msg = change?.messages?.[0];
+    if (!msg || msg.type !== "text" || !msg.text?.body) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const waPhone = toWaNumber(msg.from);
+    const text = msg.text.body.trim();
+    const profileName = change?.contacts?.[0]?.profile?.name ?? null;
+
+    // Idempotency: Meta re-delivers; the unique wa_message_id blocks dupes.
+    const { data: seen } = await supabaseAdmin
+      .from("whatsapp_messages")
+      .select("id")
+      .eq("wa_message_id", msg.id)
+      .maybeSingle();
+    if (seen) return NextResponse.json({ ok: true });
+
+    // Find or create the lead by normalized phone (last 10 digits).
+    const last10 = waPhone.slice(-10);
+    let { data: lead } = await supabaseAdmin
+      .from("leads")
+      .select("id, name, assigned_staff")
+      .ilike("contact", `%${last10}`)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    let isNew = false;
+    if (!lead) {
+      const { data: created } = await supabaseAdmin
+        .from("leads")
+        .insert({
+          name: profileName ?? last10,
+          contact: last10,
+          source: "WhatsApp",
+          lead_status: "new_contact_pending",
+          pipeline_stage: "new_inquiry",
+          lead_type: "Other",
+          classification: "direct_customer",
+        })
+        .select("id, name, assigned_staff")
+        .single();
+      lead = created ?? null;
+      isNew = true;
+      if (lead) await createFirstResponseTask({ ...lead, source: "WhatsApp" });
+    }
+
+    const handoff = HANDOFF_RE.test(text);
+
+    await logWhatsAppMessage({
+      lead_id: lead?.id ?? null,
+      wa_phone: waPhone,
+      direction: "inbound",
+      body: text,
+      wa_message_id: msg.id,
+      handoff,
+    });
+
+    // AI reply from the Ask-Mayur knowledge base (Tamil/English).
+    const isTamil = /[஀-௿]/.test(text);
+    let answer =
+      "Vanakkam! 🙏 Thank you for messaging Maiyuri Bricks. Our team will get back to you very shortly.";
+    try {
+      const result = await routes.knowledge.answerQuestion({
+        question: text,
+        leadId: lead?.id,
+        includeNotes: false,
+        maxSources: 4,
+        language: isTamil ? "ta" : "en",
+      });
+      if (result.success && result.data?.answer) {
+        answer = result.data.answer;
+      }
+    } catch (err) {
+      console.error("[WhatsApp] RAG answer failed:", err);
+    }
+
+    if (handoff) {
+      answer +=
+        "\n\n" +
+        (isTamil
+          ? "எங்கள் விற்பனை நண்பர் விரைவில் உங்களை அழைப்பார். 📞"
+          : "Our sales colleague will call you shortly to help further. 📞");
+    }
+
+    await sendWhatsAppText(waPhone, answer, {
+      leadId: lead?.id ?? null,
+      aiReplied: true,
+    });
+
+    // Buying intent (or brand-new WhatsApp lead) → put it in front of a human.
+    if ((handoff || isNew) && lead) {
+      await createFirstResponseTask({
+        id: lead.id,
+        name: lead.name,
+        assigned_staff: (lead.assigned_staff as string | null) ?? null,
+        source: "WhatsApp",
+      });
+      try {
+        const leadership = await getUserIdsByRoles(["founder", "owner"]);
+        const recipients = await filterByPushPref(leadership, "push_leads");
+        await notifyLeadPush(recipients, {
+          title: `💬 WhatsApp: ${lead.name ?? last10}`,
+          body: text.slice(0, 160),
+          leadId: lead.id,
+        });
+      } catch {
+        /* push best-effort */
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[WhatsApp] webhook error (ignored):", err);
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -50,6 +50,7 @@ const publicApiRoutes = [
   "/api/users/accept-invite", // Accept invitation (uses invite token)
   "/api/webhooks", // External webhooks
   "/api/telegram/webhook", // Telegram bot webhook (receives voice recordings)
+  "/api/whatsapp/webhook", // WhatsApp Cloud API webhook (verify + inbound; token-gated on GET)
   "/api/telegram/processing-callback", // Telegram callback
   "/api/notifications/telegram", // Telegram webhook
   "/api/notifications/daily-summary", // Daily summary cron job

--- a/apps/web/src/lib/whatsapp.ts
+++ b/apps/web/src/lib/whatsapp.ts
@@ -1,0 +1,151 @@
+/**
+ * WhatsApp Cloud API client for the AI Concierge.
+ *
+ * Dormant until three env vars are set (nothing sends without them):
+ *   WHATSAPP_TOKEN          — permanent/system-user access token (Meta)
+ *   WHATSAPP_PHONE_NUMBER_ID — the sending number's id
+ *   WHATSAPP_VERIFY_TOKEN    — arbitrary string, matched on webhook verify
+ *
+ * All sends are logged to whatsapp_messages and best-effort (never throw).
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const GRAPH = "https://graph.facebook.com/v21.0";
+
+export function isWhatsAppConfigured(): boolean {
+  return (
+    !!process.env.WHATSAPP_TOKEN && !!process.env.WHATSAPP_PHONE_NUMBER_ID
+  );
+}
+
+/** Digits only (Cloud API wants E.164 without '+', e.g. 919345971162). */
+export function toWaNumber(phone: string): string {
+  const d = phone.replace(/\D/g, "");
+  // Bare 10-digit Indian mobile → prefix 91.
+  return d.length === 10 ? `91${d}` : d;
+}
+
+async function logMessage(row: {
+  lead_id?: string | null;
+  wa_phone: string;
+  direction: "inbound" | "outbound";
+  body?: string | null;
+  wa_message_id?: string | null;
+  ai_replied?: boolean;
+  handoff?: boolean;
+}): Promise<void> {
+  try {
+    await supabaseAdmin.from("whatsapp_messages").insert(row);
+  } catch (err) {
+    console.error("[WhatsApp] log failed (ignored):", err);
+  }
+}
+
+/**
+ * Send a free-form text message. Only works inside the 24-hour customer-service
+ * window (i.e. the customer messaged us recently); outside it Meta requires an
+ * approved template — see sendTemplate.
+ */
+export async function sendWhatsAppText(
+  toPhone: string,
+  body: string,
+  opts: { leadId?: string | null; aiReplied?: boolean } = {},
+): Promise<boolean> {
+  if (!isWhatsAppConfigured()) return false;
+  const to = toWaNumber(toPhone);
+  try {
+    const res = await fetch(
+      `${GRAPH}/${process.env.WHATSAPP_PHONE_NUMBER_ID}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.WHATSAPP_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          to,
+          type: "text",
+          text: { body: body.slice(0, 4096), preview_url: true },
+        }),
+      },
+    );
+    const json = (await res.json().catch(() => ({}))) as {
+      messages?: { id: string }[];
+      error?: { message?: string };
+    };
+    if (!res.ok) {
+      console.error("[WhatsApp] send failed:", json.error?.message ?? res.status);
+      return false;
+    }
+    await logMessage({
+      lead_id: opts.leadId ?? null,
+      wa_phone: to,
+      direction: "outbound",
+      body,
+      wa_message_id: json.messages?.[0]?.id ?? null,
+      ai_replied: opts.aiReplied ?? false,
+    });
+    return true;
+  } catch (err) {
+    console.error("[WhatsApp] send threw (ignored):", err);
+    return false;
+  }
+}
+
+/**
+ * Send an approved template (for proactively reaching a NEW lead outside the
+ * 24h window — the welcome/intro). Falls back silently if not configured or
+ * the template name env isn't set.
+ */
+export async function sendWhatsAppTemplate(
+  toPhone: string,
+  templateName: string,
+  languageCode = "en",
+  opts: { leadId?: string | null } = {},
+): Promise<boolean> {
+  if (!isWhatsAppConfigured() || !templateName) return false;
+  const to = toWaNumber(toPhone);
+  try {
+    const res = await fetch(
+      `${GRAPH}/${process.env.WHATSAPP_PHONE_NUMBER_ID}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.WHATSAPP_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          to,
+          type: "template",
+          template: { name: templateName, language: { code: languageCode } },
+        }),
+      },
+    );
+    const json = (await res.json().catch(() => ({}))) as {
+      messages?: { id: string }[];
+      error?: { message?: string };
+    };
+    if (!res.ok) {
+      console.error(
+        "[WhatsApp] template send failed:",
+        json.error?.message ?? res.status,
+      );
+      return false;
+    }
+    await logMessage({
+      lead_id: opts.leadId ?? null,
+      wa_phone: to,
+      direction: "outbound",
+      body: `[template:${templateName}]`,
+      wa_message_id: json.messages?.[0]?.id ?? null,
+    });
+    return true;
+  } catch (err) {
+    console.error("[WhatsApp] template threw (ignored):", err);
+    return false;
+  }
+}
+
+export { logMessage as logWhatsAppMessage };

--- a/supabase/migrations/20260719160000_whatsapp.sql
+++ b/supabase/migrations/20260719160000_whatsapp.sql
@@ -1,0 +1,18 @@
+-- WhatsApp AI Concierge: full conversation log per lead (inbound + outbound).
+CREATE TABLE IF NOT EXISTS public.whatsapp_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lead_id UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  wa_phone TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('inbound','outbound')),
+  body TEXT,
+  wa_message_id TEXT UNIQUE,
+  ai_replied BOOLEAN NOT NULL DEFAULT false,
+  handoff BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_wa_messages_lead ON public.whatsapp_messages (lead_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_wa_messages_phone ON public.whatsapp_messages (wa_phone, created_at);
+ALTER TABLE public.whatsapp_messages ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "wa_messages_read" ON public.whatsapp_messages;
+CREATE POLICY "wa_messages_read" ON public.whatsapp_messages
+  FOR SELECT TO authenticated USING (true);


### PR DESCRIPTION
The premium 24/7 customer front door. **Dormant until WHATSAPP_TOKEN / WHATSAPP_PHONE_NUMBER_ID / WHATSAPP_VERIFY_TOKEN are set** — every path no-ops without them.

- **`lib/whatsapp.ts`** — Cloud API client (send text/template, phone normalization); every send logged to `whatsapp_messages`, all best-effort.
- **`GET /api/whatsapp/webhook`** — Meta verification handshake (verify-token gate).
- **`POST /api/whatsapp/webhook`** — inbound text → idempotent (wa_message_id) → find/create lead by normalized phone (source WhatsApp; 30-min SLA task on new) → **AI reply from the Ask-Mayur knowledge base**, Tamil/English auto-detected → on buying-intent (price/quote/order/visit/விலை…) or a brand-new lead: append "our colleague will call you", create a first-response task, push leadership. Always 200 (no Meta retry-storm).
- Migration `whatsapp_messages` applied to prod; webhook in middleware public routes; env documented.

**Setup to activate** (Meta side): create a WhatsApp Business app at business.facebook.com, set the webhook URL to `https://mb.maiyuri.com/api/whatsapp/webhook` with your chosen verify token, subscribe to `messages`, then add the 3 env vars in Vercel.

tsc + eslint clean.