### PR TITLE
feat(factory): /api/factory routes — CRUD + Friday-review reports (PR 2/4)

### DIFF
--- a/apps/web/app/api/factory/assets/route.ts
+++ b/apps/web/app/api/factory/assets/route.ts
@@ -1,0 +1,71 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { ASSET_CATEGORIES, ASSET_LOCATIONS } from "@/lib/factory";
+
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .select("*")
+      .order("category")
+      .order("asset");
+    if (dbError) return error("Failed to load assets", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory assets GET failed:", err);
+    return error("Failed to load assets", 500);
+  }
+}
+
+const baseSchema = z.object({
+  asset: z.string().min(1).max(160),
+  category: z.enum(ASSET_CATEGORIES),
+  qty: z.number().min(0).default(1),
+  location: z.enum(ASSET_LOCATIONS).default("Unknown"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create asset: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory assets POST failed:", err);
+    return error("Failed to create asset", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update asset", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory assets PATCH failed:", err);
+    return error("Failed to update asset", 500);
+  }
+}

--- a/apps/web/app/api/factory/customers/route.ts
+++ b/apps/web/app/api/factory/customers/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .select("*")
+      .order("name");
+    if (dbError) return error("Failed to load customers", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory customers GET failed:", err);
+    return error("Failed to load customers", 500);
+  }
+}
+
+const baseSchema = z.object({
+  name: z.string().min(1).max(120),
+  location: z.string().nullable().optional(),
+  phone: z.string().max(20).nullable().optional(),
+  credit_hold: z.boolean().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create customer: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory customers POST failed:", err);
+    return error("Failed to create customer", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update customer", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory customers PATCH failed:", err);
+    return error("Failed to update customer", 500);
+  }
+}

--- a/apps/web/app/api/factory/deliveries/[id]/route.ts
+++ b/apps/web/app/api/factory/deliveries/[id]/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_DELIVERY, DELIVERY_STATUSES } from "@/lib/factory";
+
+const patchSchema = z.object({
+  delivery_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  qty: z.number().int().min(0).optional(),
+  status: z.enum(DELIVERY_STATUSES).optional(),
+  order_id: z.string().uuid().nullable().optional(),
+  trip_id: z.string().uuid().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_DELIVERY).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+// PATCH /api/factory/deliveries/:id — the daily workflow: Planned → Delivered
+// (or Postponed). Stock and order fulfilment recompute automatically.
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*, factory_customers(name, credit_hold), factory_products(code)")
+      .single();
+    if (dbError || !data) return error("Failed to update delivery", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory deliveries PATCH failed:", err);
+    return error("Failed to update delivery", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete delivery", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory deliveries DELETE failed:", err);
+    return error("Failed to delete delivery", 500);
+  }
+}

--- a/apps/web/app/api/factory/deliveries/route.ts
+++ b/apps/web/app/api/factory/deliveries/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  DATA_FLAGS_DELIVERY,
+  DELIVERY_STATUSES,
+  factoryWeekEnd,
+  factoryWeekStart,
+} from "@/lib/factory";
+
+// GET /api/factory/deliveries?week=YYYY-MM-DD (any date in the Sat–Fri week)
+// or ?from&to. Joined with customer + product for composed row labels.
+export async function GET(request: NextRequest) {
+  try {
+    const { week, from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_deliveries")
+      .select("*, factory_customers(name, credit_hold), factory_products(code)")
+      .order("delivery_date", { ascending: true });
+    if (week) {
+      query = query
+        .gte("delivery_date", factoryWeekStart(week))
+        .lte("delivery_date", factoryWeekEnd(week));
+    } else {
+      if (from) query = query.gte("delivery_date", from);
+      if (to) query = query.lte("delivery_date", to);
+    }
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load deliveries", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory deliveries GET failed:", err);
+    return error("Failed to load deliveries", 500);
+  }
+}
+
+const baseSchema = z.object({
+  delivery_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  customer_id: z.string().uuid(),
+  product_id: z.string().uuid(),
+  qty: z.number().int().min(0), // 0 = qty still to confirm
+  status: z.enum(DELIVERY_STATUSES).default("Planned"),
+  order_id: z.string().uuid().nullable().optional(),
+  trip_id: z.string().uuid().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_DELIVERY).default("OK"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create delivery: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory deliveries POST failed:", err);
+    return error("Failed to create delivery", 500);
+  }
+}

--- a/apps/web/app/api/factory/labour/[id]/route.ts
+++ b/apps/web/app/api/factory/labour/[id]/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { WORK_TYPES } from "@/lib/factory";
+
+const patchSchema = z.object({
+  work_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  worker: z.string().min(1).max(120).optional(),
+  work_type: z.enum(WORK_TYPES).optional(),
+  qty: z.number().optional(),
+  rate: z.number().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update labour entry", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory labour PATCH failed:", err);
+    return error("Failed to update labour entry", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete labour entry", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory labour DELETE failed:", err);
+    return error("Failed to delete labour entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/labour/route.ts
+++ b/apps/web/app/api/factory/labour/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, WORK_TYPES } from "@/lib/factory";
+
+// GET /api/factory/labour?week=YYYY-MM-DD or ?from&to
+export async function GET(request: NextRequest) {
+  try {
+    const { week, from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_labour")
+      .select("*")
+      .order("work_date", { ascending: false });
+    if (week) {
+      query = query
+        .gte("work_date", factoryWeekStart(week))
+        .lte("work_date", factoryWeekEnd(week));
+    } else {
+      if (from) query = query.gte("work_date", from);
+      if (to) query = query.lte("work_date", to);
+    }
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load labour entries", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory labour GET failed:", err);
+    return error("Failed to load labour entries", 500);
+  }
+}
+
+const baseSchema = z
+  .object({
+    work_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    worker: z.string().min(1).max(120),
+    work_type: z.enum(WORK_TYPES),
+    qty: z.number(),
+    rate: z.number(),
+    notes: z.string().nullable().optional(),
+  })
+  .refine((l) => l.work_type !== "Advance" || (l.qty === 1 && l.rate < 0), {
+    message: "Advances are qty 1 with a negative rate (e.g. 1 × -3500)",
+  });
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create labour entry: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory labour POST failed:", err);
+    return error("Failed to create labour entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/orders/route.ts
+++ b/apps/web/app/api/factory/orders/route.ts
@@ -1,0 +1,78 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { PAYMENT_STATUSES } from "@/lib/factory";
+
+// GET /api/factory/orders — reads factory_orders_v (delivered/balance/fulfilment
+// derived from dispatches). ?status=open → not Complete, not Cancelled, oldest first.
+export async function GET(request: NextRequest) {
+  try {
+    const { status } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_orders_v")
+      .select("*")
+      .order("order_date", { ascending: true });
+    if (status === "open") {
+      query = query.neq("fulfilment", "Complete").neq("payment_status", "Cancelled");
+    }
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load orders", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory orders GET failed:", err);
+    return error("Failed to load orders", 500);
+  }
+}
+
+const baseSchema = z.object({
+  customer_id: z.string().uuid(),
+  order_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  qty_ordered: z.number().int().positive(),
+  payment_status: z.enum(PAYMENT_STATUSES).default("Clear"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_orders")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create order: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory orders POST failed:", err);
+    return error("Failed to create order", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_orders")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update order", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory orders PATCH failed:", err);
+    return error("Failed to update order", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-log/[id]/route.ts
+++ b/apps/web/app/api/factory/production-log/[id]/route.ts
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_PRODUCTION, DOWNTIME_REASONS } from "@/lib/factory";
+
+const patchSchema = z.object({
+  qty_produced: z.number().int().min(0).optional(),
+  cement_bags: z.number().min(0).nullable().optional(),
+  downtime_reason: z.enum(DOWNTIME_REASONS).optional(),
+  remarks: z.string().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_PRODUCTION).optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update entry", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-log PATCH failed:", err);
+    return error("Failed to update entry", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete entry", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory production-log DELETE failed:", err);
+    return error("Failed to delete entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-log/route.ts
+++ b/apps/web/app/api/factory/production-log/route.ts
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_PRODUCTION, DOWNTIME_REASONS } from "@/lib/factory";
+
+// GET /api/factory/production-log?from&to&product_id
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to, product_id } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_log")
+      .select("*, factory_products(code)")
+      .order("log_date", { ascending: false });
+    if (from) query = query.gte("log_date", from);
+    if (to) query = query.lte("log_date", to);
+    if (product_id) query = query.eq("product_id", product_id);
+    const { data, error: dbError } = await query.limit(400);
+    if (dbError) return error("Failed to load production log", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory production-log GET failed:", err);
+    return error("Failed to load production log", 500);
+  }
+}
+
+const upsertSchema = z.object({
+  log_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  qty_produced: z.number().int().min(0),
+  cement_bags: z.number().min(0).nullable().optional(),
+  downtime_reason: z.enum(DOWNTIME_REASONS).default("None"),
+  remarks: z.string().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_PRODUCTION).default("OK"),
+});
+
+// POST /api/factory/production-log — one row per date+product; re-submitting
+// the same date+product EDITS it (upsert), so mobile entry can't duplicate.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, upsertSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .upsert(parsed.data, { onConflict: "log_date,product_id" })
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to save production entry: ${dbError.message}`, 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-log POST failed:", err);
+    return error("Failed to save production entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-plan/[id]/route.ts
+++ b/apps/web/app/api/factory/production-plan/[id]/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const patchSchema = z.object({
+  planned_qty: z.number().int().min(0).optional(),
+  plan_note: z.string().nullable().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update plan row", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-plan PATCH failed:", err);
+    return error("Failed to update plan row", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete plan row", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory production-plan DELETE failed:", err);
+    return error("Failed to delete plan row", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-plan/route.ts
+++ b/apps/web/app/api/factory/production-plan/route.ts
@@ -1,0 +1,54 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/production-plan?from&to
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_plan")
+      .select("*, factory_products(code)")
+      .order("plan_date", { ascending: true });
+    if (from) query = query.gte("plan_date", from);
+    if (to) query = query.lte("plan_date", to);
+    const { data, error: dbError } = await query.limit(400);
+    if (dbError) return error("Failed to load production plan", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory production-plan GET failed:", err);
+    return error("Failed to load production plan", 500);
+  }
+}
+
+const upsertSchema = z.object({
+  plan_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  planned_qty: z.number().int().min(0),
+  plan_note: z.string().nullable().optional(),
+});
+
+// POST — one row per date+product; actuals are NEVER stored here, they come
+// from the production log at read time.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, upsertSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .upsert(parsed.data, { onConflict: "plan_date,product_id" })
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to save plan row: ${dbError.message}`, 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-plan POST failed:", err);
+    return error("Failed to save plan row", 500);
+  }
+}

--- a/apps/web/app/api/factory/products/route.ts
+++ b/apps/web/app/api/factory/products/route.ts
@@ -1,0 +1,58 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/products — the 4 SKUs with opening stock state
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_products")
+      .select("*")
+      .order("code");
+    if (dbError) return error("Failed to load products", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory products GET failed:", err);
+    return error("Failed to load products", 500);
+  }
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  // Opening stock entry IS the stock-take: recording it sets opening_counted_at.
+  opening_stock: z.number().int().min(0).optional(),
+  opening_counted_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+// PATCH /api/factory/products — opening stock + notes only; code is immutable.
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const update: Record<string, unknown> = { ...fields };
+    if (fields.opening_stock !== undefined && fields.opening_counted_at === undefined) {
+      update.opening_counted_at = new Date().toISOString().slice(0, 10);
+    }
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_products")
+      .update(update)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update product", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory products PATCH failed:", err);
+    return error("Failed to update product", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/cement/route.ts
+++ b/apps/web/app/api/factory/reports/cement/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekStart } from "@/lib/factory";
+
+// GET /api/factory/reports/cement — View 6: bricks per cement bag by week and
+// product. The sheet showed a 40.4–54.4 swing on the largest input cost.
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .select("log_date, qty_produced, cement_bags, data_flag, factory_products(code)")
+      .gt("cement_bags", 0)
+      .order("log_date");
+    if (dbError) return error("Failed to load cement data", 500);
+
+    // Weekly aggregation per product
+    const byWeekProduct = new Map<string, { qty: number; bags: number; estimated: boolean }>();
+    // Daily points for the scatter/trend
+    const daily = (data ?? []).map((row) => {
+      const code = (row.factory_products as { code?: string } | null)?.code ?? "?";
+      const qty = Number(row.qty_produced);
+      const bags = Number(row.cement_bags);
+      const week = factoryWeekStart(row.log_date as string);
+      const key = `${week}|${code}`;
+      const agg = byWeekProduct.get(key) ?? { qty: 0, bags: 0, estimated: false };
+      agg.qty += qty;
+      agg.bags += bags;
+      if (row.data_flag === "Estimated") agg.estimated = true;
+      byWeekProduct.set(key, agg);
+      return {
+        date: row.log_date as string,
+        product_code: code,
+        bricks_per_bag: bags > 0 ? Math.round((qty / bags) * 10) / 10 : null,
+        data_flag: row.data_flag as string,
+      };
+    });
+
+    const weekly = [...byWeekProduct.entries()]
+      .map(([key, agg]) => {
+        const [week_start, product_code] = key.split("|");
+        return {
+          week_start,
+          product_code,
+          bricks_per_bag: agg.bags > 0 ? Math.round((agg.qty / agg.bags) * 10) / 10 : null,
+          total_bags: Math.round(agg.bags * 10) / 10,
+          includes_estimates: agg.estimated,
+        };
+      })
+      .sort(
+        (a, b) =>
+          a.week_start.localeCompare(b.week_start) ||
+          a.product_code.localeCompare(b.product_code),
+      );
+
+    return success({ daily, weekly });
+  } catch (err) {
+    console.error("factory cement report failed:", err);
+    return error("Failed to build cement report", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/downtime/route.ts
+++ b/apps/web/app/api/factory/reports/downtime/route.ts
@@ -1,0 +1,55 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/reports/downtime?from&to — View 5: causes ranked.
+// "days lost" = distinct dates with zero production for that cause;
+// "days affected" = distinct dates the cause appeared at all.
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_log")
+      .select("log_date, qty_produced, downtime_reason, remarks")
+      .neq("downtime_reason", "None");
+    if (from) query = query.gte("log_date", from);
+    if (to) query = query.lte("log_date", to);
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load downtime", 500);
+
+    const byReason = new Map<
+      string,
+      { entries: number; affected: Set<string>; lost: Set<string>; remarks: string[] }
+    >();
+    for (const row of data ?? []) {
+      const r = byReason.get(row.downtime_reason) ?? {
+        entries: 0,
+        affected: new Set<string>(),
+        lost: new Set<string>(),
+        remarks: [],
+      };
+      r.entries += 1;
+      r.affected.add(row.log_date);
+      if (Number(row.qty_produced) === 0) r.lost.add(row.log_date);
+      if (row.remarks) r.remarks.push(`${row.log_date}: ${row.remarks}`);
+      byReason.set(row.downtime_reason, r);
+    }
+
+    const ranked = [...byReason.entries()]
+      .map(([reason, r]) => ({
+        reason,
+        entries: r.entries,
+        days_affected: r.affected.size,
+        days_lost: r.lost.size,
+        remarks: r.remarks.slice(0, 6),
+      }))
+      .sort((a, b) => b.days_lost - a.days_lost || b.days_affected - a.days_affected);
+
+    return success({ causes: ranked });
+  } catch (err) {
+    console.error("factory downtime report failed:", err);
+    return error("Failed to build downtime report", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/friday-review/route.ts
+++ b/apps/web/app/api/factory/reports/friday-review/route.ts
@@ -1,0 +1,107 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate } from "@/lib/factory";
+
+// GET /api/factory/reports/friday-review?week=YYYY-MM-DD
+// Rajesh's Friday deck: the target COMMITTED in last week's review vs what
+// actually happened, plus live stock and the week's downtime.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const [plans, logs, deliveries, stock] = await Promise.all([
+      supabaseAdmin
+        .from("factory_production_plan")
+        .select("plan_date, planned_qty, factory_products(code)")
+        .gte("plan_date", from)
+        .lte("plan_date", to),
+      supabaseAdmin
+        .from("factory_production_log")
+        .select("log_date, qty_produced, downtime_reason, remarks, factory_products(code)")
+        .gte("log_date", from)
+        .lte("log_date", to),
+      supabaseAdmin
+        .from("factory_deliveries")
+        .select("qty, status, factory_products(code)")
+        .gte("delivery_date", from)
+        .lte("delivery_date", to),
+      supabaseAdmin.from("factory_stock_v").select("*").order("code"),
+    ]);
+
+    // Supabase types embedded relations as object OR array depending on
+    // inference — normalise both shapes.
+    const code = (r: { factory_products: unknown }): string => {
+      const fp = r.factory_products as { code?: string } | { code?: string }[] | null;
+      return (Array.isArray(fp) ? fp[0]?.code : fp?.code) ?? "?";
+    };
+
+    // Production: committed plan vs actual, per product
+    const perProduct = new Map<string, { planned: number; actual: number }>();
+    for (const p of plans.data ?? []) {
+      const e = perProduct.get(code(p)) ?? { planned: 0, actual: 0 };
+      e.planned += Number(p.planned_qty);
+      perProduct.set(code(p), e);
+    }
+    for (const l of logs.data ?? []) {
+      const e = perProduct.get(code(l)) ?? { planned: 0, actual: 0 };
+      e.actual += Number(l.qty_produced);
+      perProduct.set(code(l), e);
+    }
+    const production = [...perProduct.entries()]
+      .map(([product_code, v]) => ({
+        product_code,
+        planned: v.planned,
+        actual: v.actual,
+        variance: v.actual - v.planned,
+        achievement_pct: v.planned > 0 ? Math.round((v.actual / v.planned) * 100) : null,
+      }))
+      .sort((a, b) => a.product_code.localeCompare(b.product_code));
+
+    // Deliveries: committed (all scheduled rows) vs completed
+    let committedQty = 0;
+    let deliveredQty = 0;
+    let postponed = 0;
+    for (const d of deliveries.data ?? []) {
+      committedQty += Number(d.qty);
+      if (d.status === "Delivered") deliveredQty += Number(d.qty);
+      if (d.status === "Postponed") postponed += 1;
+    }
+
+    // Downtime within the week
+    const downtime = (logs.data ?? [])
+      .filter((l) => l.downtime_reason !== "None")
+      .map((l) => ({
+        date: l.log_date as string,
+        product_code: code(l),
+        reason: l.downtime_reason as string,
+        remarks: (l.remarks as string | null) ?? null,
+      }));
+
+    return success({
+      week_start: from,
+      week_end: to,
+      production,
+      production_totals: {
+        planned: production.reduce((s, p) => s + p.planned, 0),
+        actual: production.reduce((s, p) => s + p.actual, 0),
+      },
+      deliveries: {
+        committed_qty: committedQty,
+        delivered_qty: deliveredQty,
+        variance: deliveredQty - committedQty,
+        postponed_count: postponed,
+      },
+      downtime,
+      stock: stock.data ?? [],
+    });
+  } catch (err) {
+    console.error("factory friday-review failed:", err);
+    return error("Failed to build Friday review", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/labour-week/route.ts
+++ b/apps/web/app/api/factory/reports/labour-week/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate } from "@/lib/factory";
+
+// GET /api/factory/reports/labour-week?week=YYYY-MM-DD — View 7.
+// amount = qty × rate everywhere; advances are negative, so a plain sum
+// gives net payable directly.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .select("*")
+      .gte("work_date", from)
+      .lte("work_date", to)
+      .order("work_date");
+    if (dbError) return error("Failed to load labour", 500);
+
+    const byWorker = new Map<
+      string,
+      { gross: number; advances: number; net: number; entries: number }
+    >();
+    let gross = 0;
+    let advances = 0;
+    for (const row of data ?? []) {
+      const amount = Number(row.qty) * Number(row.rate);
+      const w = byWorker.get(row.worker) ?? {
+        gross: 0,
+        advances: 0,
+        net: 0,
+        entries: 0,
+      };
+      if (amount >= 0) {
+        w.gross += amount;
+        gross += amount;
+      } else {
+        w.advances += amount;
+        advances += amount;
+      }
+      w.net += amount;
+      w.entries += 1;
+      byWorker.set(row.worker, w);
+    }
+
+    return success({
+      week_start: from,
+      week_end: to,
+      entries: data ?? [],
+      workers: [...byWorker.entries()]
+        .map(([worker, w]) => ({ worker, ...w }))
+        .sort((a, b) => b.net - a.net),
+      totals: { gross, advances, net: gross + advances },
+    });
+  } catch (err) {
+    console.error("factory labour-week failed:", err);
+    return error("Failed to build labour week", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/plan-vs-actual/route.ts
+++ b/apps/web/app/api/factory/reports/plan-vs-actual/route.ts
@@ -1,0 +1,101 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate, parseISODate } from "@/lib/factory";
+
+type Row = {
+  date: string;
+  product_code: string;
+  planned: number;
+  actual: number | null; // null = no log entry yet for that day/product
+  variance: number | null;
+  achievement_pct: number | null; // null when planned is 0
+  plan_note: string | null;
+  downtime_reason: string | null;
+};
+
+// GET /api/factory/reports/plan-vs-actual?week=YYYY-MM-DD — View 4.
+// Actuals are read from the production log, never re-keyed.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const [{ data: plans }, { data: logs }] = await Promise.all([
+      supabaseAdmin
+        .from("factory_production_plan")
+        .select("plan_date, planned_qty, plan_note, factory_products(code)")
+        .gte("plan_date", from)
+        .lte("plan_date", to),
+      supabaseAdmin
+        .from("factory_production_log")
+        .select("log_date, qty_produced, downtime_reason, factory_products(code)")
+        .gte("log_date", from)
+        .lte("log_date", to),
+    ]);
+
+    const logMap = new Map<string, { qty: number; downtime: string }>();
+    for (const l of logs ?? []) {
+      const code = (l.factory_products as { code?: string } | null)?.code ?? "?";
+      logMap.set(`${l.log_date}|${code}`, {
+        qty: Number(l.qty_produced),
+        downtime: l.downtime_reason,
+      });
+    }
+
+    const rows: Row[] = (plans ?? [])
+      .map((p) => {
+        const code = (p.factory_products as { code?: string } | null)?.code ?? "?";
+        const log = logMap.get(`${p.plan_date}|${code}`);
+        const planned = Number(p.planned_qty);
+        const actual = log ? log.qty : null;
+        return {
+          date: p.plan_date as string,
+          product_code: code,
+          planned,
+          actual,
+          variance: actual === null ? null : actual - planned,
+          achievement_pct:
+            planned > 0 && actual !== null
+              ? Math.round((actual / planned) * 100)
+              : null,
+          plan_note: (p.plan_note as string | null) ?? null,
+          downtime_reason: log?.downtime ?? null,
+        };
+      })
+      .sort(
+        (a, b) =>
+          a.date.localeCompare(b.date) || a.product_code.localeCompare(b.product_code),
+      );
+
+    const plannedTotal = rows.reduce((s, r) => s + r.planned, 0);
+    const actualTotal = rows.reduce((s, r) => s + (r.actual ?? 0), 0);
+    const days: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = parseISODate(from);
+      d.setDate(d.getDate() + i);
+      days.push(toISODate(d));
+    }
+
+    return success({
+      week_start: from,
+      week_end: to,
+      days,
+      rows,
+      totals: {
+        planned: plannedTotal,
+        actual: actualTotal,
+        variance: actualTotal - plannedTotal,
+        achievement_pct:
+          plannedTotal > 0 ? Math.round((actualTotal / plannedTotal) * 100) : null,
+      },
+    });
+  } catch (err) {
+    console.error("factory plan-vs-actual failed:", err);
+    return error("Failed to build plan vs actual", 500);
+  }
+}

--- a/apps/web/app/api/factory/stock/route.ts
+++ b/apps/web/app/api/factory/stock/route.ts
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic";
+
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/stock — live stock per product (View 1).
+// free_stock is the number a salesperson needs before promising a date.
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_stock_v")
+      .select("*")
+      .order("code");
+    if (dbError) return error("Failed to load stock", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory stock GET failed:", err);
+    return error("Failed to load stock", 500);
+  }
+}

--- a/apps/web/app/api/factory/trips/route.ts
+++ b/apps/web/app/api/factory/trips/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { VEHICLES } from "@/lib/factory";
+
+// GET /api/factory/trips — vehicle log; total_km / km_per_litre derived client-side
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_trips")
+      .select("*")
+      .order("trip_date", { ascending: false })
+      .limit(200);
+    if (dbError) return error("Failed to load trips", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory trips GET failed:", err);
+    return error("Failed to load trips", 500);
+  }
+}
+
+const baseSchema = z
+  .object({
+    trip_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    vehicle: z.enum(VEHICLES),
+    start_km: z.number().min(0).nullable().optional(),
+    end_km: z.number().min(0).nullable().optional(),
+    diesel_litres: z.number().min(0).nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .refine(
+    (t) => t.start_km == null || t.end_km == null || t.end_km >= t.start_km,
+    { message: "End KM must be at or after start KM" },
+  );
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_trips")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create trip: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory trips POST failed:", err);
+    return error("Failed to create trip", 500);
+  }
+}


### PR DESCRIPTION
Second Factory Ledger PR (stacked on #123 — retarget to main after it merges).

**10 CRUD surfaces**: stock (view), products (opening-stock entry IS the stock-take; code immutable), customers, orders (?status=open via factory_orders_v, oldest first), production-log (POST upserts on date+product — mobile re-submits edit, never duplicate), production-plan (same; actuals never stored), deliveries (?week= Sat–Fri filter, joined names), trips (end≥start), labour (Advance ⇒ qty 1 × negative rate), assets.

**5 reports**: plan-vs-actual (achievement% null when planned=0), downtime ranked (days-lost = zero-production days), cement weekly bricks/bag (Estimated flags propagate), labour-week net payable, friday-review (committed vs actual vs variance + stock + downtime).

**Auth**: GET any authenticated (drivers can read the schedule); writes founder/owner/production_supervisor; DELETE founder/owner.

Verified: web tsc clean. Live curl checks happen after deploy (endpoints read the already-seeded prod tables).

Generated with Claude Code