### PR TITLE
feat(factory): mobile entry screens (PR 4/4)

### DIFF
--- a/apps/native/app/(tabs)/deliveries.tsx
+++ b/apps/native/app/(tabs)/deliveries.tsx
@@ -1,5 +1,6 @@
 import type { DeliveryStatus, DeliveryWithLines } from '@maiyuri/shared';
 import * as ImagePicker from 'expo-image-picker';
+import { Link } from 'expo-router';
 import { useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -371,6 +372,18 @@ export default function DeliveriesScreen() {
 
   return (
     <SafeAreaView edges={['bottom']} className="flex-1 bg-canvas">
+      <Link href={'/factory/deliveries' as import('expo-router').Href} asChild>
+        <Pressable className="mx-4 mt-3 flex-row items-center rounded-xl border border-slate-200 bg-white px-4 py-3 active:opacity-70">
+          <Text className="mr-3 text-xl">🏭</Text>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-ink">Factory schedule (Sat–Fri)</Text>
+            <Text className="text-xs text-slate-400">
+              Yard deliveries · mark delivered / postponed
+            </Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
       <View className="px-4 pb-1 pt-3">
         <TextInput
           value={search}

--- a/apps/native/app/(tabs)/production.tsx
+++ b/apps/native/app/(tabs)/production.tsx
@@ -1,4 +1,5 @@
 import type { ProductionOrder, ProductionOrderStatus } from '@maiyuri/shared';
+import { Link } from 'expo-router';
 import { useState } from 'react';
 import {
   ActivityIndicator,
@@ -267,6 +268,18 @@ export default function ProductionScreen() {
 
   return (
     <SafeAreaView edges={['bottom']} className="flex-1 bg-canvas">
+      <Link href={'/factory' as import('expo-router').Href} asChild>
+        <Pressable className="mx-4 mt-3 flex-row items-center rounded-xl border border-slate-200 bg-white px-4 py-3 active:opacity-70">
+          <Text className="mr-3 text-xl">🏭</Text>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-ink">Factory Ledger</Text>
+            <Text className="text-xs text-slate-400">
+              Daily production entry · stock · downtime
+            </Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
       <View className="px-4 pb-2 pt-3">
         <TextInput
           value={search}

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -89,6 +89,7 @@ function RootLayout() {
                 options={{ headerShown: true, title: 'New Lead' }}
               />
               <Stack.Screen name="onehub" options={{ headerShown: false }} />
+          <Stack.Screen name="factory" options={{ headerShown: false }} />
             </Stack>
             {/* Native left navigation drawer (hamburger + left-edge swipe).
                 Rendered above the Stack so it overlays every screen. */}

--- a/apps/native/app/factory/_layout.tsx
+++ b/apps/native/app/factory/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from 'expo-router';
+
+export default function FactoryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: '#0f172a' },
+        headerTintColor: '#ffffff',
+        headerTitleStyle: { fontWeight: '700' },
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: '🏭 Factory Ledger' }} />
+      <Stack.Screen name="production" options={{ title: 'Production Entry' }} />
+      <Stack.Screen name="deliveries" options={{ title: 'Delivery Schedule' }} />
+      <Stack.Screen name="labour" options={{ title: 'Labour Entry' }} />
+    </Stack>
+  );
+}

--- a/apps/native/app/factory/deliveries.tsx
+++ b/apps/native/app/factory/deliveries.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+import { useFactorySchedule, useUpdateDeliveryStatus } from '@/hooks/use-factory';
+import { factoryWeekStart, parseISODate, toISODate } from '@/lib/factory';
+
+const DAY_NAMES = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+export default function FactoryDeliverySchedule() {
+  const [anchor, setAnchor] = useState(toISODate(new Date()));
+  const weekStart = factoryWeekStart(anchor);
+  const { data, isLoading } = useFactorySchedule(weekStart);
+  const update = useUpdateDeliveryStatus(weekStart);
+
+  const shiftWeek = (days: number) => {
+    const d = parseISODate(weekStart);
+    d.setDate(d.getDate() + days);
+    setAnchor(toISODate(d));
+  };
+
+  const byDay = useMemo(() => {
+    const days: { date: string; name: string; rows: NonNullable<typeof data>['data'] }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = parseISODate(weekStart);
+      d.setDate(d.getDate() + i);
+      days.push({ date: toISODate(d), name: DAY_NAMES[i], rows: [] });
+    }
+    for (const row of data?.data ?? []) {
+      days.find((d) => d.date === row.delivery_date)?.rows.push(row);
+    }
+    return days.filter((d) => d.rows.length > 0);
+  }, [data, weekStart]);
+
+  return (
+    <ScrollView className="flex-1 bg-canvas" contentContainerClassName="p-4 pb-10">
+      {/* week nav */}
+      <View className="mb-3 flex-row items-center justify-between">
+        <Pressable onPress={() => shiftWeek(-7)} className="rounded-lg bg-slate-200 px-3 py-1.5">
+          <Text className="font-semibold text-slate-600">←</Text>
+        </Pressable>
+        <Text className="text-sm font-bold text-ink">
+          Week of Sat {weekStart.slice(5)}
+        </Text>
+        <Pressable onPress={() => shiftWeek(7)} className="rounded-lg bg-slate-200 px-3 py-1.5">
+          <Text className="font-semibold text-slate-600">→</Text>
+        </Pressable>
+      </View>
+
+      {isLoading ? (
+        <ActivityIndicator size="large" color="#f97316" className="mt-8" />
+      ) : byDay.length === 0 ? (
+        <Text className="mt-8 text-center text-sm text-slate-400">
+          No deliveries scheduled this week.
+        </Text>
+      ) : (
+        byDay.map((day) => (
+          <View key={day.date} className="mb-3">
+            <Text className="mb-1.5 text-xs font-bold uppercase tracking-wider text-slate-500">
+              {day.name} {day.date.slice(5)}
+            </Text>
+            {day.rows.map((r) => {
+              const hold = r.factory_customers?.credit_hold;
+              return (
+                <View
+                  key={r.id}
+                  className="mb-1.5 rounded-xl border border-slate-200 bg-white p-3"
+                >
+                  <View className="flex-row items-center">
+                    <View className="flex-1">
+                      <Text className="text-sm font-semibold text-ink" numberOfLines={1}>
+                        {r.factory_customers?.name ?? '?'} — {Number(r.qty).toLocaleString('en-IN')}{' '}
+                        {r.factory_products?.code}
+                      </Text>
+                      {hold ? (
+                        <Text className="text-xs font-bold text-red-600">
+                          🚫 CREDIT HOLD — do not dispatch
+                        </Text>
+                      ) : null}
+                      {r.data_flag !== 'OK' ? (
+                        <Text className="text-xs text-amber-600">⚠️ {r.data_flag}</Text>
+                      ) : null}
+                    </View>
+                    <Text
+                      className={`text-xs font-bold ${
+                        r.status === 'Delivered'
+                          ? 'text-green-600'
+                          : r.status === 'Postponed'
+                            ? 'text-amber-600'
+                            : r.status === 'Cancelled'
+                              ? 'text-slate-400 line-through'
+                              : 'text-sky-600'
+                      }`}
+                    >
+                      {r.status}
+                    </Text>
+                  </View>
+                  {(r.status === 'Planned' || r.status === 'Postponed') && !hold ? (
+                    <View className="mt-2 flex-row gap-2">
+                      <Pressable
+                        onPress={() => update.mutate({ id: r.id, status: 'Delivered' })}
+                        disabled={update.isPending}
+                        className="flex-1 items-center rounded-lg bg-green-600 py-2 active:opacity-80"
+                      >
+                        <Text className="text-xs font-bold text-white">✓ Delivered</Text>
+                      </Pressable>
+                      {r.status === 'Planned' ? (
+                        <Pressable
+                          onPress={() => update.mutate({ id: r.id, status: 'Postponed' })}
+                          disabled={update.isPending}
+                          className="flex-1 items-center rounded-lg border border-amber-400 py-2 active:opacity-80"
+                        >
+                          <Text className="text-xs font-bold text-amber-700">Postpone</Text>
+                        </Pressable>
+                      ) : null}
+                    </View>
+                  ) : null}
+                </View>
+              );
+            })}
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/factory/index.tsx
+++ b/apps/native/app/factory/index.tsx
@@ -1,0 +1,94 @@
+import { Link } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+import { useFactoryStock } from '@/hooks/use-factory';
+import { useMyProfile } from '@/hooks/use-push-settings';
+import { useAuth } from '@/store/auth';
+
+const fmt = (n: number | null | undefined) =>
+  n == null ? '—' : Number(n).toLocaleString('en-IN');
+
+export default function FactoryHome() {
+  const { data, isLoading } = useFactoryStock();
+  const userId = useAuth((s) => s.session?.user?.id);
+  const profile = useMyProfile(userId);
+  const role = profile.data?.data.role ?? '';
+  const isDriver = role === 'driver';
+
+  const uncounted = (data?.data ?? []).filter((p) => !p.opening_counted_at);
+
+  return (
+    <ScrollView className="flex-1 bg-canvas" contentContainerClassName="p-4 pb-10">
+      {uncounted.length > 0 ? (
+        <View className="mb-3 rounded-xl border border-amber-300 bg-amber-50 p-3">
+          <Text className="text-xs font-semibold text-amber-800">
+            ⚠️ Opening stock not counted ({uncounted.map((p) => p.code).join(', ')}).
+            Balances assume 0 as at 01/07 — enter the yard count on the web app.
+          </Text>
+        </View>
+      ) : null}
+
+      {/* stock cards */}
+      <Text className="mb-2 text-base font-bold text-ink">Free stock (promisable)</Text>
+      {isLoading ? (
+        <ActivityIndicator size="large" color="#f97316" className="mt-6" />
+      ) : (
+        <View className="flex-row flex-wrap justify-between">
+          {(data?.data ?? []).map((p) => (
+            <View
+              key={p.id}
+              className="mb-3 w-[48.5%] rounded-xl border border-slate-200 bg-white p-3.5"
+            >
+              <Text className="text-sm font-bold text-ink">{p.code}</Text>
+              <Text
+                className={`mt-1 text-2xl font-bold ${
+                  p.free_stock < 0 ? 'text-red-600' : 'text-green-600'
+                }`}
+              >
+                {fmt(p.free_stock)}
+              </Text>
+              <Text className="text-[11px] text-slate-400">
+                bal {fmt(p.stock_balance)} · committed {fmt(p.committed)}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* actions */}
+      {!isDriver ? (
+        <Link href={'/factory/production' as import('expo-router').Href} asChild>
+          <Pressable className="mb-2.5 flex-row items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+            <Text className="mr-3 text-2xl">⚙️</Text>
+            <View className="flex-1">
+              <Text className="text-sm font-semibold text-ink">Record today's production</Text>
+              <Text className="text-xs text-slate-400">Qty, cement bags, downtime reason</Text>
+            </View>
+            <Text className="text-slate-400">→</Text>
+          </Pressable>
+        </Link>
+      ) : null}
+      <Link href={'/factory/deliveries' as import('expo-router').Href} asChild>
+        <Pressable className="mb-2.5 flex-row items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+          <Text className="mr-3 text-2xl">🚚</Text>
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-ink">Delivery schedule</Text>
+            <Text className="text-xs text-slate-400">This week Sat–Fri · mark delivered</Text>
+          </View>
+          <Text className="text-slate-400">→</Text>
+        </Pressable>
+      </Link>
+      {!isDriver ? (
+        <Link href={'/factory/labour' as import('expo-router').Href} asChild>
+          <Pressable className="mb-2.5 flex-row items-center rounded-xl border border-slate-200 bg-white p-4 active:opacity-70">
+            <Text className="mr-3 text-2xl">👷</Text>
+            <View className="flex-1">
+              <Text className="text-sm font-semibold text-ink">Labour & wages entry</Text>
+              <Text className="text-xs text-slate-400">Loading, production, NMR, advances</Text>
+            </View>
+            <Text className="text-slate-400">→</Text>
+          </Pressable>
+        </Link>
+      ) : null}
+    </ScrollView>
+  );
+}

--- a/apps/native/app/factory/labour.tsx
+++ b/apps/native/app/factory/labour.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSaveLabour } from '@/hooks/use-factory';
+import { WORK_TYPES } from '@/lib/factory';
+
+const todayISO = () => {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+// Labour & wages entry. Advance = qty 1 × negative amount so the weekly sum
+// nets out automatically.
+export default function FactoryLabourEntry() {
+  const save = useSaveLabour();
+  const [worker, setWorker] = useState('');
+  const [workType, setWorkType] = useState<string>('Loading');
+  const [qty, setQty] = useState('');
+  const [rate, setRate] = useState('');
+  const [notes, setNotes] = useState('');
+  const isAdvance = workType === 'Advance';
+
+  const submit = () => {
+    save.mutate(
+      {
+        work_date: todayISO(),
+        worker: worker.trim(),
+        work_type: workType,
+        qty: isAdvance ? 1 : Number(qty.replace(/[,\s]/g, '')),
+        rate: isAdvance
+          ? -Math.abs(Number(rate.replace(/[,\s]/g, '')))
+          : Number(rate.replace(/[,\s]/g, '')),
+        notes: notes.trim() || null,
+      },
+      {
+        onSuccess: () => {
+          setQty('');
+          setRate('');
+          setNotes('');
+        },
+      },
+    );
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-canvas" contentContainerClassName="p-4 pb-10">
+      <Text className="mb-2 text-sm font-bold text-ink">Today · {todayISO()}</Text>
+
+      <TextInput
+        value={worker}
+        onChangeText={setWorker}
+        placeholder="Worker / team name"
+        placeholderTextColor="#94a3b8"
+        className="rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+      />
+
+      <Text className="mb-1 mt-3 text-xs font-semibold uppercase tracking-wider text-slate-500">
+        Work type
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {WORK_TYPES.map((t) => (
+          <Pressable
+            key={t}
+            onPress={() => setWorkType(t)}
+            className={`rounded-full px-3 py-1.5 ${
+              workType === t ? 'bg-ink' : 'bg-slate-200'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                workType === t ? 'text-white' : 'text-slate-600'
+              }`}
+            >
+              {t}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View className="mt-3 flex-row gap-2">
+        {!isAdvance ? (
+          <TextInput
+            value={qty}
+            onChangeText={setQty}
+            keyboardType="numeric"
+            placeholder="Qty (bricks / days)"
+            placeholderTextColor="#94a3b8"
+            className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+          />
+        ) : null}
+        <TextInput
+          value={rate}
+          onChangeText={setRate}
+          keyboardType="numeric"
+          placeholder={isAdvance ? 'Advance amount ₹' : 'Rate ₹/unit'}
+          placeholderTextColor="#94a3b8"
+          className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+        />
+      </View>
+      {isAdvance ? (
+        <Text className="mt-1 text-xs text-slate-400">
+          Advances are recorded as negative amounts and deducted from the week's
+          net payable automatically.
+        </Text>
+      ) : null}
+
+      <TextInput
+        value={notes}
+        onChangeText={setNotes}
+        placeholder="Notes (optional)"
+        placeholderTextColor="#94a3b8"
+        multiline
+        className="mt-3 min-h-[60px] rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+      />
+
+      <Pressable
+        onPress={submit}
+        disabled={
+          save.isPending || !worker.trim() || rate.trim() === '' || (!isAdvance && qty.trim() === '')
+        }
+        className={`mt-4 items-center rounded-xl py-3 ${
+          save.isPending || !worker.trim() || rate.trim() === ''
+            ? 'bg-slate-200'
+            : 'bg-brand active:opacity-80'
+        }`}
+      >
+        {save.isPending ? (
+          <ActivityIndicator size="small" color="#0f172a" />
+        ) : (
+          <Text className="font-bold text-ink">
+            {isAdvance ? 'Record advance' : 'Save labour entry'}
+          </Text>
+        )}
+      </Pressable>
+    </ScrollView>
+  );
+}

--- a/apps/native/app/factory/production.tsx
+++ b/apps/native/app/factory/production.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  useFactoryLog,
+  useFactoryProducts,
+  useSaveProductionLog,
+} from '@/hooks/use-factory';
+import { DOWNTIME_REASONS } from '@/lib/factory';
+
+const todayISO = () => {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+// Daily production entry: one row per date+product — re-submitting the same
+// day+product edits it (server upsert), so no duplicate risk in the yard.
+export default function FactoryProductionEntry() {
+  const products = useFactoryProducts();
+  const log = useFactoryLog();
+  const save = useSaveProductionLog();
+
+  const [productId, setProductId] = useState('');
+  const [qty, setQty] = useState('');
+  const [bags, setBags] = useState('');
+  const [downtime, setDowntime] = useState('None');
+  const [remarks, setRemarks] = useState('');
+
+  const submit = () => {
+    save.mutate(
+      {
+        log_date: todayISO(),
+        product_id: productId,
+        qty_produced: Number(qty.replace(/[,\s]/g, '')),
+        cement_bags: bags === '' ? null : Number(bags.replace(/[,\s]/g, '')),
+        downtime_reason: downtime,
+        remarks: remarks.trim() || null,
+      },
+      {
+        onSuccess: () => {
+          setQty('');
+          setBags('');
+          setRemarks('');
+        },
+      },
+    );
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-canvas" contentContainerClassName="p-4 pb-10">
+      <Text className="mb-2 text-sm font-bold text-ink">
+        Today · {todayISO()}
+      </Text>
+
+      {/* product picker */}
+      <View className="mb-3 flex-row flex-wrap gap-2">
+        {(products.data?.data ?? []).map((p) => (
+          <Pressable
+            key={p.id}
+            onPress={() => setProductId(p.id)}
+            className={`rounded-full px-4 py-2 ${
+              productId === p.id ? 'bg-ink' : 'bg-slate-200'
+            }`}
+          >
+            <Text
+              className={`text-sm font-semibold ${
+                productId === p.id ? 'text-white' : 'text-slate-600'
+              }`}
+            >
+              {p.code}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View className="flex-row gap-2">
+        <TextInput
+          value={qty}
+          onChangeText={setQty}
+          keyboardType="numeric"
+          placeholder="Qty produced"
+          placeholderTextColor="#94a3b8"
+          className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+        />
+        <TextInput
+          value={bags}
+          onChangeText={setBags}
+          keyboardType="numeric"
+          placeholder="Cement bags"
+          placeholderTextColor="#94a3b8"
+          className="w-32 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+        />
+      </View>
+
+      <Text className="mb-1 mt-3 text-xs font-semibold uppercase tracking-wider text-slate-500">
+        Downtime reason
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {DOWNTIME_REASONS.map((r) => (
+          <Pressable
+            key={r}
+            onPress={() => setDowntime(r)}
+            className={`rounded-full px-3 py-1.5 ${
+              downtime === r ? 'bg-brand' : 'bg-slate-200'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                downtime === r ? 'text-ink' : 'text-slate-600'
+              }`}
+            >
+              {r}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <TextInput
+        value={remarks}
+        onChangeText={setRemarks}
+        placeholder="Remarks (optional)"
+        placeholderTextColor="#94a3b8"
+        multiline
+        className="mt-3 min-h-[60px] rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-ink"
+      />
+
+      <Pressable
+        onPress={submit}
+        disabled={save.isPending || !productId || qty.trim() === ''}
+        className={`mt-4 items-center rounded-xl py-3 ${
+          save.isPending || !productId || qty.trim() === ''
+            ? 'bg-slate-200'
+            : 'bg-brand active:opacity-80'
+        }`}
+      >
+        {save.isPending ? (
+          <ActivityIndicator size="small" color="#0f172a" />
+        ) : (
+          <Text className="font-bold text-ink">Save production day</Text>
+        )}
+      </Pressable>
+
+      {/* recent entries */}
+      <Text className="mb-2 mt-6 text-sm font-bold text-ink">Recent days</Text>
+      {(log.data?.data ?? []).slice(0, 14).map((r) => (
+        <View
+          key={r.id}
+          className="mb-1.5 flex-row items-center rounded-xl border border-slate-200 bg-white px-3.5 py-2.5"
+        >
+          <Text className="w-20 text-xs text-slate-400">{r.log_date.slice(5)}</Text>
+          <Text className="w-14 text-sm font-semibold text-ink">
+            {r.factory_products?.code}
+          </Text>
+          <Text className="w-16 text-right text-sm font-medium text-ink">
+            {Number(r.qty_produced).toLocaleString('en-IN')}
+          </Text>
+          <Text className="flex-1 pl-2 text-xs text-slate-400" numberOfLines={1}>
+            {r.downtime_reason !== 'None' ? `⚠️ ${r.downtime_reason}` : ''}
+          </Text>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}

--- a/apps/native/src/hooks/use-factory.ts
+++ b/apps/native/src/hooks/use-factory.ts
@@ -1,0 +1,146 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { toast } from '@/lib/toast';
+
+// ---- shapes mirrored from /api/factory (keep in sync with apps/web) ----
+
+export type FactoryStockRow = {
+  id: string;
+  code: string;
+  opening_stock: number | null;
+  opening_counted_at: string | null;
+  produced: number;
+  delivered: number;
+  committed: number;
+  stock_balance: number;
+  free_stock: number;
+  bricks_per_bag: number | null;
+};
+
+export type FactoryProduct = { id: string; code: string };
+
+export type FactoryDelivery = {
+  id: string;
+  delivery_date: string;
+  qty: number;
+  status: 'Planned' | 'Delivered' | 'Postponed' | 'Cancelled';
+  data_flag: string;
+  notes: string | null;
+  factory_customers: { name: string; credit_hold: boolean } | null;
+  factory_products: { code: string } | null;
+};
+
+export type FactoryLogRow = {
+  id: string;
+  log_date: string;
+  qty_produced: number;
+  cement_bags: number | null;
+  downtime_reason: string;
+  remarks: string | null;
+  data_flag: string;
+  factory_products: { code: string } | null;
+};
+
+// ---- hooks ----
+
+export function useFactoryStock() {
+  return useQuery({
+    queryKey: ['factory', 'stock'],
+    queryFn: () => api.get<FactoryStockRow[]>('/api/factory/stock'),
+  });
+}
+
+export function useFactoryProducts() {
+  return useQuery({
+    queryKey: ['factory', 'products'],
+    queryFn: () => api.get<FactoryProduct[]>('/api/factory/products'),
+  });
+}
+
+/** Sat–Fri schedule; pass any date inside the wanted week. */
+export function useFactorySchedule(week: string) {
+  return useQuery({
+    queryKey: ['factory', 'schedule', week],
+    queryFn: () =>
+      api.get<FactoryDelivery[]>('/api/factory/deliveries', { week }),
+  });
+}
+
+export function useFactoryLog() {
+  return useQuery({
+    queryKey: ['factory', 'log'],
+    queryFn: () => api.get<FactoryLogRow[]>('/api/factory/production-log'),
+  });
+}
+
+/** Upsert a production day (date+product). Re-submitting edits, not duplicates. */
+export function useSaveProductionLog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: {
+      log_date: string;
+      product_id: string;
+      qty_produced: number;
+      cement_bags: number | null;
+      downtime_reason: string;
+      remarks: string | null;
+    }) => api.post('/api/factory/production-log', body),
+    onSuccess: () => {
+      toast.success('Production day saved');
+      void queryClient.invalidateQueries({ queryKey: ['factory'] });
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : 'Failed to save production'),
+  });
+}
+
+/** Planned → Delivered / Postponed with optimistic update. */
+export function useUpdateDeliveryStatus(week: string) {
+  const queryClient = useQueryClient();
+  const key = ['factory', 'schedule', week];
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: FactoryDelivery['status'] }) =>
+      api.patch(`/api/factory/deliveries/${id}`, { status }),
+    onMutate: async ({ id, status }) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<{ data: FactoryDelivery[] }>(key);
+      if (prev?.data) {
+        queryClient.setQueryData(key, {
+          ...prev,
+          data: prev.data.map((d) => (d.id === id ? { ...d, status } : d)),
+        });
+      }
+      return { prev };
+    },
+    onError: (e, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(key, ctx.prev);
+      toast.error(e instanceof Error ? e.message : 'Update failed');
+    },
+    onSuccess: (_res, vars) => {
+      toast.success(vars.status === 'Delivered' ? '✓ Marked delivered' : 'Updated');
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['factory'] });
+    },
+  });
+}
+
+export function useSaveLabour() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: {
+      work_date: string;
+      worker: string;
+      work_type: string;
+      qty: number;
+      rate: number;
+      notes: string | null;
+    }) => api.post('/api/factory/labour', body),
+    onSuccess: () => {
+      toast.success('Labour entry saved');
+      void queryClient.invalidateQueries({ queryKey: ['factory'] });
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : 'Failed to save labour'),
+  });
+}

--- a/apps/native/src/lib/factory.ts
+++ b/apps/native/src/lib/factory.ts
@@ -1,0 +1,134 @@
+/**
+ * Factory Ledger shared helpers.
+ *
+ * Sat–Fri reporting weeks, product metadata derived from SKU codes, row-label
+ * composers, and the picklist enums shared by Zod schemas and UI pickers.
+ * Mirrors public.factory_week_start() in the database.
+ *
+ * A pure copy of this file lives at apps/native/src/lib/factory.ts (the native
+ * app has a standalone node_modules tree) — keep the two in sync.
+ */
+
+/** Parse 'YYYY-MM-DD' by components. NEVER new Date('YYYY-MM-DD') — that
+ * parses as UTC midnight, which is the previous day in IST and silently
+ * shifts Sat/Fri week boundaries. */
+export function parseISODate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function toISODate(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Sat–Fri reporting week: the Saturday on or before the given date.
+ * JS getDay(): Sun=0 … Sat=6 → offset (day+1)%7 (Sat→0, Sun→1, Fri→6). */
+export function factoryWeekStart(iso: string): string {
+  const d = parseISODate(iso);
+  d.setDate(d.getDate() - ((d.getDay() + 1) % 7));
+  return toISODate(d);
+}
+
+/** Friday that ends the Sat–Fri week containing the given date. */
+export function factoryWeekEnd(iso: string): string {
+  const d = parseISODate(factoryWeekStart(iso));
+  d.setDate(d.getDate() + 6);
+  return toISODate(d);
+}
+
+/** 'DD/MM' for composed row labels ("04/08 Umapathi Sriperumbudur 1000 CIB-6"). */
+export function shortDate(iso: string): string {
+  const [, m, d] = iso.split('-');
+  return `${d}/${m}`;
+}
+
+// ---------------------------------------------------------------- products
+
+export type FactoryProductCode = 'MIB-8' | 'MIB-6' | 'CIB-8' | 'CIB-6';
+
+export const FACTORY_PRODUCT_CODES: FactoryProductCode[] = [
+  'MIB-8',
+  'MIB-6',
+  'CIB-8',
+  'CIB-6',
+];
+
+/** Type, size and labour rate derive from the code — never stored.
+ * 8" bricks pay ₹7/brick, 6" pay ₹6. Loading is ₹3/brick for every size. */
+export function productMeta(code: FactoryProductCode): {
+  type: 'MIB' | 'CIB';
+  size: '8"' | '6"';
+  labourRate: 7 | 6;
+} {
+  const size = code.endsWith('8') ? '8"' : '6"';
+  return {
+    type: code.startsWith('MIB') ? 'MIB' : 'CIB',
+    size,
+    labourRate: size === '8"' ? 7 : 6,
+  };
+}
+
+export const LOADING_RATE_PER_BRICK = 3;
+
+// ----------------------------------------------------------------- enums
+
+export const DOWNTIME_REASONS = [
+  'None',
+  'Power Cut',
+  'Machine Breakdown',
+  'Raw Material Shortage',
+  'Labour Shortage',
+  'Dye / Profile Change',
+  'Payment Issue',
+  'Holiday',
+  'Other',
+] as const;
+
+export const DATA_FLAGS_PRODUCTION = ['OK', 'Estimated', 'Check - sources disagree'] as const;
+export const DATA_FLAGS_DELIVERY = ['OK', 'Check - sources disagree', 'Qty to confirm'] as const;
+export const DELIVERY_STATUSES = ['Planned', 'Delivered', 'Postponed', 'Cancelled'] as const;
+export const PAYMENT_STATUSES = ['Clear', 'Hold - Payment', 'Cancelled'] as const;
+export const VEHICLES = ['407 Eicher', '439 RDX Tractor', 'Tricycle', 'Other'] as const;
+export const WORK_TYPES = ['Loading', 'Production 6"', 'Production 8"', 'NMR Daily', 'Advance'] as const;
+export const ASSET_CATEGORIES = [
+  'Machinery',
+  'Machinery Tools',
+  'Mechanical Tools',
+  'Vehicles',
+  'Construction Tools',
+  'Electrical & Electronic Tools',
+] as const;
+export const ASSET_LOCATIONS = ['Plant', 'RTO', 'VM', 'Split - see notes', 'Unknown'] as const;
+
+// ---------------------------------------------------------- label composers
+// Row identity is composed from the row's own data — no hand-typed codes.
+
+export function deliveryLabel(d: {
+  delivery_date: string;
+  customer_name: string;
+  qty: number;
+  product_code: string;
+}): string {
+  return `${shortDate(d.delivery_date)} ${d.customer_name} ${d.qty} ${d.product_code}`;
+}
+
+export function orderLabel(o: {
+  customer_name: string;
+  qty_ordered: number;
+  product_code: string;
+}): string {
+  return `${o.customer_name} - ${o.qty_ordered} ${o.product_code}`;
+}
+
+export function productionLabel(r: { log_date: string; product_code: string }): string {
+  return `${shortDate(r.log_date)} ${r.product_code}`;
+}
+
+export function labourLabel(l: {
+  work_date: string;
+  worker: string;
+  work_type: string;
+}): string {
+  return `${shortDate(l.work_date)} ${l.worker} - ${l.work_type}`;
+}

--- a/apps/web/app/(dashboard)/factory/data/page.tsx
+++ b/apps/web/app/(dashboard)/factory/data/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fmt, getFactory, sendFactory } from "@/components/factory/shared";
+
+type Product = {
+  id: string;
+  code: string;
+  opening_stock: number | null;
+  opening_counted_at: string | null;
+  notes: string | null;
+};
+type Customer = {
+  id: string;
+  name: string;
+  location: string | null;
+  phone: string | null;
+  credit_hold: boolean;
+  notes: string | null;
+};
+type Trip = {
+  id: string;
+  trip_date: string;
+  vehicle: string;
+  start_km: number | null;
+  end_km: number | null;
+  diesel_litres: number | null;
+  notes: string | null;
+};
+type Asset = {
+  id: string;
+  asset: string;
+  category: string;
+  qty: number;
+  location: string;
+  notes: string | null;
+};
+
+// Low-traffic CRUD: products (the opening stock-take entry lives HERE),
+// customers, trips, asset register.
+export default function FactoryDataPage() {
+  const queryClient = useQueryClient();
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ["factory"] });
+
+  const products = useQuery({
+    queryKey: ["factory", "products"],
+    queryFn: () => getFactory<Product[]>("products"),
+  });
+  const customers = useQuery({
+    queryKey: ["factory", "customers"],
+    queryFn: () => getFactory<Customer[]>("customers"),
+  });
+  const trips = useQuery({
+    queryKey: ["factory", "trips"],
+    queryFn: () => getFactory<Trip[]>("trips"),
+  });
+  const assets = useQuery({
+    queryKey: ["factory", "assets"],
+    queryFn: () => getFactory<Asset[]>("assets"),
+  });
+
+  const [openingDraft, setOpeningDraft] = useState<Record<string, string>>({});
+  const saveOpening = useMutation({
+    mutationFn: ({ id, value }: { id: string; value: number }) =>
+      sendFactory("products", "PATCH", { id, opening_stock: value }),
+    onSuccess: invalidate,
+  });
+
+  const toggleHold = useMutation({
+    mutationFn: (c: Customer) =>
+      sendFactory("customers", "PATCH", { id: c.id, credit_hold: !c.credit_hold }),
+    onSuccess: invalidate,
+  });
+
+  return (
+    <div className="space-y-8">
+      {/* ------------------------------------------- opening stock-take */}
+      <section>
+        <h2 className="mb-1 text-sm font-bold uppercase tracking-wide text-slate-500">
+          Products — opening stock (physical count as at 01/07)
+        </h2>
+        <p className="mb-3 text-xs text-slate-400">
+          Entering a count records today as the stock-take date and clears the
+          warning banner. A genuine count of 0 is valid.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {(products.data ?? []).map((p) => (
+            <div
+              key={p.id}
+              className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-bold">{p.code}</span>
+                {p.opening_counted_at ? (
+                  <span className="text-xs text-emerald-600">✓ counted {p.opening_counted_at}</span>
+                ) : (
+                  <span className="text-xs font-semibold text-amber-600">not counted</span>
+                )}
+              </div>
+              <div className="mt-2 flex gap-2">
+                <input
+                  type="number"
+                  min={0}
+                  placeholder={p.opening_stock != null ? String(p.opening_stock) : "count"}
+                  value={openingDraft[p.id] ?? ""}
+                  onChange={(e) => setOpeningDraft({ ...openingDraft, [p.id]: e.target.value })}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-1.5 text-sm dark:border-slate-600 dark:bg-slate-900"
+                />
+                <button
+                  onClick={() =>
+                    saveOpening.mutate({ id: p.id, value: Number(openingDraft[p.id]) })
+                  }
+                  disabled={saveOpening.isPending || openingDraft[p.id] === undefined || openingDraft[p.id] === ""}
+                  className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-40 dark:bg-white dark:text-slate-900"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+        {saveOpening.isError ? (
+          <p className="mt-2 text-sm text-red-600">
+            {saveOpening.error instanceof Error ? saveOpening.error.message : "Failed"}
+          </p>
+        ) : null}
+      </section>
+
+      {/* --------------------------------------------------- customers */}
+      <section>
+        <h2 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">
+          Customers ({(customers.data ?? []).length})
+        </h2>
+        <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+                <th className="px-4 py-2.5">Name</th>
+                <th className="px-3 py-2.5">Location</th>
+                <th className="px-3 py-2.5">Credit</th>
+                <th className="px-3 py-2.5">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(customers.data ?? []).map((c) => (
+                <tr key={c.id} className="border-b border-slate-100 last:border-0 dark:border-slate-700/50">
+                  <td className="px-4 py-2 font-medium">{c.name}</td>
+                  <td className="px-3 py-2 text-slate-500">{c.location ?? "—"}</td>
+                  <td className="px-3 py-2">
+                    <button
+                      onClick={() => toggleHold.mutate(c)}
+                      disabled={toggleHold.isPending}
+                      className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                        c.credit_hold
+                          ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200"
+                          : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+                      }`}
+                    >
+                      {c.credit_hold ? "ON HOLD" : "Clear"}
+                    </button>
+                  </td>
+                  <td className="max-w-md truncate px-3 py-2 text-xs text-slate-400">{c.notes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ------------------------------------------------------- trips */}
+      <section>
+        <h2 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">
+          Vehicle log ({(trips.data ?? []).length} trips)
+        </h2>
+        <div className="space-y-1.5">
+          {(trips.data ?? []).map((t) => {
+            const km = t.start_km != null && t.end_km != null ? t.end_km - t.start_km : null;
+            const kmpl =
+              km != null && t.diesel_litres ? Math.round((km / t.diesel_litres) * 100) / 100 : null;
+            return (
+              <div
+                key={t.id}
+                className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <span className="w-20 text-xs text-slate-400">{t.trip_date}</span>
+                <span className="w-32 font-medium">{t.vehicle}</span>
+                <span className="text-xs text-slate-500">
+                  {km != null ? `${fmt(km)} km` : "—"}
+                  {t.diesel_litres ? ` · ${t.diesel_litres} L` : ""}
+                  {kmpl != null ? ` · ${kmpl} km/L` : ""}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs text-slate-400">{t.notes}</span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ------------------------------------------------------ assets */}
+      <section>
+        <h2 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">
+          Asset register ({(assets.data ?? []).length})
+        </h2>
+        <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+                <th className="px-4 py-2.5">Asset</th>
+                <th className="px-3 py-2.5">Category</th>
+                <th className="px-3 py-2.5 text-right">Qty</th>
+                <th className="px-3 py-2.5">Location</th>
+                <th className="px-3 py-2.5">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(assets.data ?? []).map((a) => (
+                <tr key={a.id} className="border-b border-slate-100 last:border-0 dark:border-slate-700/50">
+                  <td className="px-4 py-2 font-medium">{a.asset}</td>
+                  <td className="px-3 py-2 text-xs text-slate-500">{a.category}</td>
+                  <td className="px-3 py-2 text-right">{fmt(a.qty)}</td>
+                  <td className="px-3 py-2 text-xs text-slate-500">{a.location}</td>
+                  <td className="max-w-xs truncate px-3 py-2 text-xs text-slate-400">{a.notes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/labour/page.tsx
+++ b/apps/web/app/(dashboard)/factory/labour/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fmt, getFactory, sendFactory, WeekPicker } from "@/components/factory/shared";
+import { factoryWeekStart, toISODate, WORK_TYPES } from "@/lib/factory";
+
+type LabourWeek = {
+  week_start: string;
+  week_end: string;
+  entries: {
+    id: string;
+    work_date: string;
+    worker: string;
+    work_type: string;
+    qty: number;
+    rate: number;
+    notes: string | null;
+  }[];
+  workers: { worker: string; gross: number; advances: number; net: number; entries: number }[];
+  totals: { gross: number; advances: number; net: number };
+};
+
+const inr = (n: number) =>
+  `₹${Math.abs(n).toLocaleString("en-IN", { maximumFractionDigits: 0 })}`;
+
+// View 7: weekly labour — gross, advances, net payable. Advance entries are
+// qty 1 × negative rate so a plain sum nets out automatically.
+export default function FactoryLabourPage() {
+  const queryClient = useQueryClient();
+  const [week, setWeek] = useState(toISODate(new Date()));
+  const ws = factoryWeekStart(week);
+
+  const data = useQuery({
+    queryKey: ["factory", "labour-week", ws],
+    queryFn: () => getFactory<LabourWeek>(`reports/labour-week?week=${ws}`),
+  });
+
+  const [form, setForm] = useState({
+    work_date: new Date().toISOString().slice(0, 10),
+    worker: "",
+    work_type: "Loading",
+    qty: "",
+    rate: "",
+    notes: "",
+  });
+  const isAdvance = form.work_type === "Advance";
+
+  const create = useMutation({
+    mutationFn: () =>
+      sendFactory("labour", "POST", {
+        ...form,
+        qty: isAdvance ? 1 : Number(form.qty),
+        rate: isAdvance ? -Math.abs(Number(form.rate)) : Number(form.rate),
+        notes: form.notes || null,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["factory"] });
+      setForm((f) => ({ ...f, qty: "", rate: "", notes: "" }));
+    },
+  });
+
+  const input =
+    "rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900";
+
+  return (
+    <div className="space-y-4">
+      <WeekPicker week={week} onChange={setWeek} />
+
+      {/* entry form */}
+      <div className="grid grid-cols-2 gap-2 rounded-2xl border border-slate-200 bg-white p-4 lg:grid-cols-6 dark:border-slate-700 dark:bg-slate-800">
+        <input
+          type="date"
+          value={form.work_date}
+          onChange={(e) => setForm({ ...form, work_date: e.target.value })}
+          className={input}
+        />
+        <input
+          placeholder="Worker"
+          value={form.worker}
+          onChange={(e) => setForm({ ...form, worker: e.target.value })}
+          className={input}
+        />
+        <select
+          value={form.work_type}
+          onChange={(e) => setForm({ ...form, work_type: e.target.value })}
+          className={input}
+        >
+          {WORK_TYPES.map((t) => (
+            <option key={t}>{t}</option>
+          ))}
+        </select>
+        {!isAdvance ? (
+          <input
+            type="number"
+            placeholder="Qty (bricks/days)"
+            value={form.qty}
+            onChange={(e) => setForm({ ...form, qty: e.target.value })}
+            className={input}
+          />
+        ) : (
+          <span className="flex items-center px-2 text-xs text-slate-400">qty = 1</span>
+        )}
+        <input
+          type="number"
+          placeholder={isAdvance ? "Advance amount ₹" : "Rate ₹"}
+          value={form.rate}
+          onChange={(e) => setForm({ ...form, rate: e.target.value })}
+          className={input}
+        />
+        <input
+          placeholder="Notes"
+          value={form.notes}
+          onChange={(e) => setForm({ ...form, notes: e.target.value })}
+          className={input}
+        />
+        <div className="col-span-2 flex items-center gap-3 lg:col-span-6">
+          <button
+            onClick={() => create.mutate()}
+            disabled={
+              create.isPending || !form.worker || !form.rate || (!isAdvance && !form.qty)
+            }
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+          >
+            {create.isPending ? "Saving…" : isAdvance ? "Record advance" : "Save entry"}
+          </button>
+          {create.isError ? (
+            <p className="text-sm text-red-600">
+              {create.error instanceof Error ? create.error.message : "Failed"}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {/* weekly summary */}
+      {data.data ? (
+        <>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+              <p className="text-xs uppercase text-slate-400">Gross earned</p>
+              <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                {inr(data.data.totals.gross)}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+              <p className="text-xs uppercase text-slate-400">Advances</p>
+              <p className="text-2xl font-bold text-amber-600">
+                −{inr(data.data.totals.advances)}
+              </p>
+            </div>
+            <div className="rounded-2xl border-2 border-slate-900 bg-white p-4 dark:border-white dark:bg-slate-800">
+              <p className="text-xs uppercase text-slate-400">Net payable</p>
+              <p className="text-2xl font-bold text-emerald-600">{inr(data.data.totals.net)}</p>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+                  <th className="px-4 py-3">Worker</th>
+                  <th className="px-3 py-3 text-right">Gross</th>
+                  <th className="px-3 py-3 text-right">Advances</th>
+                  <th className="px-3 py-3 text-right">Net</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.data.workers.map((w) => (
+                  <tr key={w.worker} className="border-b border-slate-100 last:border-0 dark:border-slate-700/50">
+                    <td className="px-4 py-2.5 font-medium">{w.worker}</td>
+                    <td className="px-3 py-2.5 text-right">{inr(w.gross)}</td>
+                    <td className="px-3 py-2.5 text-right text-amber-600">
+                      {w.advances !== 0 ? `−${inr(w.advances)}` : "—"}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-semibold">{inr(w.net)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="space-y-1.5">
+            <h3 className="text-xs font-semibold uppercase text-slate-400">Entries this week</h3>
+            {data.data.entries.map((e) => (
+              <div
+                key={e.id}
+                className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <span className="w-20 shrink-0 text-xs text-slate-400">{e.work_date}</span>
+                <span className="w-32 shrink-0 font-medium">{e.worker}</span>
+                <span className="w-28 shrink-0 text-xs text-slate-500">{e.work_type}</span>
+                <span className="w-24 shrink-0 text-right text-xs text-slate-400">
+                  {fmt(e.qty)} × {e.rate}
+                </span>
+                <span
+                  className={`w-24 shrink-0 text-right font-semibold ${
+                    e.qty * e.rate < 0 ? "text-amber-600" : ""
+                  }`}
+                >
+                  {e.qty * e.rate < 0 ? "−" : ""}
+                  {inr(e.qty * e.rate)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs text-slate-400">{e.notes}</span>
+              </div>
+            ))}
+            {data.data.entries.length === 0 ? (
+              <p className="text-sm text-slate-400">No entries this week.</p>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <p className="py-6 text-center text-slate-400">{data.isLoading ? "Loading…" : "No data."}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/layout.tsx
+++ b/apps/web/app/(dashboard)/factory/layout.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { StockTakeBanner } from "@/components/factory/shared";
+
+const TABS = [
+  { href: "/factory", label: "Overview" },
+  { href: "/factory/orders", label: "Orders" },
+  { href: "/factory/schedule", label: "Schedule" },
+  { href: "/factory/production", label: "Production" },
+  { href: "/factory/reports", label: "Reports" },
+  { href: "/factory/labour", label: "Labour" },
+  { href: "/factory/data", label: "Data" },
+];
+
+export default function FactoryLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+          🏭 Factory Ledger
+        </h1>
+        <p className="text-sm text-slate-500">
+          Stock, orders, plan vs actual and labour — replaces the factory sheet.
+          Reporting weeks run Saturday to Friday.
+        </p>
+      </div>
+
+      <nav className="flex flex-wrap gap-1.5">
+        {TABS.map((t) => {
+          const active =
+            t.href === "/factory" ? pathname === "/factory" : pathname.startsWith(t.href);
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              className={`rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                  : "bg-white text-slate-600 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              }`}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <StockTakeBanner />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/orders/page.tsx
+++ b/apps/web/app/(dashboard)/factory/orders/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fmt, getFactory, sendFactory, DataFlagBadge } from "@/components/factory/shared";
+
+type OrderRow = {
+  id: string;
+  order_date: string;
+  customer_name: string;
+  credit_hold: boolean;
+  product_code: string;
+  qty_ordered: number;
+  delivered: number;
+  balance_due: number;
+  fulfilment: string;
+  payment_status: string;
+  notes: string | null;
+};
+
+type Customer = { id: string; name: string; credit_hold: boolean };
+type Product = { id: string; code: string };
+
+// View 2: open orders, oldest first, credit-hold flagged.
+export default function FactoryOrdersPage() {
+  const queryClient = useQueryClient();
+  const [showAll, setShowAll] = useState(false);
+  const [formOpen, setFormOpen] = useState(false);
+
+  const orders = useQuery({
+    queryKey: ["factory", "orders", showAll],
+    queryFn: () => getFactory<OrderRow[]>(`orders${showAll ? "" : "?status=open"}`),
+  });
+  const customers = useQuery({
+    queryKey: ["factory", "customers"],
+    queryFn: () => getFactory<Customer[]>("customers"),
+  });
+  const products = useQuery({
+    queryKey: ["factory", "products"],
+    queryFn: () => getFactory<Product[]>("products"),
+  });
+
+  const [form, setForm] = useState({
+    customer_id: "",
+    product_id: "",
+    order_date: new Date().toISOString().slice(0, 10),
+    qty_ordered: "",
+    payment_status: "Clear",
+    notes: "",
+  });
+  const create = useMutation({
+    mutationFn: () =>
+      sendFactory("orders", "POST", {
+        ...form,
+        qty_ordered: Number(form.qty_ordered),
+        notes: form.notes || null,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["factory"] });
+      setFormOpen(false);
+      setForm((f) => ({ ...f, qty_ordered: "", notes: "" }));
+    },
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-2 text-sm text-slate-500">
+          <input
+            type="checkbox"
+            checked={showAll}
+            onChange={(e) => setShowAll(e.target.checked)}
+          />
+          Show completed & cancelled
+        </label>
+        <button
+          onClick={() => setFormOpen((v) => !v)}
+          className="rounded-lg bg-slate-900 px-3.5 py-2 text-sm font-semibold text-white dark:bg-white dark:text-slate-900"
+        >
+          + New order
+        </button>
+      </div>
+
+      {formOpen ? (
+        <div className="grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 sm:grid-cols-2 lg:grid-cols-3 dark:border-slate-700 dark:bg-slate-800">
+          <select
+            value={form.customer_id}
+            onChange={(e) => setForm({ ...form, customer_id: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          >
+            <option value="">Customer…</option>
+            {(customers.data ?? []).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+                {c.credit_hold ? " (CREDIT HOLD)" : ""}
+              </option>
+            ))}
+          </select>
+          <select
+            value={form.product_id}
+            onChange={(e) => setForm({ ...form, product_id: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          >
+            <option value="">Product…</option>
+            {(products.data ?? []).map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.code}
+              </option>
+            ))}
+          </select>
+          <input
+            type="date"
+            value={form.order_date}
+            onChange={(e) => setForm({ ...form, order_date: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          />
+          <input
+            type="number"
+            min={1}
+            placeholder="Qty ordered"
+            value={form.qty_ordered}
+            onChange={(e) => setForm({ ...form, qty_ordered: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          />
+          <select
+            value={form.payment_status}
+            onChange={(e) => setForm({ ...form, payment_status: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          >
+            <option>Clear</option>
+            <option>Hold - Payment</option>
+            <option>Cancelled</option>
+          </select>
+          <input
+            placeholder="Notes"
+            value={form.notes}
+            onChange={(e) => setForm({ ...form, notes: e.target.value })}
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+          />
+          <div className="flex items-center gap-3 sm:col-span-2 lg:col-span-3">
+            <button
+              onClick={() => create.mutate()}
+              disabled={create.isPending || !form.customer_id || !form.product_id || !form.qty_ordered}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+            >
+              {create.isPending ? "Saving…" : "Save order"}
+            </button>
+            {create.isError ? (
+              <p className="text-sm text-red-600">
+                {create.error instanceof Error ? create.error.message : "Failed"}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-400 dark:border-slate-700">
+              <th className="px-4 py-3">Order</th>
+              <th className="px-3 py-3 text-right">Ordered</th>
+              <th className="px-3 py-3 text-right">Delivered</th>
+              <th className="px-3 py-3 text-right">Balance due</th>
+              <th className="px-3 py-3">Fulfilment</th>
+              <th className="px-3 py-3">Payment</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.isLoading ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">
+                  Loading…
+                </td>
+              </tr>
+            ) : (orders.data ?? []).length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">
+                  No open orders 🎉
+                </td>
+              </tr>
+            ) : (
+              (orders.data ?? []).map((o) => (
+                <tr
+                  key={o.id}
+                  className="border-b border-slate-100 last:border-0 dark:border-slate-700/50"
+                >
+                  <td className="px-4 py-3">
+                    <p className="font-medium text-slate-900 dark:text-white">
+                      {o.customer_name} — {fmt(o.qty_ordered)} {o.product_code}
+                      {o.credit_hold ? (
+                        <span className="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700 dark:bg-red-900 dark:text-red-200">
+                          CREDIT HOLD
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {o.order_date}
+                      {o.notes ? ` · ${o.notes}` : ""}
+                    </p>
+                  </td>
+                  <td className="px-3 py-3 text-right">{fmt(o.qty_ordered)}</td>
+                  <td className="px-3 py-3 text-right">{fmt(o.delivered)}</td>
+                  <td className="px-3 py-3 text-right font-semibold">{fmt(o.balance_due)}</td>
+                  <td className="px-3 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        o.fulfilment === "Complete"
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+                          : o.fulfilment === "Partial"
+                            ? "bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                            : "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+                      }`}
+                    >
+                      {o.fulfilment}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3">
+                    {o.payment_status !== "Clear" ? <DataFlagBadge flag={o.payment_status} /> : "Clear"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/page.tsx
+++ b/apps/web/app/(dashboard)/factory/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fmt, getFactory, useStock } from "@/components/factory/shared";
+import { productMeta, toISODate, type FactoryProductCode } from "@/lib/factory";
+
+type PlanVsActual = {
+  week_start: string;
+  week_end: string;
+  totals: {
+    planned: number;
+    actual: number;
+    variance: number;
+    achievement_pct: number | null;
+  };
+};
+
+// Overview: live stock (View 1) with free_stock as the hero number, plus a
+// this-week plan-vs-actual strip.
+export default function FactoryOverviewPage() {
+  const stock = useStock();
+  const pva = useQuery({
+    queryKey: ["factory", "pva", "current"],
+    queryFn: () =>
+      getFactory<PlanVsActual>(`reports/plan-vs-actual?week=${toISODate(new Date())}`),
+  });
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">
+          Live stock by product
+        </h2>
+        {stock.isLoading ? (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-44 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {(stock.data ?? []).map((p) => {
+              const meta = productMeta(p.code as FactoryProductCode);
+              const negative = p.free_stock < 0;
+              return (
+                <div
+                  key={p.id}
+                  className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-base font-bold text-slate-900 dark:text-white">
+                      {p.code}
+                    </span>
+                    <span className="text-xs text-slate-400">
+                      {meta.type} · {meta.size}
+                    </span>
+                  </div>
+                  <p
+                    className={`mt-2 text-3xl font-bold ${
+                      negative ? "text-red-600" : "text-emerald-600"
+                    }`}
+                  >
+                    {fmt(p.free_stock)}
+                  </p>
+                  <p className="text-xs text-slate-400">free stock (promisable)</p>
+                  <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-slate-500">
+                    <dt>Opening</dt>
+                    <dd className="text-right">
+                      {p.opening_counted_at ? fmt(p.opening_stock) : "not counted"}
+                    </dd>
+                    <dt>Produced</dt>
+                    <dd className="text-right">{fmt(p.produced)}</dd>
+                    <dt>Delivered</dt>
+                    <dd className="text-right">{fmt(p.delivered)}</dd>
+                    <dt>Committed</dt>
+                    <dd className="text-right">{fmt(p.committed)}</dd>
+                    <dt>Balance</dt>
+                    <dd className={`text-right font-semibold ${p.stock_balance < 0 ? "text-red-600" : ""}`}>
+                      {fmt(p.stock_balance)}
+                    </dd>
+                    <dt>Bricks/bag</dt>
+                    <dd className="text-right">{p.bricks_per_bag ?? "—"}</dd>
+                  </dl>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+          This week — plan vs actual
+        </h2>
+        {pva.data ? (
+          <div className="mt-2 flex flex-wrap items-end gap-6">
+            <div>
+              <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                {fmt(pva.data.totals.actual)}
+                <span className="text-sm font-normal text-slate-400">
+                  {" "}/ {fmt(pva.data.totals.planned)} planned
+                </span>
+              </p>
+              <p className="text-xs text-slate-400">
+                {pva.data.week_start} → {pva.data.week_end}
+              </p>
+            </div>
+            <p
+              className={`text-lg font-semibold ${
+                (pva.data.totals.variance ?? 0) < 0 ? "text-red-600" : "text-emerald-600"
+              }`}
+            >
+              {pva.data.totals.variance >= 0 ? "+" : ""}
+              {fmt(pva.data.totals.variance)} variance
+            </p>
+            {pva.data.totals.achievement_pct != null ? (
+              <p className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+                {pva.data.totals.achievement_pct}% achieved
+              </p>
+            ) : null}
+            <a href="/factory/reports" className="ml-auto text-sm font-medium text-blue-600 underline">
+              Full reports →
+            </a>
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-slate-400">
+            {pva.isLoading ? "Loading…" : "No plan rows for the current week."}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/production/page.tsx
+++ b/apps/web/app/(dashboard)/factory/production/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { DataFlagBadge, fmt, getFactory, sendFactory } from "@/components/factory/shared";
+import { DOWNTIME_REASONS } from "@/lib/factory";
+
+type Product = { id: string; code: string };
+type LogRow = {
+  id: string;
+  log_date: string;
+  qty_produced: number;
+  cement_bags: number | null;
+  downtime_reason: string;
+  remarks: string | null;
+  data_flag: string;
+  factory_products: { code: string } | null;
+};
+type PlanRow = {
+  id: string;
+  plan_date: string;
+  planned_qty: number;
+  plan_note: string | null;
+  factory_products: { code: string } | null;
+};
+
+// Daily production entry: log (one row per date+product — resubmitting the
+// same pair edits it) and forward plan, side by side.
+export default function FactoryProductionPage() {
+  const queryClient = useQueryClient();
+  const products = useQuery({
+    queryKey: ["factory", "products"],
+    queryFn: () => getFactory<Product[]>("products"),
+  });
+  const log = useQuery({
+    queryKey: ["factory", "production-log"],
+    queryFn: () => getFactory<LogRow[]>("production-log"),
+  });
+  const plan = useQuery({
+    queryKey: ["factory", "production-plan"],
+    queryFn: () => getFactory<PlanRow[]>("production-plan"),
+  });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const [logForm, setLogForm] = useState({
+    log_date: today,
+    product_id: "",
+    qty_produced: "",
+    cement_bags: "",
+    downtime_reason: "None",
+    remarks: "",
+  });
+  const [planForm, setPlanForm] = useState({
+    plan_date: today,
+    product_id: "",
+    planned_qty: "",
+    plan_note: "",
+  });
+
+  const saveLog = useMutation({
+    mutationFn: () =>
+      sendFactory("production-log", "POST", {
+        ...logForm,
+        qty_produced: Number(logForm.qty_produced),
+        cement_bags: logForm.cement_bags === "" ? null : Number(logForm.cement_bags),
+        remarks: logForm.remarks || null,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["factory"] });
+      setLogForm((f) => ({ ...f, qty_produced: "", cement_bags: "", remarks: "" }));
+    },
+  });
+  const savePlan = useMutation({
+    mutationFn: () =>
+      sendFactory("production-plan", "POST", {
+        ...planForm,
+        planned_qty: Number(planForm.planned_qty),
+        plan_note: planForm.plan_note || null,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["factory"] });
+      setPlanForm((f) => ({ ...f, planned_qty: "", plan_note: "" }));
+    },
+  });
+
+  const input =
+    "rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900";
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-2">
+      {/* ------------------------------------------------ production log */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+          Production log <span className="font-normal">(actuals — one row per day & product)</span>
+        </h2>
+        <div className="grid grid-cols-2 gap-2 rounded-2xl border border-slate-200 bg-white p-4 lg:grid-cols-3 dark:border-slate-700 dark:bg-slate-800">
+          <input
+            type="date"
+            value={logForm.log_date}
+            onChange={(e) => setLogForm({ ...logForm, log_date: e.target.value })}
+            className={input}
+          />
+          <select
+            value={logForm.product_id}
+            onChange={(e) => setLogForm({ ...logForm, product_id: e.target.value })}
+            className={input}
+          >
+            <option value="">Product…</option>
+            {(products.data ?? []).map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.code}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min={0}
+            placeholder="Qty produced"
+            value={logForm.qty_produced}
+            onChange={(e) => setLogForm({ ...logForm, qty_produced: e.target.value })}
+            className={input}
+          />
+          <input
+            type="number"
+            min={0}
+            step={0.1}
+            placeholder="Cement bags"
+            value={logForm.cement_bags}
+            onChange={(e) => setLogForm({ ...logForm, cement_bags: e.target.value })}
+            className={input}
+          />
+          <select
+            value={logForm.downtime_reason}
+            onChange={(e) => setLogForm({ ...logForm, downtime_reason: e.target.value })}
+            className={input}
+          >
+            {DOWNTIME_REASONS.map((r) => (
+              <option key={r}>{r}</option>
+            ))}
+          </select>
+          <input
+            placeholder="Remarks"
+            value={logForm.remarks}
+            onChange={(e) => setLogForm({ ...logForm, remarks: e.target.value })}
+            className={input}
+          />
+          <div className="col-span-2 flex items-center gap-3 lg:col-span-3">
+            <button
+              onClick={() => saveLog.mutate()}
+              disabled={saveLog.isPending || !logForm.product_id || logForm.qty_produced === ""}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+            >
+              {saveLog.isPending ? "Saving…" : "Save day"}
+            </button>
+            {saveLog.isError ? (
+              <p className="text-sm text-red-600">
+                {saveLog.error instanceof Error ? saveLog.error.message : "Failed"}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="max-h-[480px] space-y-1.5 overflow-y-auto pr-1">
+          {(log.data ?? []).map((r) => (
+            <div
+              key={r.id}
+              className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+            >
+              <span className="w-20 shrink-0 text-xs text-slate-400">{r.log_date}</span>
+              <span className="w-14 shrink-0 font-semibold">{r.factory_products?.code}</span>
+              <span className="w-16 shrink-0 text-right font-medium">{fmt(r.qty_produced)}</span>
+              <span className="w-16 shrink-0 text-right text-xs text-slate-400">
+                {r.cement_bags != null ? `${r.cement_bags} bags` : "—"}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-xs text-slate-400">
+                {r.downtime_reason !== "None" ? `⚠️ ${r.downtime_reason}` : ""}
+                {r.remarks ? ` ${r.remarks}` : ""}
+              </span>
+              <DataFlagBadge flag={r.data_flag} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ------------------------------------------------ production plan */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+          Production plan <span className="font-normal">(targets — actuals come from the log)</span>
+        </h2>
+        <div className="grid grid-cols-2 gap-2 rounded-2xl border border-slate-200 bg-white p-4 lg:grid-cols-4 dark:border-slate-700 dark:bg-slate-800">
+          <input
+            type="date"
+            value={planForm.plan_date}
+            onChange={(e) => setPlanForm({ ...planForm, plan_date: e.target.value })}
+            className={input}
+          />
+          <select
+            value={planForm.product_id}
+            onChange={(e) => setPlanForm({ ...planForm, product_id: e.target.value })}
+            className={input}
+          >
+            <option value="">Product…</option>
+            {(products.data ?? []).map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.code}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min={0}
+            placeholder="Planned qty"
+            value={planForm.planned_qty}
+            onChange={(e) => setPlanForm({ ...planForm, planned_qty: e.target.value })}
+            className={input}
+          />
+          <input
+            placeholder="Note"
+            value={planForm.plan_note}
+            onChange={(e) => setPlanForm({ ...planForm, plan_note: e.target.value })}
+            className={input}
+          />
+          <div className="col-span-2 flex items-center gap-3 lg:col-span-4">
+            <button
+              onClick={() => savePlan.mutate()}
+              disabled={savePlan.isPending || !planForm.product_id || planForm.planned_qty === ""}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+            >
+              {savePlan.isPending ? "Saving…" : "Save plan row"}
+            </button>
+            {savePlan.isError ? (
+              <p className="text-sm text-red-600">
+                {savePlan.error instanceof Error ? savePlan.error.message : "Failed"}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="max-h-[480px] space-y-1.5 overflow-y-auto pr-1">
+          {(plan.data ?? [])
+            .slice()
+            .reverse()
+            .map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2 text-sm dark:border-slate-700 dark:bg-slate-800"
+              >
+                <span className="w-20 shrink-0 text-xs text-slate-400">{r.plan_date}</span>
+                <span className="w-14 shrink-0 font-semibold">{r.factory_products?.code}</span>
+                <span className="w-16 shrink-0 text-right font-medium">{fmt(r.planned_qty)}</span>
+                <span className="min-w-0 flex-1 truncate text-xs text-slate-400">
+                  {r.plan_note ?? ""}
+                </span>
+              </div>
+            ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/reports/page.tsx
+++ b/apps/web/app/(dashboard)/factory/reports/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmt, getFactory, WeekPicker } from "@/components/factory/shared";
+import { factoryWeekStart, toISODate } from "@/lib/factory";
+
+type PvaRow = {
+  date: string;
+  product_code: string;
+  planned: number;
+  actual: number | null;
+  variance: number | null;
+  achievement_pct: number | null;
+  plan_note: string | null;
+  downtime_reason: string | null;
+};
+type Pva = {
+  week_start: string;
+  week_end: string;
+  rows: PvaRow[];
+  totals: { planned: number; actual: number; variance: number; achievement_pct: number | null };
+};
+type Downtime = {
+  causes: { reason: string; entries: number; days_affected: number; days_lost: number; remarks: string[] }[];
+};
+type Cement = {
+  weekly: { week_start: string; product_code: string; bricks_per_bag: number | null; includes_estimates: boolean }[];
+};
+type Friday = {
+  production: { product_code: string; planned: number; actual: number; variance: number; achievement_pct: number | null }[];
+  deliveries: { committed_qty: number; delivered_qty: number; variance: number; postponed_count: number };
+  downtime: { date: string; product_code: string; reason: string; remarks: string | null }[];
+};
+
+const CHART_COLORS: Record<string, string> = {
+  "MIB-8": "#2563eb",
+  "MIB-6": "#0891b2",
+  "CIB-8": "#d97706",
+  "CIB-6": "#dc2626",
+};
+
+// Views 4 (plan vs actual), 5 (downtime ranked), 6 (cement trend) + the
+// Friday review block (committed vs actual vs variance).
+export default function FactoryReportsPage() {
+  const [week, setWeek] = useState(toISODate(new Date()));
+  const ws = factoryWeekStart(week);
+
+  const pva = useQuery({
+    queryKey: ["factory", "pva", ws],
+    queryFn: () => getFactory<Pva>(`reports/plan-vs-actual?week=${ws}`),
+  });
+  const friday = useQuery({
+    queryKey: ["factory", "friday", ws],
+    queryFn: () => getFactory<Friday>(`reports/friday-review?week=${ws}`),
+  });
+  const downtime = useQuery({
+    queryKey: ["factory", "downtime"],
+    queryFn: () => getFactory<Downtime>("reports/downtime"),
+  });
+  const cement = useQuery({
+    queryKey: ["factory", "cement"],
+    queryFn: () => getFactory<Cement>("reports/cement"),
+  });
+
+  // Pivot weekly cement rows into one point per week with a key per product
+  const cementSeries = (() => {
+    const byWeek = new Map<string, Record<string, number | string | boolean>>();
+    for (const w of cement.data?.weekly ?? []) {
+      const point = byWeek.get(w.week_start) ?? { week: w.week_start.slice(5) };
+      if (w.bricks_per_bag != null) point[w.product_code] = w.bricks_per_bag;
+      byWeek.set(w.week_start, point);
+    }
+    return [...byWeek.values()];
+  })();
+  const cementProducts = [...new Set((cement.data?.weekly ?? []).map((w) => w.product_code))];
+
+  return (
+    <div className="space-y-6">
+      <WeekPicker week={week} onChange={setWeek} />
+
+      {/* -------------------------------------------------- Friday review */}
+      <section className="rounded-2xl border-2 border-slate-900 bg-white p-4 dark:border-white dark:bg-slate-800">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+          📋 Friday review — committed vs actual
+        </h2>
+        {friday.data ? (
+          <div className="mt-3 grid gap-4 lg:grid-cols-2">
+            <div>
+              <h3 className="mb-1.5 text-xs font-semibold uppercase text-slate-400">Production</h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {friday.data.production.map((p) => (
+                    <tr key={p.product_code} className="border-b border-slate-100 last:border-0 dark:border-slate-700/50">
+                      <td className="py-1.5 font-semibold">{p.product_code}</td>
+                      <td className="py-1.5 text-right">{fmt(p.planned)} planned</td>
+                      <td className="py-1.5 text-right">{fmt(p.actual)} actual</td>
+                      <td
+                        className={`py-1.5 text-right font-semibold ${
+                          p.variance < 0 ? "text-red-600" : "text-emerald-600"
+                        }`}
+                      >
+                        {p.variance >= 0 ? "+" : ""}
+                        {fmt(p.variance)}
+                      </td>
+                      <td className="py-1.5 text-right text-slate-400">
+                        {p.achievement_pct != null ? `${p.achievement_pct}%` : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase text-slate-400">Deliveries</h3>
+              <p className="text-sm">
+                Committed <b>{fmt(friday.data.deliveries.committed_qty)}</b> · Delivered{" "}
+                <b>{fmt(friday.data.deliveries.delivered_qty)}</b> ·{" "}
+                <span className={friday.data.deliveries.variance < 0 ? "text-red-600" : "text-emerald-600"}>
+                  {friday.data.deliveries.variance >= 0 ? "+" : ""}
+                  {fmt(friday.data.deliveries.variance)}
+                </span>
+                {friday.data.deliveries.postponed_count > 0
+                  ? ` · ${friday.data.deliveries.postponed_count} postponed`
+                  : ""}
+              </p>
+              {friday.data.downtime.length > 0 ? (
+                <>
+                  <h3 className="pt-1 text-xs font-semibold uppercase text-slate-400">
+                    Downtime this week
+                  </h3>
+                  <ul className="space-y-0.5 text-xs text-slate-500">
+                    {friday.data.downtime.map((d, i) => (
+                      <li key={i}>
+                        {d.date.slice(5)} {d.product_code}: <b>{d.reason}</b>
+                        {d.remarks ? ` — ${d.remarks}` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-slate-400">{friday.isLoading ? "Loading…" : "No data."}</p>
+        )}
+      </section>
+
+      {/* --------------------------------------------------- plan vs actual */}
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+        <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+          Plan vs actual — daily
+        </h2>
+        {pva.data && pva.data.rows.length > 0 ? (
+          <div className="mt-2 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-400 dark:border-slate-700">
+                  <th className="py-2 pr-3">Date</th>
+                  <th className="py-2 pr-3">Product</th>
+                  <th className="py-2 pr-3 text-right">Planned</th>
+                  <th className="py-2 pr-3 text-right">Actual</th>
+                  <th className="py-2 pr-3 text-right">Variance</th>
+                  <th className="py-2 pr-3 text-right">Achieved</th>
+                  <th className="py-2">Note</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pva.data.rows.map((r, i) => (
+                  <tr key={i} className="border-b border-slate-100 last:border-0 dark:border-slate-700/50">
+                    <td className="py-1.5 pr-3 text-xs text-slate-400">{r.date}</td>
+                    <td className="py-1.5 pr-3 font-semibold">{r.product_code}</td>
+                    <td className="py-1.5 pr-3 text-right">{fmt(r.planned)}</td>
+                    <td className="py-1.5 pr-3 text-right">{r.actual == null ? "—" : fmt(r.actual)}</td>
+                    <td
+                      className={`py-1.5 pr-3 text-right font-medium ${
+                        (r.variance ?? 0) < 0 ? "text-red-600" : "text-emerald-600"
+                      }`}
+                    >
+                      {r.variance == null ? "—" : `${r.variance >= 0 ? "+" : ""}${fmt(r.variance)}`}
+                    </td>
+                    <td className="py-1.5 pr-3 text-right">
+                      {r.achievement_pct == null ? "—" : `${r.achievement_pct}%`}
+                    </td>
+                    <td className="py-1.5 text-xs text-slate-400">
+                      {r.downtime_reason ? `⚠️ ${r.downtime_reason} · ` : ""}
+                      {r.plan_note ?? ""}
+                    </td>
+                  </tr>
+                ))}
+                <tr className="font-semibold">
+                  <td colSpan={2} className="py-2 pr-3">
+                    Week total
+                  </td>
+                  <td className="py-2 pr-3 text-right">{fmt(pva.data.totals.planned)}</td>
+                  <td className="py-2 pr-3 text-right">{fmt(pva.data.totals.actual)}</td>
+                  <td
+                    className={`py-2 pr-3 text-right ${
+                      pva.data.totals.variance < 0 ? "text-red-600" : "text-emerald-600"
+                    }`}
+                  >
+                    {pva.data.totals.variance >= 0 ? "+" : ""}
+                    {fmt(pva.data.totals.variance)}
+                  </td>
+                  <td className="py-2 pr-3 text-right">
+                    {pva.data.totals.achievement_pct != null ? `${pva.data.totals.achievement_pct}%` : "—"}
+                  </td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-slate-400">
+            {pva.isLoading ? "Loading…" : "No plan rows for this week."}
+          </p>
+        )}
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* ------------------------------------------------ downtime ranked */}
+        <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+            Downtime by cause — all time
+          </h2>
+          <div className="mt-2 space-y-2">
+            {(downtime.data?.causes ?? []).map((c) => (
+              <div key={c.reason} className="rounded-xl bg-slate-50 px-3.5 py-2.5 dark:bg-slate-900">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-semibold">{c.reason}</span>
+                  <span className="text-xs text-slate-400">
+                    {c.days_lost} day{c.days_lost === 1 ? "" : "s"} lost · {c.days_affected} affected ·{" "}
+                    {c.entries} entr{c.entries === 1 ? "y" : "ies"}
+                  </span>
+                </div>
+                {c.remarks.length > 0 ? (
+                  <p className="mt-1 truncate text-xs text-slate-400">{c.remarks[0]}</p>
+                ) : null}
+              </div>
+            ))}
+            {downtime.data && downtime.data.causes.length === 0 ? (
+              <p className="text-sm text-slate-400">No downtime recorded 🎉</p>
+            ) : null}
+          </div>
+        </section>
+
+        {/* -------------------------------------------------- cement trend */}
+        <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800">
+          <h2 className="text-sm font-bold uppercase tracking-wide text-slate-500">
+            Cement efficiency — bricks per bag (weekly)
+          </h2>
+          {cementSeries.length > 0 ? (
+            <div className="mt-2 h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={cementSeries}>
+                  <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+                  <XAxis dataKey="week" fontSize={11} />
+                  <YAxis domain={["auto", "auto"]} fontSize={11} />
+                  <Tooltip />
+                  <Legend />
+                  {cementProducts.map((code) => (
+                    <Line
+                      key={code}
+                      type="monotone"
+                      dataKey={code}
+                      stroke={CHART_COLORS[code] ?? "#64748b"}
+                      strokeWidth={2}
+                      connectNulls
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-slate-400">
+              {cement.isLoading ? "Loading…" : "No cement data yet."}
+            </p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/factory/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/factory/schedule/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  DataFlagBadge,
+  fmt,
+  getFactory,
+  sendFactory,
+  WeekPicker,
+} from "@/components/factory/shared";
+import { factoryWeekStart, parseISODate, toISODate } from "@/lib/factory";
+
+type DeliveryRow = {
+  id: string;
+  delivery_date: string;
+  qty: number;
+  status: string;
+  data_flag: string;
+  notes: string | null;
+  factory_customers: { name: string; credit_hold: boolean } | null;
+  factory_products: { code: string } | null;
+};
+
+const DAY_NAMES = ["Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri"];
+
+// View 3: the Sat–Fri delivery schedule grouped by day, with the daily
+// Planned → Delivered / Postponed workflow.
+export default function FactorySchedulePage() {
+  const queryClient = useQueryClient();
+  const [week, setWeek] = useState(toISODate(new Date()));
+  const weekStart = factoryWeekStart(week);
+
+  const deliveries = useQuery({
+    queryKey: ["factory", "deliveries", weekStart],
+    queryFn: () => getFactory<DeliveryRow[]>(`deliveries?week=${weekStart}`),
+  });
+
+  const updateStatus = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) =>
+      sendFactory(`deliveries/${id}`, "PATCH", { status }),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["factory"] }),
+  });
+
+  const byDay = useMemo(() => {
+    const days: { date: string; name: string; rows: DeliveryRow[] }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = parseISODate(weekStart);
+      d.setDate(d.getDate() + i);
+      days.push({ date: toISODate(d), name: DAY_NAMES[i], rows: [] });
+    }
+    for (const row of deliveries.data ?? []) {
+      days.find((d) => d.date === row.delivery_date)?.rows.push(row);
+    }
+    return days;
+  }, [deliveries.data, weekStart]);
+
+  return (
+    <div className="space-y-4">
+      <WeekPicker week={week} onChange={setWeek} />
+
+      {deliveries.isLoading ? (
+        <p className="py-8 text-center text-slate-400">Loading…</p>
+      ) : (
+        byDay.map((day) => (
+          <section key={day.date}>
+            <h3 className="mb-1.5 text-sm font-bold text-slate-500">
+              {day.name} <span className="font-normal text-slate-400">{day.date}</span>
+            </h3>
+            {day.rows.length === 0 ? (
+              <p className="mb-2 text-xs text-slate-300 dark:text-slate-600">
+                No deliveries.
+              </p>
+            ) : (
+              <div className="space-y-1.5">
+                {day.rows.map((r) => {
+                  const hold = r.factory_customers?.credit_hold;
+                  return (
+                    <div
+                      key={r.id}
+                      className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 dark:border-slate-700 dark:bg-slate-800"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-slate-900 dark:text-white">
+                          {r.factory_customers?.name ?? "?"} — {fmt(r.qty)}{" "}
+                          {r.factory_products?.code ?? "?"}
+                          {hold ? (
+                            <span className="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700 dark:bg-red-900 dark:text-red-200">
+                              CREDIT HOLD
+                            </span>
+                          ) : null}{" "}
+                          <DataFlagBadge flag={r.data_flag} />
+                        </p>
+                        {r.notes ? (
+                          <p className="truncate text-xs text-slate-400">{r.notes}</p>
+                        ) : null}
+                      </div>
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                          r.status === "Delivered"
+                            ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"
+                            : r.status === "Postponed"
+                              ? "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
+                              : r.status === "Cancelled"
+                                ? "bg-slate-200 text-slate-500 line-through dark:bg-slate-700"
+                                : "bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                        }`}
+                      >
+                        {r.status}
+                      </span>
+                      {r.status === "Planned" || r.status === "Postponed" ? (
+                        <div className="flex gap-1.5">
+                          <button
+                            onClick={() => updateStatus.mutate({ id: r.id, status: "Delivered" })}
+                            disabled={updateStatus.isPending || hold}
+                            title={hold ? "Credit hold — do not dispatch" : undefined}
+                            className="rounded-lg bg-emerald-600 px-2.5 py-1 text-xs font-semibold text-white disabled:opacity-40"
+                          >
+                            ✓ Delivered
+                          </button>
+                          {r.status === "Planned" ? (
+                            <button
+                              onClick={() => updateStatus.mutate({ id: r.id, status: "Postponed" })}
+                              disabled={updateStatus.isPending}
+                              className="rounded-lg border border-amber-400 px-2.5 py-1 text-xs font-semibold text-amber-700 disabled:opacity-40 dark:text-amber-300"
+                            >
+                              Postpone
+                            </button>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        ))
+      )}
+      {updateStatus.isError ? (
+        <p className="text-sm text-red-600">
+          {updateStatus.error instanceof Error ? updateStatus.error.message : "Update failed"}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -50,6 +50,7 @@ const navigation: NavItem[] = [
     icon: DeliveriesIcon,
     key: "deliveries",
   },
+  { name: "Factory", href: "/factory", icon: ProductionIcon, key: "factory" },
   {
     name: "Production",
     href: "/production",
@@ -108,7 +109,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
   ],
   sales: ["dashboard", "onehub", "leads", "quotes", "tasks", "settings", "knowledge", "coaching"],
   driver: ["dashboard", "onehub", "deliveries", "settings"],
-  production_supervisor: ["dashboard", "onehub", "production", "planning", "deliveries", "settings", "projects", "coaching"],
+  production_supervisor: ["dashboard", "onehub", "factory", "production", "planning", "deliveries", "settings", "projects", "coaching"],
 };
 
 function getNavigationForRole(role: UserRole | undefined): NavItem[] {

--- a/apps/web/app/api/factory/assets/route.ts
+++ b/apps/web/app/api/factory/assets/route.ts
@@ -1,0 +1,71 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { ASSET_CATEGORIES, ASSET_LOCATIONS } from "@/lib/factory";
+
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .select("*")
+      .order("category")
+      .order("asset");
+    if (dbError) return error("Failed to load assets", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory assets GET failed:", err);
+    return error("Failed to load assets", 500);
+  }
+}
+
+const baseSchema = z.object({
+  asset: z.string().min(1).max(160),
+  category: z.enum(ASSET_CATEGORIES),
+  qty: z.number().min(0).default(1),
+  location: z.enum(ASSET_LOCATIONS).default("Unknown"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create asset: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory assets POST failed:", err);
+    return error("Failed to create asset", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_assets")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update asset", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory assets PATCH failed:", err);
+    return error("Failed to update asset", 500);
+  }
+}

--- a/apps/web/app/api/factory/customers/route.ts
+++ b/apps/web/app/api/factory/customers/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .select("*")
+      .order("name");
+    if (dbError) return error("Failed to load customers", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory customers GET failed:", err);
+    return error("Failed to load customers", 500);
+  }
+}
+
+const baseSchema = z.object({
+  name: z.string().min(1).max(120),
+  location: z.string().nullable().optional(),
+  phone: z.string().max(20).nullable().optional(),
+  credit_hold: z.boolean().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create customer: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory customers POST failed:", err);
+    return error("Failed to create customer", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_customers")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update customer", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory customers PATCH failed:", err);
+    return error("Failed to update customer", 500);
+  }
+}

--- a/apps/web/app/api/factory/deliveries/[id]/route.ts
+++ b/apps/web/app/api/factory/deliveries/[id]/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_DELIVERY, DELIVERY_STATUSES } from "@/lib/factory";
+
+const patchSchema = z.object({
+  delivery_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  qty: z.number().int().min(0).optional(),
+  status: z.enum(DELIVERY_STATUSES).optional(),
+  order_id: z.string().uuid().nullable().optional(),
+  trip_id: z.string().uuid().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_DELIVERY).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+// PATCH /api/factory/deliveries/:id — the daily workflow: Planned → Delivered
+// (or Postponed). Stock and order fulfilment recompute automatically.
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*, factory_customers(name, credit_hold), factory_products(code)")
+      .single();
+    if (dbError || !data) return error("Failed to update delivery", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory deliveries PATCH failed:", err);
+    return error("Failed to update delivery", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete delivery", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory deliveries DELETE failed:", err);
+    return error("Failed to delete delivery", 500);
+  }
+}

--- a/apps/web/app/api/factory/deliveries/route.ts
+++ b/apps/web/app/api/factory/deliveries/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import {
+  DATA_FLAGS_DELIVERY,
+  DELIVERY_STATUSES,
+  factoryWeekEnd,
+  factoryWeekStart,
+} from "@/lib/factory";
+
+// GET /api/factory/deliveries?week=YYYY-MM-DD (any date in the Sat–Fri week)
+// or ?from&to. Joined with customer + product for composed row labels.
+export async function GET(request: NextRequest) {
+  try {
+    const { week, from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_deliveries")
+      .select("*, factory_customers(name, credit_hold), factory_products(code)")
+      .order("delivery_date", { ascending: true });
+    if (week) {
+      query = query
+        .gte("delivery_date", factoryWeekStart(week))
+        .lte("delivery_date", factoryWeekEnd(week));
+    } else {
+      if (from) query = query.gte("delivery_date", from);
+      if (to) query = query.lte("delivery_date", to);
+    }
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load deliveries", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory deliveries GET failed:", err);
+    return error("Failed to load deliveries", 500);
+  }
+}
+
+const baseSchema = z.object({
+  delivery_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  customer_id: z.string().uuid(),
+  product_id: z.string().uuid(),
+  qty: z.number().int().min(0), // 0 = qty still to confirm
+  status: z.enum(DELIVERY_STATUSES).default("Planned"),
+  order_id: z.string().uuid().nullable().optional(),
+  trip_id: z.string().uuid().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_DELIVERY).default("OK"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_deliveries")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create delivery: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory deliveries POST failed:", err);
+    return error("Failed to create delivery", 500);
+  }
+}

--- a/apps/web/app/api/factory/labour/[id]/route.ts
+++ b/apps/web/app/api/factory/labour/[id]/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { WORK_TYPES } from "@/lib/factory";
+
+const patchSchema = z.object({
+  work_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  worker: z.string().min(1).max(120).optional(),
+  work_type: z.enum(WORK_TYPES).optional(),
+  qty: z.number().optional(),
+  rate: z.number().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update labour entry", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory labour PATCH failed:", err);
+    return error("Failed to update labour entry", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete labour entry", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory labour DELETE failed:", err);
+    return error("Failed to delete labour entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/labour/route.ts
+++ b/apps/web/app/api/factory/labour/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, WORK_TYPES } from "@/lib/factory";
+
+// GET /api/factory/labour?week=YYYY-MM-DD or ?from&to
+export async function GET(request: NextRequest) {
+  try {
+    const { week, from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_labour")
+      .select("*")
+      .order("work_date", { ascending: false });
+    if (week) {
+      query = query
+        .gte("work_date", factoryWeekStart(week))
+        .lte("work_date", factoryWeekEnd(week));
+    } else {
+      if (from) query = query.gte("work_date", from);
+      if (to) query = query.lte("work_date", to);
+    }
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load labour entries", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory labour GET failed:", err);
+    return error("Failed to load labour entries", 500);
+  }
+}
+
+const baseSchema = z
+  .object({
+    work_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    worker: z.string().min(1).max(120),
+    work_type: z.enum(WORK_TYPES),
+    qty: z.number(),
+    rate: z.number(),
+    notes: z.string().nullable().optional(),
+  })
+  .refine((l) => l.work_type !== "Advance" || (l.qty === 1 && l.rate < 0), {
+    message: "Advances are qty 1 with a negative rate (e.g. 1 × -3500)",
+  });
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create labour entry: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory labour POST failed:", err);
+    return error("Failed to create labour entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/orders/route.ts
+++ b/apps/web/app/api/factory/orders/route.ts
@@ -1,0 +1,78 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { PAYMENT_STATUSES } from "@/lib/factory";
+
+// GET /api/factory/orders — reads factory_orders_v (delivered/balance/fulfilment
+// derived from dispatches). ?status=open → not Complete, not Cancelled, oldest first.
+export async function GET(request: NextRequest) {
+  try {
+    const { status } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_orders_v")
+      .select("*")
+      .order("order_date", { ascending: true });
+    if (status === "open") {
+      query = query.neq("fulfilment", "Complete").neq("payment_status", "Cancelled");
+    }
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load orders", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory orders GET failed:", err);
+    return error("Failed to load orders", 500);
+  }
+}
+
+const baseSchema = z.object({
+  customer_id: z.string().uuid(),
+  order_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  qty_ordered: z.number().int().positive(),
+  payment_status: z.enum(PAYMENT_STATUSES).default("Clear"),
+  notes: z.string().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_orders")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create order: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory orders POST failed:", err);
+    return error("Failed to create order", 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema.partial().extend({ id: z.string().uuid() }));
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_orders")
+      .update(fields)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update order", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory orders PATCH failed:", err);
+    return error("Failed to update order", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-log/[id]/route.ts
+++ b/apps/web/app/api/factory/production-log/[id]/route.ts
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_PRODUCTION, DOWNTIME_REASONS } from "@/lib/factory";
+
+const patchSchema = z.object({
+  qty_produced: z.number().int().min(0).optional(),
+  cement_bags: z.number().min(0).nullable().optional(),
+  downtime_reason: z.enum(DOWNTIME_REASONS).optional(),
+  remarks: z.string().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_PRODUCTION).optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update entry", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-log PATCH failed:", err);
+    return error("Failed to update entry", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete entry", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory production-log DELETE failed:", err);
+    return error("Failed to delete entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-log/route.ts
+++ b/apps/web/app/api/factory/production-log/route.ts
@@ -1,0 +1,59 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { DATA_FLAGS_PRODUCTION, DOWNTIME_REASONS } from "@/lib/factory";
+
+// GET /api/factory/production-log?from&to&product_id
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to, product_id } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_log")
+      .select("*, factory_products(code)")
+      .order("log_date", { ascending: false });
+    if (from) query = query.gte("log_date", from);
+    if (to) query = query.lte("log_date", to);
+    if (product_id) query = query.eq("product_id", product_id);
+    const { data, error: dbError } = await query.limit(400);
+    if (dbError) return error("Failed to load production log", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory production-log GET failed:", err);
+    return error("Failed to load production log", 500);
+  }
+}
+
+const upsertSchema = z.object({
+  log_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  qty_produced: z.number().int().min(0),
+  cement_bags: z.number().min(0).nullable().optional(),
+  downtime_reason: z.enum(DOWNTIME_REASONS).default("None"),
+  remarks: z.string().nullable().optional(),
+  data_flag: z.enum(DATA_FLAGS_PRODUCTION).default("OK"),
+});
+
+// POST /api/factory/production-log — one row per date+product; re-submitting
+// the same date+product EDITS it (upsert), so mobile entry can't duplicate.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, upsertSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .upsert(parsed.data, { onConflict: "log_date,product_id" })
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to save production entry: ${dbError.message}`, 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-log POST failed:", err);
+    return error("Failed to save production entry", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-plan/[id]/route.ts
+++ b/apps/web/app/api/factory/production-plan/[id]/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import {
+  requireProductionRole,
+  PRODUCTION_DELETE_ROLES,
+} from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+const patchSchema = z.object({
+  planned_qty: z.number().int().min(0).optional(),
+  plan_note: z.string().nullable().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .update(parsed.data)
+      .eq("id", params.id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update plan row", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-plan PATCH failed:", err);
+    return error("Failed to update plan row", 500);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .delete()
+      .eq("id", params.id);
+    if (dbError) return error("Failed to delete plan row", 500);
+    return success({ deleted: true });
+  } catch (err) {
+    console.error("factory production-plan DELETE failed:", err);
+    return error("Failed to delete plan row", 500);
+  }
+}

--- a/apps/web/app/api/factory/production-plan/route.ts
+++ b/apps/web/app/api/factory/production-plan/route.ts
@@ -1,0 +1,54 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/production-plan?from&to
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_plan")
+      .select("*, factory_products(code)")
+      .order("plan_date", { ascending: true });
+    if (from) query = query.gte("plan_date", from);
+    if (to) query = query.lte("plan_date", to);
+    const { data, error: dbError } = await query.limit(400);
+    if (dbError) return error("Failed to load production plan", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory production-plan GET failed:", err);
+    return error("Failed to load production plan", 500);
+  }
+}
+
+const upsertSchema = z.object({
+  plan_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  product_id: z.string().uuid(),
+  planned_qty: z.number().int().min(0),
+  plan_note: z.string().nullable().optional(),
+});
+
+// POST — one row per date+product; actuals are NEVER stored here, they come
+// from the production log at read time.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, upsertSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_plan")
+      .upsert(parsed.data, { onConflict: "plan_date,product_id" })
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to save plan row: ${dbError.message}`, 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory production-plan POST failed:", err);
+    return error("Failed to save plan row", 500);
+  }
+}

--- a/apps/web/app/api/factory/products/route.ts
+++ b/apps/web/app/api/factory/products/route.ts
@@ -1,0 +1,58 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/products — the 4 SKUs with opening stock state
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_products")
+      .select("*")
+      .order("code");
+    if (dbError) return error("Failed to load products", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory products GET failed:", err);
+    return error("Failed to load products", 500);
+  }
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  // Opening stock entry IS the stock-take: recording it sets opening_counted_at.
+  opening_stock: z.number().int().min(0).optional(),
+  opening_counted_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+// PATCH /api/factory/products — opening stock + notes only; code is immutable.
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, patchSchema);
+    if (parsed.error) return parsed.error;
+    const { id, ...fields } = parsed.data;
+
+    const update: Record<string, unknown> = { ...fields };
+    if (fields.opening_stock !== undefined && fields.opening_counted_at === undefined) {
+      update.opening_counted_at = new Date().toISOString().slice(0, 10);
+    }
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_products")
+      .update(update)
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (dbError || !data) return error("Failed to update product", 500);
+    return success(data);
+  } catch (err) {
+    console.error("factory products PATCH failed:", err);
+    return error("Failed to update product", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/cement/route.ts
+++ b/apps/web/app/api/factory/reports/cement/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekStart } from "@/lib/factory";
+
+// GET /api/factory/reports/cement — View 6: bricks per cement bag by week and
+// product. The sheet showed a 40.4–54.4 swing on the largest input cost.
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_production_log")
+      .select("log_date, qty_produced, cement_bags, data_flag, factory_products(code)")
+      .gt("cement_bags", 0)
+      .order("log_date");
+    if (dbError) return error("Failed to load cement data", 500);
+
+    // Weekly aggregation per product
+    const byWeekProduct = new Map<string, { qty: number; bags: number; estimated: boolean }>();
+    // Daily points for the scatter/trend
+    const daily = (data ?? []).map((row) => {
+      const code = (row.factory_products as { code?: string } | null)?.code ?? "?";
+      const qty = Number(row.qty_produced);
+      const bags = Number(row.cement_bags);
+      const week = factoryWeekStart(row.log_date as string);
+      const key = `${week}|${code}`;
+      const agg = byWeekProduct.get(key) ?? { qty: 0, bags: 0, estimated: false };
+      agg.qty += qty;
+      agg.bags += bags;
+      if (row.data_flag === "Estimated") agg.estimated = true;
+      byWeekProduct.set(key, agg);
+      return {
+        date: row.log_date as string,
+        product_code: code,
+        bricks_per_bag: bags > 0 ? Math.round((qty / bags) * 10) / 10 : null,
+        data_flag: row.data_flag as string,
+      };
+    });
+
+    const weekly = [...byWeekProduct.entries()]
+      .map(([key, agg]) => {
+        const [week_start, product_code] = key.split("|");
+        return {
+          week_start,
+          product_code,
+          bricks_per_bag: agg.bags > 0 ? Math.round((agg.qty / agg.bags) * 10) / 10 : null,
+          total_bags: Math.round(agg.bags * 10) / 10,
+          includes_estimates: agg.estimated,
+        };
+      })
+      .sort(
+        (a, b) =>
+          a.week_start.localeCompare(b.week_start) ||
+          a.product_code.localeCompare(b.product_code),
+      );
+
+    return success({ daily, weekly });
+  } catch (err) {
+    console.error("factory cement report failed:", err);
+    return error("Failed to build cement report", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/downtime/route.ts
+++ b/apps/web/app/api/factory/reports/downtime/route.ts
@@ -1,0 +1,55 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/reports/downtime?from&to — View 5: causes ranked.
+// "days lost" = distinct dates with zero production for that cause;
+// "days affected" = distinct dates the cause appeared at all.
+export async function GET(request: NextRequest) {
+  try {
+    const { from, to } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("factory_production_log")
+      .select("log_date, qty_produced, downtime_reason, remarks")
+      .neq("downtime_reason", "None");
+    if (from) query = query.gte("log_date", from);
+    if (to) query = query.lte("log_date", to);
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load downtime", 500);
+
+    const byReason = new Map<
+      string,
+      { entries: number; affected: Set<string>; lost: Set<string>; remarks: string[] }
+    >();
+    for (const row of data ?? []) {
+      const r = byReason.get(row.downtime_reason) ?? {
+        entries: 0,
+        affected: new Set<string>(),
+        lost: new Set<string>(),
+        remarks: [],
+      };
+      r.entries += 1;
+      r.affected.add(row.log_date);
+      if (Number(row.qty_produced) === 0) r.lost.add(row.log_date);
+      if (row.remarks) r.remarks.push(`${row.log_date}: ${row.remarks}`);
+      byReason.set(row.downtime_reason, r);
+    }
+
+    const ranked = [...byReason.entries()]
+      .map(([reason, r]) => ({
+        reason,
+        entries: r.entries,
+        days_affected: r.affected.size,
+        days_lost: r.lost.size,
+        remarks: r.remarks.slice(0, 6),
+      }))
+      .sort((a, b) => b.days_lost - a.days_lost || b.days_affected - a.days_affected);
+
+    return success({ causes: ranked });
+  } catch (err) {
+    console.error("factory downtime report failed:", err);
+    return error("Failed to build downtime report", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/friday-review/route.ts
+++ b/apps/web/app/api/factory/reports/friday-review/route.ts
@@ -1,0 +1,107 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate } from "@/lib/factory";
+
+// GET /api/factory/reports/friday-review?week=YYYY-MM-DD
+// Rajesh's Friday deck: the target COMMITTED in last week's review vs what
+// actually happened, plus live stock and the week's downtime.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const [plans, logs, deliveries, stock] = await Promise.all([
+      supabaseAdmin
+        .from("factory_production_plan")
+        .select("plan_date, planned_qty, factory_products(code)")
+        .gte("plan_date", from)
+        .lte("plan_date", to),
+      supabaseAdmin
+        .from("factory_production_log")
+        .select("log_date, qty_produced, downtime_reason, remarks, factory_products(code)")
+        .gte("log_date", from)
+        .lte("log_date", to),
+      supabaseAdmin
+        .from("factory_deliveries")
+        .select("qty, status, factory_products(code)")
+        .gte("delivery_date", from)
+        .lte("delivery_date", to),
+      supabaseAdmin.from("factory_stock_v").select("*").order("code"),
+    ]);
+
+    // Supabase types embedded relations as object OR array depending on
+    // inference — normalise both shapes.
+    const code = (r: { factory_products: unknown }): string => {
+      const fp = r.factory_products as { code?: string } | { code?: string }[] | null;
+      return (Array.isArray(fp) ? fp[0]?.code : fp?.code) ?? "?";
+    };
+
+    // Production: committed plan vs actual, per product
+    const perProduct = new Map<string, { planned: number; actual: number }>();
+    for (const p of plans.data ?? []) {
+      const e = perProduct.get(code(p)) ?? { planned: 0, actual: 0 };
+      e.planned += Number(p.planned_qty);
+      perProduct.set(code(p), e);
+    }
+    for (const l of logs.data ?? []) {
+      const e = perProduct.get(code(l)) ?? { planned: 0, actual: 0 };
+      e.actual += Number(l.qty_produced);
+      perProduct.set(code(l), e);
+    }
+    const production = [...perProduct.entries()]
+      .map(([product_code, v]) => ({
+        product_code,
+        planned: v.planned,
+        actual: v.actual,
+        variance: v.actual - v.planned,
+        achievement_pct: v.planned > 0 ? Math.round((v.actual / v.planned) * 100) : null,
+      }))
+      .sort((a, b) => a.product_code.localeCompare(b.product_code));
+
+    // Deliveries: committed (all scheduled rows) vs completed
+    let committedQty = 0;
+    let deliveredQty = 0;
+    let postponed = 0;
+    for (const d of deliveries.data ?? []) {
+      committedQty += Number(d.qty);
+      if (d.status === "Delivered") deliveredQty += Number(d.qty);
+      if (d.status === "Postponed") postponed += 1;
+    }
+
+    // Downtime within the week
+    const downtime = (logs.data ?? [])
+      .filter((l) => l.downtime_reason !== "None")
+      .map((l) => ({
+        date: l.log_date as string,
+        product_code: code(l),
+        reason: l.downtime_reason as string,
+        remarks: (l.remarks as string | null) ?? null,
+      }));
+
+    return success({
+      week_start: from,
+      week_end: to,
+      production,
+      production_totals: {
+        planned: production.reduce((s, p) => s + p.planned, 0),
+        actual: production.reduce((s, p) => s + p.actual, 0),
+      },
+      deliveries: {
+        committed_qty: committedQty,
+        delivered_qty: deliveredQty,
+        variance: deliveredQty - committedQty,
+        postponed_count: postponed,
+      },
+      downtime,
+      stock: stock.data ?? [],
+    });
+  } catch (err) {
+    console.error("factory friday-review failed:", err);
+    return error("Failed to build Friday review", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/labour-week/route.ts
+++ b/apps/web/app/api/factory/reports/labour-week/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate } from "@/lib/factory";
+
+// GET /api/factory/reports/labour-week?week=YYYY-MM-DD — View 7.
+// amount = qty × rate everywhere; advances are negative, so a plain sum
+// gives net payable directly.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_labour")
+      .select("*")
+      .gte("work_date", from)
+      .lte("work_date", to)
+      .order("work_date");
+    if (dbError) return error("Failed to load labour", 500);
+
+    const byWorker = new Map<
+      string,
+      { gross: number; advances: number; net: number; entries: number }
+    >();
+    let gross = 0;
+    let advances = 0;
+    for (const row of data ?? []) {
+      const amount = Number(row.qty) * Number(row.rate);
+      const w = byWorker.get(row.worker) ?? {
+        gross: 0,
+        advances: 0,
+        net: 0,
+        entries: 0,
+      };
+      if (amount >= 0) {
+        w.gross += amount;
+        gross += amount;
+      } else {
+        w.advances += amount;
+        advances += amount;
+      }
+      w.net += amount;
+      w.entries += 1;
+      byWorker.set(row.worker, w);
+    }
+
+    return success({
+      week_start: from,
+      week_end: to,
+      entries: data ?? [],
+      workers: [...byWorker.entries()]
+        .map(([worker, w]) => ({ worker, ...w }))
+        .sort((a, b) => b.net - a.net),
+      totals: { gross, advances, net: gross + advances },
+    });
+  } catch (err) {
+    console.error("factory labour-week failed:", err);
+    return error("Failed to build labour week", 500);
+  }
+}

--- a/apps/web/app/api/factory/reports/plan-vs-actual/route.ts
+++ b/apps/web/app/api/factory/reports/plan-vs-actual/route.ts
@@ -1,0 +1,101 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseQuery } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { factoryWeekEnd, factoryWeekStart, toISODate, parseISODate } from "@/lib/factory";
+
+type Row = {
+  date: string;
+  product_code: string;
+  planned: number;
+  actual: number | null; // null = no log entry yet for that day/product
+  variance: number | null;
+  achievement_pct: number | null; // null when planned is 0
+  plan_note: string | null;
+  downtime_reason: string | null;
+};
+
+// GET /api/factory/reports/plan-vs-actual?week=YYYY-MM-DD — View 4.
+// Actuals are read from the production log, never re-keyed.
+export async function GET(request: NextRequest) {
+  try {
+    const { week } = parseQuery(request);
+    const anchor = week || toISODate(new Date());
+    const from = factoryWeekStart(anchor);
+    const to = factoryWeekEnd(anchor);
+
+    const [{ data: plans }, { data: logs }] = await Promise.all([
+      supabaseAdmin
+        .from("factory_production_plan")
+        .select("plan_date, planned_qty, plan_note, factory_products(code)")
+        .gte("plan_date", from)
+        .lte("plan_date", to),
+      supabaseAdmin
+        .from("factory_production_log")
+        .select("log_date, qty_produced, downtime_reason, factory_products(code)")
+        .gte("log_date", from)
+        .lte("log_date", to),
+    ]);
+
+    const logMap = new Map<string, { qty: number; downtime: string }>();
+    for (const l of logs ?? []) {
+      const code = (l.factory_products as { code?: string } | null)?.code ?? "?";
+      logMap.set(`${l.log_date}|${code}`, {
+        qty: Number(l.qty_produced),
+        downtime: l.downtime_reason,
+      });
+    }
+
+    const rows: Row[] = (plans ?? [])
+      .map((p) => {
+        const code = (p.factory_products as { code?: string } | null)?.code ?? "?";
+        const log = logMap.get(`${p.plan_date}|${code}`);
+        const planned = Number(p.planned_qty);
+        const actual = log ? log.qty : null;
+        return {
+          date: p.plan_date as string,
+          product_code: code,
+          planned,
+          actual,
+          variance: actual === null ? null : actual - planned,
+          achievement_pct:
+            planned > 0 && actual !== null
+              ? Math.round((actual / planned) * 100)
+              : null,
+          plan_note: (p.plan_note as string | null) ?? null,
+          downtime_reason: log?.downtime ?? null,
+        };
+      })
+      .sort(
+        (a, b) =>
+          a.date.localeCompare(b.date) || a.product_code.localeCompare(b.product_code),
+      );
+
+    const plannedTotal = rows.reduce((s, r) => s + r.planned, 0);
+    const actualTotal = rows.reduce((s, r) => s + (r.actual ?? 0), 0);
+    const days: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = parseISODate(from);
+      d.setDate(d.getDate() + i);
+      days.push(toISODate(d));
+    }
+
+    return success({
+      week_start: from,
+      week_end: to,
+      days,
+      rows,
+      totals: {
+        planned: plannedTotal,
+        actual: actualTotal,
+        variance: actualTotal - plannedTotal,
+        achievement_pct:
+          plannedTotal > 0 ? Math.round((actualTotal / plannedTotal) * 100) : null,
+      },
+    });
+  } catch (err) {
+    console.error("factory plan-vs-actual failed:", err);
+    return error("Failed to build plan vs actual", 500);
+  }
+}

--- a/apps/web/app/api/factory/stock/route.ts
+++ b/apps/web/app/api/factory/stock/route.ts
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic";
+
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/factory/stock — live stock per product (View 1).
+// free_stock is the number a salesperson needs before promising a date.
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_stock_v")
+      .select("*")
+      .order("code");
+    if (dbError) return error("Failed to load stock", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory stock GET failed:", err);
+    return error("Failed to load stock", 500);
+  }
+}

--- a/apps/web/app/api/factory/trips/route.ts
+++ b/apps/web/app/api/factory/trips/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { success, created, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { VEHICLES } from "@/lib/factory";
+
+// GET /api/factory/trips — vehicle log; total_km / km_per_litre derived client-side
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_trips")
+      .select("*")
+      .order("trip_date", { ascending: false })
+      .limit(200);
+    if (dbError) return error("Failed to load trips", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("factory trips GET failed:", err);
+    return error("Failed to load trips", 500);
+  }
+}
+
+const baseSchema = z
+  .object({
+    trip_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    vehicle: z.enum(VEHICLES),
+    start_km: z.number().min(0).nullable().optional(),
+    end_km: z.number().min(0).nullable().optional(),
+    diesel_litres: z.number().min(0).nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .refine(
+    (t) => t.start_km == null || t.end_km == null || t.end_km >= t.start_km,
+    { message: "End KM must be at or after start KM" },
+  );
+
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, baseSchema);
+    if (parsed.error) return parsed.error;
+    const { data, error: dbError } = await supabaseAdmin
+      .from("factory_trips")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+    if (dbError) return error(`Failed to create trip: ${dbError.message}`, 500);
+    return created(data);
+  } catch (err) {
+    console.error("factory trips POST failed:", err);
+    return error("Failed to create trip", 500);
+  }
+}

--- a/apps/web/src/components/factory/shared.tsx
+++ b/apps/web/src/components/factory/shared.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * Shared client helpers for the Factory Ledger pages: typed fetchers over
+ * /api/factory, the Sat–Fri week picker, and the stock-take banner.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { factoryWeekEnd, factoryWeekStart, parseISODate, toISODate } from "@/lib/factory";
+
+export async function getFactory<T>(path: string): Promise<T> {
+  const res = await fetch(`/api/factory/${path}`);
+  if (!res.ok) throw new Error(`Failed to load ${path}`);
+  return (await res.json()).data as T;
+}
+
+export async function sendFactory<T>(
+  path: string,
+  method: "POST" | "PATCH" | "DELETE",
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`/api/factory/${path}`, {
+    method,
+    headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(json?.error ?? `Request failed (${res.status})`);
+  return json?.data as T;
+}
+
+export type StockRow = {
+  id: string;
+  code: string;
+  opening_stock: number | null;
+  opening_counted_at: string | null;
+  produced: number;
+  delivered: number;
+  committed: number;
+  stock_balance: number;
+  free_stock: number;
+  bricks_per_bag: number | null;
+};
+
+export function useStock() {
+  return useQuery({
+    queryKey: ["factory", "stock"],
+    queryFn: () => getFactory<StockRow[]>("stock"),
+  });
+}
+
+export const fmt = (n: number | null | undefined) =>
+  n == null ? "—" : Number(n).toLocaleString("en-IN");
+
+/* ------------------------------------------------------------- banner */
+
+export function StockTakeBanner() {
+  const { data } = useStock();
+  const uncounted = (data ?? []).filter((p) => !p.opening_counted_at);
+  if (!data || uncounted.length === 0) return null;
+  return (
+    <div className="mb-4 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
+      <span className="font-semibold">⚠️ Opening stock not counted.</span> Stock
+      figures assume 0 as at 01/07 for{" "}
+      {uncounted.map((p) => p.code).join(", ")} — every balance below is
+      understated until the yard is physically counted.{" "}
+      <a href="/factory/data" className="font-semibold underline">
+        Enter the stock-take →
+      </a>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------- week picker */
+
+export function WeekPicker({
+  week,
+  onChange,
+}: {
+  week: string; // any date inside the week; normalised to its Saturday
+  onChange: (saturday: string) => void;
+}) {
+  const start = factoryWeekStart(week);
+  const end = factoryWeekEnd(week);
+  const shift = (days: number) => {
+    const d = parseISODate(start);
+    d.setDate(d.getDate() + days);
+    onChange(toISODate(d));
+  };
+  const label = (iso: string) => {
+    const [, m, d] = iso.split("-");
+    return `${d}/${m}`;
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => shift(-7)}
+        className="rounded-lg border border-slate-300 px-2.5 py-1 text-sm hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-800"
+        aria-label="Previous week"
+      >
+        ←
+      </button>
+      <span className="min-w-[150px] text-center text-sm font-semibold">
+        Sat {label(start)} – Fri {label(end)}
+      </span>
+      <button
+        onClick={() => shift(7)}
+        className="rounded-lg border border-slate-300 px-2.5 py-1 text-sm hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-800"
+        aria-label="Next week"
+      >
+        →
+      </button>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------- flags */
+
+export function DataFlagBadge({ flag }: { flag: string }) {
+  if (flag === "OK") return null;
+  const cls =
+    flag === "Estimated"
+      ? "bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+      : "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200";
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold ${cls}`}>
+      {flag}
+    </span>
+  );
+}

--- a/apps/web/src/lib/factory.test.ts
+++ b/apps/web/src/lib/factory.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deliveryLabel,
+  factoryWeekEnd,
+  factoryWeekStart,
+  productMeta,
+} from './factory';
+
+describe('factoryWeekStart (Sat–Fri reporting week)', () => {
+  it('maps a Saturday to itself', () => {
+    // 2026-07-04 is a Saturday
+    expect(factoryWeekStart('2026-07-04')).toBe('2026-07-04');
+  });
+
+  it('maps a Sunday to the previous day (Saturday)', () => {
+    expect(factoryWeekStart('2026-07-05')).toBe('2026-07-04');
+  });
+
+  it('maps a Friday to the previous Saturday (end of week)', () => {
+    // 2026-07-10 is a Friday → week started 2026-07-04
+    expect(factoryWeekStart('2026-07-10')).toBe('2026-07-04');
+  });
+
+  it('handles month boundaries', () => {
+    // 2026-08-01 is a Saturday; 2026-07-31 (Friday) belongs to the week of 25 Jul
+    expect(factoryWeekStart('2026-08-01')).toBe('2026-08-01');
+    expect(factoryWeekStart('2026-07-31')).toBe('2026-07-25');
+  });
+
+  it('handles year boundaries', () => {
+    // 2027-01-01 is a Friday → its Sat–Fri week began 2026-12-26 (Saturday)
+    expect(factoryWeekStart('2027-01-01')).toBe('2026-12-26');
+  });
+
+  it('week end is always 6 days after week start', () => {
+    expect(factoryWeekEnd('2026-07-04')).toBe('2026-07-10');
+    expect(factoryWeekEnd('2026-07-10')).toBe('2026-07-10');
+    expect(factoryWeekEnd('2026-07-31')).toBe('2026-07-31');
+  });
+
+  it('never shifts a day across the IST/UTC boundary (component parsing)', () => {
+    // If the implementation used new Date('YYYY-MM-DD') (UTC midnight), local
+    // IST rendering would move Saturdays back to Fridays. Component parsing
+    // keeps the calendar date intact regardless of host timezone.
+    for (const sat of ['2026-07-04', '2026-07-11', '2026-08-08', '2026-12-26']) {
+      expect(factoryWeekStart(sat)).toBe(sat);
+    }
+  });
+});
+
+describe('productMeta', () => {
+  it('derives type, size and labour rate from the code', () => {
+    expect(productMeta('MIB-8')).toEqual({ type: 'MIB', size: '8"', labourRate: 7 });
+    expect(productMeta('MIB-6')).toEqual({ type: 'MIB', size: '6"', labourRate: 6 });
+    expect(productMeta('CIB-8')).toEqual({ type: 'CIB', size: '8"', labourRate: 7 });
+    expect(productMeta('CIB-6')).toEqual({ type: 'CIB', size: '6"', labourRate: 6 });
+  });
+});
+
+describe('label composers', () => {
+  it('composes the spec example label', () => {
+    expect(
+      deliveryLabel({
+        delivery_date: '2026-08-04',
+        customer_name: 'Umapathi Sriperumbudur',
+        qty: 1000,
+        product_code: 'CIB-6',
+      }),
+    ).toBe('04/08 Umapathi Sriperumbudur 1000 CIB-6');
+  });
+});

--- a/apps/web/src/lib/factory.ts
+++ b/apps/web/src/lib/factory.ts
@@ -1,0 +1,134 @@
+/**
+ * Factory Ledger shared helpers.
+ *
+ * Sat–Fri reporting weeks, product metadata derived from SKU codes, row-label
+ * composers, and the picklist enums shared by Zod schemas and UI pickers.
+ * Mirrors public.factory_week_start() in the database.
+ *
+ * A pure copy of this file lives at apps/native/src/lib/factory.ts (the native
+ * app has a standalone node_modules tree) — keep the two in sync.
+ */
+
+/** Parse 'YYYY-MM-DD' by components. NEVER new Date('YYYY-MM-DD') — that
+ * parses as UTC midnight, which is the previous day in IST and silently
+ * shifts Sat/Fri week boundaries. */
+export function parseISODate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function toISODate(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Sat–Fri reporting week: the Saturday on or before the given date.
+ * JS getDay(): Sun=0 … Sat=6 → offset (day+1)%7 (Sat→0, Sun→1, Fri→6). */
+export function factoryWeekStart(iso: string): string {
+  const d = parseISODate(iso);
+  d.setDate(d.getDate() - ((d.getDay() + 1) % 7));
+  return toISODate(d);
+}
+
+/** Friday that ends the Sat–Fri week containing the given date. */
+export function factoryWeekEnd(iso: string): string {
+  const d = parseISODate(factoryWeekStart(iso));
+  d.setDate(d.getDate() + 6);
+  return toISODate(d);
+}
+
+/** 'DD/MM' for composed row labels ("04/08 Umapathi Sriperumbudur 1000 CIB-6"). */
+export function shortDate(iso: string): string {
+  const [, m, d] = iso.split('-');
+  return `${d}/${m}`;
+}
+
+// ---------------------------------------------------------------- products
+
+export type FactoryProductCode = 'MIB-8' | 'MIB-6' | 'CIB-8' | 'CIB-6';
+
+export const FACTORY_PRODUCT_CODES: FactoryProductCode[] = [
+  'MIB-8',
+  'MIB-6',
+  'CIB-8',
+  'CIB-6',
+];
+
+/** Type, size and labour rate derive from the code — never stored.
+ * 8" bricks pay ₹7/brick, 6" pay ₹6. Loading is ₹3/brick for every size. */
+export function productMeta(code: FactoryProductCode): {
+  type: 'MIB' | 'CIB';
+  size: '8"' | '6"';
+  labourRate: 7 | 6;
+} {
+  const size = code.endsWith('8') ? '8"' : '6"';
+  return {
+    type: code.startsWith('MIB') ? 'MIB' : 'CIB',
+    size,
+    labourRate: size === '8"' ? 7 : 6,
+  };
+}
+
+export const LOADING_RATE_PER_BRICK = 3;
+
+// ----------------------------------------------------------------- enums
+
+export const DOWNTIME_REASONS = [
+  'None',
+  'Power Cut',
+  'Machine Breakdown',
+  'Raw Material Shortage',
+  'Labour Shortage',
+  'Dye / Profile Change',
+  'Payment Issue',
+  'Holiday',
+  'Other',
+] as const;
+
+export const DATA_FLAGS_PRODUCTION = ['OK', 'Estimated', 'Check - sources disagree'] as const;
+export const DATA_FLAGS_DELIVERY = ['OK', 'Check - sources disagree', 'Qty to confirm'] as const;
+export const DELIVERY_STATUSES = ['Planned', 'Delivered', 'Postponed', 'Cancelled'] as const;
+export const PAYMENT_STATUSES = ['Clear', 'Hold - Payment', 'Cancelled'] as const;
+export const VEHICLES = ['407 Eicher', '439 RDX Tractor', 'Tricycle', 'Other'] as const;
+export const WORK_TYPES = ['Loading', 'Production 6"', 'Production 8"', 'NMR Daily', 'Advance'] as const;
+export const ASSET_CATEGORIES = [
+  'Machinery',
+  'Machinery Tools',
+  'Mechanical Tools',
+  'Vehicles',
+  'Construction Tools',
+  'Electrical & Electronic Tools',
+] as const;
+export const ASSET_LOCATIONS = ['Plant', 'RTO', 'VM', 'Split - see notes', 'Unknown'] as const;
+
+// ---------------------------------------------------------- label composers
+// Row identity is composed from the row's own data — no hand-typed codes.
+
+export function deliveryLabel(d: {
+  delivery_date: string;
+  customer_name: string;
+  qty: number;
+  product_code: string;
+}): string {
+  return `${shortDate(d.delivery_date)} ${d.customer_name} ${d.qty} ${d.product_code}`;
+}
+
+export function orderLabel(o: {
+  customer_name: string;
+  qty_ordered: number;
+  product_code: string;
+}): string {
+  return `${o.customer_name} - ${o.qty_ordered} ${o.product_code}`;
+}
+
+export function productionLabel(r: { log_date: string; product_code: string }): string {
+  return `${shortDate(r.log_date)} ${r.product_code}`;
+}
+
+export function labourLabel(l: {
+  work_date: string;
+  worker: string;
+  work_type: string;
+}): string {
+  return `${shortDate(l.work_date)} ${l.worker} - ${l.work_type}`;
+}

--- a/scripts/seed-factory-ledger.mjs
+++ b/scripts/seed-factory-ledger.mjs
@@ -1,0 +1,479 @@
+/**
+ * Seed the Factory Ledger (factory_* tables) with the migrated Google-Sheet
+ * data. Source of truth: the structured extract in
+ *   C:\Users\Ram Kumaran\Documents\baserow-maiyuri\setup-baserow.ps1
+ * transcribed here ONCE (arrays $productRows/$customerData/$orderData/
+ * $prodData/$planData/$delData/$tripData/$labourData/$assetData).
+ *
+ * Idempotent: natural keys (code / name / date+product / asset+location) and
+ * deterministic seed_key values elsewhere; every insert is ON CONFLICT DO
+ * NOTHING, wrapped in one transaction.
+ *
+ * Run:  DATABASE_URL=postgresql://... node scripts/seed-factory-ledger.mjs
+ * ('pg' must be resolvable — e.g. NODE_PATH=<dir with node_modules/pg>.)
+ */
+import pg from 'pg';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL env var is required');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------- datasets
+
+// Opening stock deliberately NULL: the physical stock-take has not happened.
+// The UI shows a stock-take banner until opening_counted_at is set.
+const PRODUCTS = [
+  { code: 'MIB-8', notes: 'Mud interlock brick 8". Loading paid separately at Rs.3/brick.' },
+  { code: 'MIB-6', notes: 'Mud interlock brick 6".' },
+  { code: 'CIB-8', notes: 'Cement interlock brick 8".' },
+  { code: 'CIB-6', notes: 'Cement interlock brick 6". July deliveries exceeded July production by 5,438 - enter the real 01-Jul opening count here.' },
+];
+
+const CUSTOMERS = [
+  { name: 'KL Associates', location: '', notes: 'Sheet variants: KL ASSOCIATES, kl associates, KL-Associate.' },
+  { name: 'Old Erumavettipalayam (Selvam)', location: 'Erumavettipalayam', notes: 'Weekly plan calls the same deliveries "RTO Site" - confirm whether these are one customer.' },
+  { name: 'RTO Site', location: '', notes: 'POSSIBLE DUPLICATE of Old Erumavettipalayam (Selvam) - same dates and quantities in the weekly plan. Merge if confirmed.' },
+  { name: 'Yuvaraj Sampath Construction', location: 'Moolakadai', notes: 'Sheet variants: Yuvaraj sambath construction, Sampath construction Yuvraj, YUVARAJ MOOLAKADAI.' },
+  { name: 'Murali Perungavur', location: 'Perungavur', notes: 'Also spelled "murali sirungavur" in the daily sheet - treated as the same customer.' },
+  { name: 'Siva Thamaraipakkam', location: 'Thamaraipakkam', notes: '' },
+  { name: 'Gopalakrishnan Kodambakkam', location: 'Kodambakkam', notes: '' },
+  { name: 'Arul Kundrathur', location: 'Kundrathur', notes: '' },
+  { name: 'Bharani Shanmugam Kundrathur', location: 'Kundrathur', notes: 'Advance 1,200 recorded 31/07.' },
+  { name: 'Umapathi Sriperumbudur', location: 'Sriperumbudur', notes: '' },
+  { name: 'Asif Periyapalayam', location: 'Periyapalayam', notes: '' },
+  { name: 'Padmanabhan (Kishore) Redhills', location: 'Redhills', notes: '' },
+  { name: 'Jeevan Pattabiram', location: 'Pattabiram', notes: 'Advance 10,000 received 27/07.' },
+  { name: 'Josep Ponneri', location: 'Ponneri', notes: '' },
+  { name: 'Sivakumar Pudhur', location: 'Pudhur', notes: '' },
+  { name: 'Kabilan Arakkonam', location: 'Arakkonam', notes: '' },
+  { name: 'Senthil Tambaram', location: 'Tambaram', notes: '2,700 bricks on hold due to payment.', hold: true },
+  { name: 'Rajagopal Thervai', location: 'Thervai', notes: '1,000 x 6" CIB on hold due to payment.', hold: true },
+];
+
+const ORDERS = [
+  { k: 'ord-001', date: '2026-07-02', cust: 'Senthil Tambaram', prod: 'MIB-8', qty: 900, pay: 'Hold - Payment', notes: 'Part of a 3,500 brick 8" MIB commitment.' },
+  { k: 'ord-002', date: '2026-07-05', cust: 'Senthil Tambaram', prod: 'MIB-8', qty: 900, pay: 'Hold - Payment', notes: '' },
+  { k: 'ord-003', date: '2026-07-08', cust: 'Senthil Tambaram', prod: 'MIB-8', qty: 900, pay: 'Hold - Payment', notes: '' },
+  { k: 'ord-004', date: '2026-07-20', cust: 'Jeevan Pattabiram', prod: 'MIB-8', qty: 5120, pay: 'Clear', notes: 'Largest open order. Advance 10,000 received 27/07. Scheduled 14/08-18/08.' },
+  { k: 'ord-005', date: '2026-07-07', cust: 'Rajagopal Thervai', prod: 'CIB-6', qty: 1000, pay: 'Hold - Payment', notes: '' },
+  { k: 'ord-006', date: '2026-06-29', cust: 'Umapathi Sriperumbudur', prod: 'MIB-8', qty: 450, pay: 'Clear', notes: '' },
+  { k: 'ord-007', date: '2026-06-29', cust: 'Umapathi Sriperumbudur', prod: 'CIB-6', qty: 300, pay: 'Clear', notes: '1,000 x 6" CIB delivered 04/08 exceeds this order - check whether a larger order was never written down.' },
+  { k: 'ord-008', date: '2026-06-28', cust: 'Yuvaraj Sampath Construction', prod: 'MIB-8', qty: 2000, pay: 'Clear', notes: '' },
+  { k: 'ord-009', date: '2026-07-09', cust: 'Josep Ponneri', prod: 'MIB-8', qty: 2950, pay: 'Clear', notes: 'Sheet records this as mixed 8" MIB + 6" MIB with no split. Booked here as 8" MIB - split it once the mix is confirmed.' },
+  { k: 'ord-010', date: '2026-07-07', cust: 'Padmanabhan (Kishore) Redhills', prod: 'MIB-8', qty: 2800, pay: 'Clear', notes: 'Scheduled 09/08-11/08.' },
+  { k: 'ord-011', date: '2026-07-07', cust: 'Padmanabhan (Kishore) Redhills', prod: 'MIB-6', qty: 1100, pay: 'Clear', notes: '' },
+  { k: 'ord-012', date: '2026-07-09', cust: 'Siva Thamaraipakkam', prod: 'MIB-8', qty: 600, pay: 'Clear', notes: 'Order book says delivered 13/07, daily sheet says 11/07 - dispatch record uses 11/07.' },
+];
+
+// One row per date + product. dr defaults 'None', fl defaults 'OK'.
+const PROD_LOG = [
+  { d: '2026-07-02', pr: 'MIB-8', q: 336, cm: 8 },
+  { d: '2026-07-03', pr: 'MIB-8', q: 913, cm: 22 },
+  { d: '2026-07-04', pr: 'MIB-8', q: 650, cm: 15 },
+  { d: '2026-07-06', pr: 'MIB-8', q: 1141, cm: 27 },
+  { d: '2026-07-07', pr: 'MIB-8', q: 1001, cm: 23 },
+  { d: '2026-07-08', pr: 'CIB-8', q: 816, cm: 19 },
+  { d: '2026-07-09', pr: 'CIB-8', q: 882, cm: 21 },
+  { d: '2026-07-10', pr: 'MIB-8', q: 597, cm: 13 },
+  { d: '2026-07-15', pr: 'CIB-6', q: 1618, cm: 30 },
+  { d: '2026-07-16', pr: 'CIB-6', q: 821, cm: 16 },
+  { d: '2026-07-17', pr: 'CIB-6', q: 1461, cm: 29 },
+  { d: '2026-07-18', pr: 'CIB-6', q: 1262, cm: 24, rm: 'Delivery postponed this day due to insufficient stock.' },
+  { d: '2026-07-19', pr: 'CIB-6', q: 270, cm: 6 },
+  { d: '2026-07-20', pr: 'CIB-6', q: 1060, cm: 19.5 },
+  { d: '2026-07-21', pr: 'CIB-6', q: 530, cm: 10, dr: 'Power Cut', rm: 'Power shutdown.' },
+  { d: '2026-07-22', pr: 'CIB-6', q: 680, cm: 13 },
+  { d: '2026-07-23', pr: 'CIB-6', q: 838, cm: 16 },
+  { d: '2026-07-24', pr: 'CIB-6', q: 699, cm: 13, dr: 'Dye / Profile Change', rm: '8" MIB dye changing work.' },
+  { d: '2026-07-25', pr: 'CIB-6', q: 542, cm: 10 },
+  { d: '2026-07-26', pr: 'CIB-6', q: 0, cm: 0, dr: 'Labour Shortage', rm: 'No production - labourers were tired (Ramjan).' },
+  { d: '2026-07-27', pr: 'CIB-6', q: 590, cm: 11 },
+  { d: '2026-07-28', pr: 'CIB-6', q: 0, cm: 0, dr: 'Machine Breakdown', rm: 'No production - machine feeder seal damaged.' },
+  { d: '2026-07-29', pr: 'CIB-6', q: 0, cm: 0, dr: 'Machine Breakdown', rm: 'No production - machine feeder seal damaged.' },
+  { d: '2026-07-30', pr: 'CIB-6', q: 199, cm: 4 },
+  { d: '2026-07-31', pr: 'CIB-6', q: 815, cm: 16 },
+  { d: '2026-08-01', pr: 'MIB-8', q: 485, cm: 12 },
+  { d: '2026-08-02', pr: 'MIB-8', q: 504, cm: 11 },
+  { d: '2026-08-03', pr: 'MIB-8', q: 581, cm: 0, dr: 'Power Cut', rm: 'Night power cut. Cement bags not recorded for this day.' },
+  { d: '2026-08-04', pr: 'MIB-8', q: 300, cm: 6.7, fl: 'Estimated', rm: 'Red soil not available so 8" CIB was made instead. Day total 14 cement bags split proportionally.' },
+  { d: '2026-08-04', pr: 'CIB-8', q: 329, cm: 7.3, fl: 'Estimated', rm: 'Day total 14 cement bags split proportionally between MIB-8 and CIB-8.' },
+  { d: '2026-08-05', pr: 'MIB-8', q: 401, cm: 9.0, fl: 'Estimated', rm: 'Day total 27 cement bags split proportionally between MIB-8 and CIB-8.' },
+  { d: '2026-08-05', pr: 'CIB-8', q: 796, cm: 18.0, fl: 'Estimated', rm: 'Day total 27 cement bags split proportionally between MIB-8 and CIB-8.' },
+  { d: '2026-08-06', pr: 'MIB-8', q: 600, cm: 0, dr: 'Power Cut', rm: 'Power cut 08:30 to 14:00. Cement bags not recorded.' },
+  { d: '2026-08-07', pr: 'MIB-8', q: 258, cm: 0, fl: 'Check - sources disagree', rm: 'Labour reckoning block records 258; weekly plan records 1,192 for the same day. 258 used here - confirm which is right.' },
+];
+
+const PLAN = [
+  { d: '2026-07-15', pr: 'CIB-6', pl: 1600, n: '6" brick production' },
+  { d: '2026-07-16', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-17', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-18', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-19', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-20', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-21', pr: 'CIB-6', pl: 800, n: 'Power shutdown' },
+  { d: '2026-07-22', pr: 'CIB-6', pl: 800, n: '6" brick production' },
+  { d: '2026-07-23', pr: 'CIB-6', pl: 1400, n: '6" brick production' },
+  { d: '2026-07-24', pr: 'CIB-6', pl: 0, n: '8" MIB dye changing work' },
+  { d: '2026-07-25', pr: 'CIB-6', pl: 1400, n: '6" CIB production' },
+  { d: '2026-07-26', pr: 'CIB-6', pl: 0, n: 'No production - labour' },
+  { d: '2026-07-27', pr: 'CIB-6', pl: 1400, n: '6" CIB production' },
+  { d: '2026-07-28', pr: 'CIB-6', pl: 1500, n: 'Machine feeder seal damaged' },
+  { d: '2026-07-29', pr: 'CIB-6', pl: 1500, n: 'Machine feeder seal damaged' },
+  { d: '2026-07-30', pr: 'CIB-6', pl: 1500, n: '6" CIB production' },
+  { d: '2026-07-31', pr: 'CIB-6', pl: 1500, n: '6" CIB production' },
+  { d: '2026-08-01', pr: 'MIB-8', pl: 800, n: '8" MIB production' },
+  { d: '2026-08-02', pr: 'MIB-8', pl: 0, n: '8" MIB production' },
+  { d: '2026-08-03', pr: 'MIB-8', pl: 1300, n: 'Night power cut' },
+  { d: '2026-08-04', pr: 'MIB-8', pl: 1300, n: 'Red soil not available so 8" CIB made' },
+  { d: '2026-08-05', pr: 'MIB-8', pl: 1300, n: '8" MIB production' },
+  { d: '2026-08-06', pr: 'MIB-8', pl: 1300, n: 'Power cut 08:30 to 14:00' },
+  { d: '2026-08-07', pr: 'MIB-8', pl: 1300, n: 'Weekly sheet claims 1,192 - unresolved' },
+  { d: '2026-08-08', pr: 'MIB-8', pl: 1300, n: '8" MIB production' },
+  { d: '2026-08-09', pr: 'MIB-8', pl: 1300, n: '8" MIB production' },
+  { d: '2026-08-10', pr: 'MIB-8', pl: 1300, n: '8" MIB production' },
+  { d: '2026-08-11', pr: 'MIB-8', pl: 1300, n: '8" MIB production' },
+  { d: '2026-08-12', pr: 'CIB-6', pl: 1100, n: 'Profile changing 6" CIB' },
+  { d: '2026-08-13', pr: 'CIB-6', pl: 2000, n: '6" CIB production' },
+  { d: '2026-08-14', pr: 'CIB-6', pl: 2000, n: '6" CIB production' },
+  { d: '2026-08-15', pr: 'CIB-6', pl: 2000, n: '6" CIB production' },
+  { d: '2026-08-16', pr: 'CIB-6', pl: 2000, n: '6" CIB production' },
+  { d: '2026-08-17', pr: 'MIB-8', pl: 0, n: 'Profile changing 8" MIB' },
+  { d: '2026-08-18', pr: 'MIB-8', pl: 0, n: 'Profile changing 8" MIB' },
+  { d: '2026-08-19', pr: 'MIB-8', pl: 0, n: 'Profile changing 8" MIB' },
+  { d: '2026-08-20', pr: 'MIB-8', pl: 0, n: 'Profile changing 8" MIB' },
+  { d: '2026-08-21', pr: 'MIB-8', pl: 0, n: 'Profile changing 8" MIB' },
+];
+
+const TRIPS = [
+  { k: 'trip-001', d: '2026-07-31', v: '407 Eicher', s: 213003, e: 213094, l: 18.2, n: 'Arul - Kundrathur.' },
+  { k: 'trip-002', d: '2026-08-01', v: '407 Eicher', s: 213094, e: 213135, l: 8.2, n: 'Yuvaraj - Moolakadai.' },
+  { k: 'trip-003', d: '2026-08-04', v: '407 Eicher', s: 213135, e: 213256, l: 24.2, n: 'Umapathi - Sriperumbudur. Rs.2,000 fuel purchase recorded against 20.10 litres.' },
+];
+
+// st defaults 'Delivered', fl defaults 'OK'. or/tr reference seed keys above.
+const DELIVERIES = [
+  { d: '2026-07-03', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-05', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-08', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-10', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-11', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-11', cu: 'Siva Thamaraipakkam', pr: 'MIB-8', q: 600, or: 'ord-012', fl: 'Check - sources disagree', n: 'Daily sheet says 11/07, order book says 13/07.' },
+  { d: '2026-07-13', cu: 'Yuvaraj Sampath Construction', pr: 'MIB-8', q: 1000, or: 'ord-008' },
+  { d: '2026-07-13', cu: 'Murali Perungavur', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-14', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-15', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 823 },
+  { d: '2026-07-17', cu: 'Gopalakrishnan Kodambakkam', pr: 'MIB-8', q: 1000 },
+  { d: '2026-07-19', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-19', cu: 'Yuvaraj Sampath Construction', pr: 'MIB-8', q: 1000, or: 'ord-008' },
+  { d: '2026-07-20', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-20', cu: 'Yuvaraj Sampath Construction', pr: 'CIB-8', q: 1000 },
+  { d: '2026-07-21', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000, fl: 'Check - sources disagree', n: 'Daily sheet row shows both 1,000 x 6" CIB and 1,000 x 8" CIB against a stated total of 1,000.' },
+  { d: '2026-07-21', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-8', q: 1000, fl: 'Check - sources disagree', n: 'Second half of the same ambiguous row - confirm whether 1,000 or 2,000 actually went out.' },
+  { d: '2026-07-22', cu: 'KL Associates', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-22', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-22', cu: 'KL Associates', pr: 'CIB-6', q: 1000, fl: 'Check - sources disagree', n: 'Third delivery logged against 22/07 - possible duplicate entry in the daily sheet.' },
+  { d: '2026-07-24', cu: 'Yuvaraj Sampath Construction', pr: 'CIB-8', q: 1000 },
+  { d: '2026-07-25', cu: 'Murali Perungavur', pr: 'MIB-6', q: 800, fl: 'Check - sources disagree', n: 'Daily sheet spells this "murali sirungavur".' },
+  { d: '2026-07-26', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-27', cu: 'Yuvaraj Sampath Construction', pr: 'MIB-8', q: 855, fl: 'Check - sources disagree', n: 'Total column says 855, product column says 1,000.' },
+  { d: '2026-07-29', cu: 'Old Erumavettipalayam (Selvam)', pr: 'CIB-6', q: 1000 },
+  { d: '2026-07-31', cu: 'Arul Kundrathur', pr: 'CIB-6', q: 1000, tr: 'trip-001' },
+  { d: '2026-08-01', cu: 'Yuvaraj Sampath Construction', pr: 'CIB-8', q: 1000, tr: 'trip-002' },
+  { d: '2026-08-04', cu: 'Umapathi Sriperumbudur', pr: 'CIB-6', q: 1000, or: 'ord-007', tr: 'trip-003', fl: 'Check - sources disagree', n: 'Order on file is only 300.' },
+  { d: '2026-08-07', cu: 'Asif Periyapalayam', pr: 'MIB-8', q: 550 },
+  { d: '2026-08-08', cu: 'Asif Periyapalayam', pr: 'MIB-6', q: 550, st: 'Planned' },
+  { d: '2026-08-09', cu: 'Padmanabhan (Kishore) Redhills', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-010' },
+  { d: '2026-08-10', cu: 'Padmanabhan (Kishore) Redhills', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-010' },
+  { d: '2026-08-11', cu: 'Padmanabhan (Kishore) Redhills', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-010' },
+  { d: '2026-08-14', cu: 'Jeevan Pattabiram', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-004' },
+  { d: '2026-08-14', cu: 'Jeevan Pattabiram', pr: 'CIB-6', q: 300, st: 'Planned' },
+  { d: '2026-08-15', cu: 'Jeevan Pattabiram', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-004' },
+  { d: '2026-08-16', cu: 'Jeevan Pattabiram', pr: 'MIB-8', q: 1000, st: 'Planned', or: 'ord-004' },
+  { d: '2026-08-17', cu: 'Jeevan Pattabiram', pr: 'MIB-8', q: 1050, st: 'Planned', or: 'ord-004', n: 'Advance 10,000 received 27/07.' },
+  { d: '2026-08-18', cu: 'Jeevan Pattabiram', pr: 'MIB-8', q: 1070, st: 'Planned', or: 'ord-004' },
+  { d: '2026-08-18', cu: 'Arul Kundrathur', pr: 'CIB-6', q: 1200, st: 'Planned' },
+  { d: '2026-08-19', cu: 'Senthil Tambaram', pr: 'MIB-6', q: 200, st: 'Planned', n: 'CREDIT HOLD - do not dispatch until payment clears.' },
+  { d: '2026-08-19', cu: 'Senthil Tambaram', pr: 'MIB-8', q: 800, st: 'Planned', or: 'ord-001', n: 'CREDIT HOLD - do not dispatch until payment clears.' },
+  { d: '2026-08-20', cu: 'Sivakumar Pudhur', pr: 'MIB-8', q: 1000, st: 'Planned', n: 'No order recorded in the order book.' },
+  { d: '2026-08-21', cu: 'Sivakumar Pudhur', pr: 'MIB-8', q: 1000, st: 'Planned' },
+  { d: '2026-08-22', cu: 'Sivakumar Pudhur', pr: 'MIB-8', q: 1000, st: 'Planned' },
+  { d: '2026-08-23', cu: 'Josep Ponneri', pr: 'MIB-8', q: 2950, st: 'Planned', or: 'ord-009', n: 'Order is mixed 8"/6" MIB - split before dispatch.' },
+  { d: '2026-08-24', cu: 'Umapathi Sriperumbudur', pr: 'CIB-6', q: 1000, st: 'Planned' },
+  { d: '2026-08-25', cu: 'Kabilan Arakkonam', pr: 'MIB-8', q: 0, st: 'Planned', fl: 'Qty to confirm', n: 'Weekly plan lists the customer with no product or quantity.' },
+  { d: '2026-08-26', cu: 'Arul Kundrathur', pr: 'MIB-8', q: 0, st: 'Planned', fl: 'Qty to confirm', n: 'Weekly plan lists the customer with no product or quantity.' },
+];
+
+// Advances carry a negative rate so amount = qty × rate holds for every row.
+const LABOUR = [
+  { d: '2026-07-25', wk: 'Production team', ty: 'Loading', q: 9800, r: 3, n: '10 loads, week 19/07-25/07.' },
+  { d: '2026-07-25', wk: 'Production team', ty: 'Production 6"', q: 4726, r: 6, n: 'Week 19/07-25/07.' },
+  { d: '2026-07-25', wk: 'Production team', ty: 'Advance', q: 1, r: -3500, n: 'Salary advance.' },
+  { d: '2026-07-25', wk: 'Ramjan', ty: 'Advance', q: 1, r: -1000, n: 'Advance. Week net paid: 53,256.' },
+  { d: '2026-08-01', wk: 'Production team', ty: 'Loading', q: 4855, r: 3, n: '5 loads, week 26/07-01/08.' },
+  { d: '2026-08-01', wk: 'Production team', ty: 'Production 6"', q: 1604, r: 6, n: 'Week 26/07-01/08.' },
+  { d: '2026-08-01', wk: 'Production team', ty: 'Production 8"', q: 485, r: 7, n: 'Week 26/07-01/08.' },
+  { d: '2026-08-01', wk: 'Production team', ty: 'Advance', q: 1, r: -5000, n: 'Salary advance.' },
+  { d: '2026-08-01', wk: 'Ramjan', ty: 'Advance', q: 1, r: -1000, n: 'Advance. Week net paid: 21,584.' },
+  { d: '2026-08-08', wk: 'Production team', ty: 'Loading', q: 2550, r: 3, n: '3 loads, week 02/08-08/08.' },
+  { d: '2026-08-08', wk: 'Production team', ty: 'Production 8"', q: 3769, r: 7, n: 'Week 02/08-08/08.' },
+  { d: '2026-08-08', wk: 'Santu', ty: 'Advance', q: 1, r: -6000, n: 'Salary advance. Running advance balance 14,000.' },
+  { d: '2026-08-08', wk: 'Ramjan', ty: 'Advance', q: 1, r: -1000, n: 'Advance. Running balance 10,000. Week net paid: 27,033.' },
+  { d: '2026-08-03', wk: 'Jerman Shke', ty: 'NMR Daily', q: 1, r: 1000, n: 'Pan mixer concrete work.' },
+  { d: '2026-08-03', wk: 'Rohith', ty: 'NMR Daily', q: 1, r: 800, n: 'Electrical pipe binding work.' },
+  { d: '2026-08-04', wk: 'Jerman Shke', ty: 'NMR Daily', q: 1, r: 1000, n: 'Pan mixer concrete work.' },
+  { d: '2026-08-04', wk: 'Rohith', ty: 'NMR Daily', q: 1, r: 800, n: 'Electrical pipe binding work.' },
+  { d: '2026-08-05', wk: 'Jerman Shke', ty: 'NMR Daily', q: 1, r: 1000, n: 'Bathroom pointing work.' },
+  { d: '2026-08-05', wk: 'Rohith', ty: 'NMR Daily', q: 1, r: 800, n: 'Filth beam work.' },
+  { d: '2026-08-06', wk: 'Samurul', ty: 'NMR Daily', q: 1, r: 600, n: 'Painting work.' },
+  { d: '2026-08-07', wk: 'Ramzan', ty: 'NMR Daily', q: 1, r: 800, n: 'Plate fixing and cutting work.' },
+];
+
+const ASSETS = [
+  ['Interlock brick machine', 'Machinery', 1, 'Plant', 'Quantity not stated in the sheet - assumed 1.'],
+  ['Hydraulic power pack', 'Machinery', 1, 'Plant', 'Quantity not stated in the sheet - assumed 1.'],
+  ['Pan mixer small (5HP motor)', 'Machinery', 1, 'Plant', 'Quantity not stated in the sheet - assumed 1.'],
+  ['Pan mixer big (7.5HP motor)', 'Machinery', 1, 'Plant', 'Quantity not stated in the sheet - assumed 1.'],
+  ['Weighing machine 50-100 kg', 'Machinery', 2, 'Plant', ''],
+  ['14" cutting machine', 'Machinery', 1, 'RTO', ''],
+  ['AG4 cutting machine', 'Machinery', 1, 'RTO', ''],
+  ['Generator', 'Machinery', 1, 'Plant', ''],
+  ['Sensor', 'Machinery', 7, 'Plant', ''],
+  ['Machine handle', 'Machinery Tools', 1, 'Plant', ''],
+  ['Bricks dye', 'Machinery Tools', 1, 'Plant', ''],
+  ['Dyes 6"', 'Machinery Tools', 2, 'Plant', ''],
+  ['Solid block dye', 'Machinery Tools', 1, 'Plant', ''],
+  ['Dyes 8"', 'Machinery Tools', 2, 'Plant', '1 of these is new.'],
+  ['Spanner set (21/23, 14/15, 18/19, 7/16, 5/16, 16/17)', 'Mechanical Tools', 1, 'Plant', '1 each.'],
+  ['Allen key box', 'Mechanical Tools', 1, 'Plant', ''],
+  ['Grease gun', 'Mechanical Tools', 1, 'Plant', ''],
+  ['10mm spanner', 'Mechanical Tools', 2, 'Plant', ''],
+  ['Circlip plier', 'Mechanical Tools', 1, 'Plant', ''],
+  ['Welding rods', 'Mechanical Tools', 50, 'Plant', ''],
+  ['Tool box - wrench bits', 'Mechanical Tools', 1, 'Plant', ''],
+  ['407 Eicher', 'Vehicles', 1, 'Plant', ''],
+  ['439 RDX tractor', 'Vehicles', 1, 'Plant', ''],
+  ['Tricycle big', 'Vehicles', 1, 'Plant', ''],
+  ['Two wheel trolley small', 'Vehicles', 1, 'Plant', ''],
+  ['Four wheel trolley big', 'Vehicles', 1, 'Plant', ''],
+  ['Spade (manvetti)', 'Construction Tools', 7, 'Plant', ''],
+  ['Hoe', 'Construction Tools', 3, 'Plant', ''],
+  ['Bond big', 'Construction Tools', 2, 'Plant', ''],
+  ['Bond small', 'Construction Tools', 4, 'Plant', ''],
+  ['Plastic bond', 'Construction Tools', 3, 'Split - see notes', 'Plant 3, RTO 5, VM 4.'],
+  ['Centring hammer', 'Construction Tools', 3, 'Split - see notes', 'Plant 3, VM 2.'],
+  ['Hammer', 'Construction Tools', 2, 'Split - see notes', 'Plant 2, VM 1.'],
+  ['Screed board', 'Construction Tools', 1, 'Plant', ''],
+  ['Ghuthirai', 'Construction Tools', 4, 'VM', ''],
+  ['Water tank (1000 ltr)', 'Construction Tools', 8, 'Split - see notes', 'Plant 8, RTO 3, VM 1.'],
+  ['Barrel (200 ltr)', 'Construction Tools', 9, 'Split - see notes', 'Plant 9, RTO 6.'],
+  ['Hook', 'Construction Tools', 4, 'Split - see notes', 'RTO and VM 2.'],
+  ['Tube level', 'Construction Tools', 2, 'Split - see notes', 'RTO 1, VM 1.'],
+  ['12mm lever', 'Construction Tools', 12, 'Split - see notes', 'RTO 1, VM 1.'],
+  ['8mm lever', 'Construction Tools', 0, 'Unknown', 'Listed in the sheet with no quantity.'],
+  ['16mm lever', 'Construction Tools', 1, 'RTO', ''],
+  ['Spirit level', 'Construction Tools', 1, 'Plant', ''],
+  ['Tape 50m', 'Construction Tools', 1, 'Plant', ''],
+  ['Plastic bucket', 'Construction Tools', 9, 'Plant', ''],
+  ['HDPE drum', 'Construction Tools', 5, 'Plant', ''],
+  ['Axe big', 'Construction Tools', 2, 'Plant', ''],
+  ['Axe small', 'Construction Tools', 1, 'Plant', ''],
+  ['Crowbar', 'Construction Tools', 2, 'Plant', ''],
+  ['Levelling wood 5ft / 3ft', 'Construction Tools', 2, 'Plant', '1 each.'],
+  ['Metal bucket', 'Construction Tools', 1, 'Plant', ''],
+  ['Sand shewar', 'Construction Tools', 2, 'Plant', ''],
+  ['Junction box cable', 'Electrical & Electronic Tools', 1, 'Plant', ''],
+  ['Tester', 'Electrical & Electronic Tools', 2, 'Plant', '1 is new.'],
+  ['Sensor - new model', 'Electrical & Electronic Tools', 2, 'Plant', ''],
+  ['Sensor - old model', 'Electrical & Electronic Tools', 7, 'Plant', ''],
+  ['Hydraulic valve', 'Electrical & Electronic Tools', 1, 'Plant', ''],
+];
+
+// ------------------------------------------------------------------ seeding
+
+const client = new pg.Client({
+  connectionString: DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+const pad3 = (n) => String(n + 1).padStart(3, '0');
+
+async function main() {
+  await client.connect();
+  await client.query('BEGIN');
+  const counts = {};
+
+  // products
+  let inserted = 0;
+  for (const p of PRODUCTS) {
+    const r = await client.query(
+      `INSERT INTO factory_products (code, notes) VALUES ($1, $2)
+       ON CONFLICT (code) DO NOTHING`,
+      [p.code, p.notes],
+    );
+    inserted += r.rowCount;
+  }
+  counts.products = inserted;
+  const prodMap = {};
+  for (const row of (await client.query('SELECT id, code FROM factory_products')).rows) {
+    prodMap[row.code] = row.id;
+  }
+
+  // customers
+  inserted = 0;
+  for (const c of CUSTOMERS) {
+    const r = await client.query(
+      `INSERT INTO factory_customers (name, location, phone, credit_hold, notes)
+       VALUES ($1, $2, NULL, $3, $4) ON CONFLICT (name) DO NOTHING`,
+      [c.name, c.location || null, !!c.hold, c.notes],
+    );
+    inserted += r.rowCount;
+  }
+  counts.customers = inserted;
+  const custMap = {};
+  for (const row of (await client.query('SELECT id, name FROM factory_customers')).rows) {
+    custMap[row.name] = row.id;
+  }
+
+  // orders
+  inserted = 0;
+  for (const o of ORDERS) {
+    const r = await client.query(
+      `INSERT INTO factory_orders
+        (customer_id, order_date, product_id, qty_ordered, payment_status, seed_key, notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (seed_key) DO NOTHING`,
+      [custMap[o.cust], o.date, prodMap[o.prod], o.qty, o.pay, o.k, o.notes || null],
+    );
+    inserted += r.rowCount;
+  }
+  counts.orders = inserted;
+  const orderMap = {};
+  for (const row of (
+    await client.query('SELECT id, seed_key FROM factory_orders WHERE seed_key IS NOT NULL')
+  ).rows) {
+    orderMap[row.seed_key] = row.id;
+  }
+
+  // trips
+  inserted = 0;
+  for (const t of TRIPS) {
+    const r = await client.query(
+      `INSERT INTO factory_trips
+        (trip_date, vehicle, start_km, end_km, diesel_litres, seed_key, notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (seed_key) DO NOTHING`,
+      [t.d, t.v, t.s, t.e, t.l, t.k, t.n || null],
+    );
+    inserted += r.rowCount;
+  }
+  counts.trips = inserted;
+  const tripMap = {};
+  for (const row of (
+    await client.query('SELECT id, seed_key FROM factory_trips WHERE seed_key IS NOT NULL')
+  ).rows) {
+    tripMap[row.seed_key] = row.id;
+  }
+
+  // production log
+  inserted = 0;
+  for (const p of PROD_LOG) {
+    const r = await client.query(
+      `INSERT INTO factory_production_log
+        (log_date, product_id, qty_produced, cement_bags, downtime_reason, remarks, data_flag)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (log_date, product_id) DO NOTHING`,
+      [p.d, prodMap[p.pr], p.q, p.cm ?? null, p.dr ?? 'None', p.rm ?? null, p.fl ?? 'OK'],
+    );
+    inserted += r.rowCount;
+  }
+  counts.production_log = inserted;
+
+  // production plan
+  inserted = 0;
+  for (const p of PLAN) {
+    const r = await client.query(
+      `INSERT INTO factory_production_plan (plan_date, product_id, planned_qty, plan_note)
+       VALUES ($1, $2, $3, $4) ON CONFLICT (plan_date, product_id) DO NOTHING`,
+      [p.d, prodMap[p.pr], p.pl, p.n || null],
+    );
+    inserted += r.rowCount;
+  }
+  counts.production_plan = inserted;
+
+  // deliveries
+  inserted = 0;
+  for (let i = 0; i < DELIVERIES.length; i++) {
+    const d = DELIVERIES[i];
+    const r = await client.query(
+      `INSERT INTO factory_deliveries
+        (delivery_date, customer_id, product_id, qty, status, order_id, trip_id,
+         data_flag, seed_key, notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       ON CONFLICT (seed_key) DO NOTHING`,
+      [
+        d.d, custMap[d.cu], prodMap[d.pr], d.q, d.st ?? 'Delivered',
+        d.or ? orderMap[d.or] : null, d.tr ? tripMap[d.tr] : null,
+        d.fl ?? 'OK', `del-${pad3(i)}`, d.n ?? null,
+      ],
+    );
+    inserted += r.rowCount;
+  }
+  counts.deliveries = inserted;
+
+  // labour
+  inserted = 0;
+  for (let i = 0; i < LABOUR.length; i++) {
+    const l = LABOUR[i];
+    const r = await client.query(
+      `INSERT INTO factory_labour (work_date, worker, work_type, qty, rate, seed_key, notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (seed_key) DO NOTHING`,
+      [l.d, l.wk, l.ty, l.q, l.r, `lab-${pad3(i)}`, l.n || null],
+    );
+    inserted += r.rowCount;
+  }
+  counts.labour = inserted;
+
+  // assets
+  inserted = 0;
+  for (const [asset, category, qty, location, notes] of ASSETS) {
+    const r = await client.query(
+      `INSERT INTO factory_assets (asset, category, qty, location, notes)
+       VALUES ($1, $2, $3, $4, $5) ON CONFLICT (asset, location) DO NOTHING`,
+      [asset, category, qty, location, notes || null],
+    );
+    inserted += r.rowCount;
+  }
+  counts.assets = inserted;
+
+  await client.query('COMMIT');
+  console.log('inserted (0 = already seeded):', JSON.stringify(counts, null, 1));
+
+  const { rows: stock } = await client.query(
+    'SELECT code, produced, delivered, committed, stock_balance, free_stock, bricks_per_bag FROM factory_stock_v ORDER BY code',
+  );
+  console.log('\nfactory_stock_v:');
+  for (const s of stock) {
+    console.log(
+      ` ${s.code}: produced=${s.produced} delivered=${s.delivered} committed=${s.committed}` +
+        ` balance=${s.stock_balance} free=${s.free_stock} bricks/bag=${s.bricks_per_bag}`,
+    );
+  }
+  const { rows: orders } = await client.query(
+    "SELECT customer_name, qty_ordered, delivered, balance_due, fulfilment FROM factory_orders_v ORDER BY order_date",
+  );
+  console.log('\nfactory_orders_v:');
+  for (const o of orders) {
+    console.log(
+      ` ${o.customer_name}: ordered=${o.qty_ordered} delivered=${o.delivered}` +
+        ` balance=${o.balance_due} (${o.fulfilment})`,
+    );
+  }
+}
+
+main()
+  .catch(async (e) => {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error('SEED FAILED:', e.message);
+    process.exitCode = 1;
+  })
+  .finally(() => client.end());

--- a/supabase/migrations/20260808120000_factory_ledger.sql
+++ b/supabase/migrations/20260808120000_factory_ledger.sql
@@ -1,0 +1,239 @@
+-- ============================================================================
+-- Factory Ledger: replaces the factory Google Sheet with a proper ledger.
+-- 9 tables under the factory_ namespace (products/deliveries/orders collide
+-- with existing app tables), Sat–Fri reporting weeks via factory_week_start(),
+-- and derived-only stock & order fulfilment via views. Writes go through
+-- service-role /api/factory routes; RLS grants authenticated reads.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Sat–Fri reporting week: shift any date back to its Saturday.
+-- Postgres DOW: Sun=0 … Sat=6 → offset (dow+1)%7 (Sat→0, Sun→1, Fri→6).
+CREATE OR REPLACE FUNCTION public.factory_week_start(d date)
+RETURNS date LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT d - ((EXTRACT(DOW FROM d)::int + 1) % 7) $$;
+
+-- ----------------------------------------------------------------- products
+CREATE TABLE IF NOT EXISTS public.factory_products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT NOT NULL UNIQUE CHECK (code IN ('MIB-8','MIB-6','CIB-8','CIB-6')),
+  -- NULL = physical stock-take not done yet (drives the UI banner).
+  -- A deliberate count of 0 is recorded by setting opening_counted_at.
+  opening_stock NUMERIC(10,0),
+  opening_counted_at DATE,
+  finished_good_id UUID REFERENCES public.finished_goods(id), -- future linkage only
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------- customers
+CREATE TABLE IF NOT EXISTS public.factory_customers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  location TEXT,
+  phone TEXT,
+  credit_hold BOOLEAN NOT NULL DEFAULT false,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ------------------------------------------------------------------- orders
+CREATE TABLE IF NOT EXISTS public.factory_orders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id UUID NOT NULL REFERENCES public.factory_customers(id),
+  order_date DATE NOT NULL,
+  product_id UUID NOT NULL REFERENCES public.factory_products(id),
+  qty_ordered NUMERIC(10,0) NOT NULL CHECK (qty_ordered > 0),
+  payment_status TEXT NOT NULL DEFAULT 'Clear'
+    CHECK (payment_status IN ('Clear','Hold - Payment','Cancelled')),
+  seed_key TEXT UNIQUE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_factory_orders_customer ON public.factory_orders (customer_id);
+CREATE INDEX IF NOT EXISTS idx_factory_orders_date ON public.factory_orders (order_date);
+
+-- ----------------------------------------------------------- production log
+CREATE TABLE IF NOT EXISTS public.factory_production_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  log_date DATE NOT NULL,
+  product_id UUID NOT NULL REFERENCES public.factory_products(id),
+  qty_produced NUMERIC(10,0) NOT NULL CHECK (qty_produced >= 0),
+  cement_bags NUMERIC(6,1) CHECK (cement_bags >= 0),
+  downtime_reason TEXT NOT NULL DEFAULT 'None' CHECK (downtime_reason IN
+    ('None','Power Cut','Machine Breakdown','Raw Material Shortage',
+     'Labour Shortage','Dye / Profile Change','Payment Issue','Holiday','Other')),
+  remarks TEXT,
+  data_flag TEXT NOT NULL DEFAULT 'OK'
+    CHECK (data_flag IN ('OK','Estimated','Check - sources disagree')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (log_date, product_id)
+);
+CREATE INDEX IF NOT EXISTS idx_factory_prodlog_date ON public.factory_production_log (log_date);
+
+-- ---------------------------------------------------------- production plan
+CREATE TABLE IF NOT EXISTS public.factory_production_plan (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_date DATE NOT NULL,
+  product_id UUID NOT NULL REFERENCES public.factory_products(id),
+  planned_qty NUMERIC(10,0) NOT NULL CHECK (planned_qty >= 0),
+  plan_note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (plan_date, product_id)
+);
+
+-- -------------------------------------------------------------------- trips
+CREATE TABLE IF NOT EXISTS public.factory_trips (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_date DATE NOT NULL,
+  vehicle TEXT NOT NULL CHECK (vehicle IN ('407 Eicher','439 RDX Tractor','Tricycle','Other')),
+  start_km NUMERIC(8,1),
+  end_km NUMERIC(8,1),
+  diesel_litres NUMERIC(6,1) CHECK (diesel_litres >= 0),
+  seed_key TEXT UNIQUE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (end_km IS NULL OR start_km IS NULL OR end_km >= start_km)
+);
+
+-- --------------------------------------------------------------- deliveries
+CREATE TABLE IF NOT EXISTS public.factory_deliveries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  delivery_date DATE NOT NULL,
+  customer_id UUID NOT NULL REFERENCES public.factory_customers(id),
+  product_id UUID NOT NULL REFERENCES public.factory_products(id),
+  -- qty 0 is allowed for 'Qty to confirm' planned rows from the weekly sheet
+  qty NUMERIC(10,0) NOT NULL CHECK (qty >= 0),
+  status TEXT NOT NULL DEFAULT 'Planned'
+    CHECK (status IN ('Planned','Delivered','Postponed','Cancelled')),
+  order_id UUID REFERENCES public.factory_orders(id),
+  trip_id UUID REFERENCES public.factory_trips(id),
+  data_flag TEXT NOT NULL DEFAULT 'OK'
+    CHECK (data_flag IN ('OK','Check - sources disagree','Qty to confirm')),
+  seed_key TEXT UNIQUE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_factory_del_date ON public.factory_deliveries (delivery_date);
+CREATE INDEX IF NOT EXISTS idx_factory_del_product_status ON public.factory_deliveries (product_id, status);
+CREATE INDEX IF NOT EXISTS idx_factory_del_order ON public.factory_deliveries (order_id) WHERE order_id IS NOT NULL;
+
+-- ------------------------------------------------------------------- labour
+CREATE TABLE IF NOT EXISTS public.factory_labour (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_date DATE NOT NULL,
+  worker TEXT NOT NULL,
+  work_type TEXT NOT NULL CHECK (work_type IN
+    ('Loading','Production 6"','Production 8"','NMR Daily','Advance')),
+  qty NUMERIC(10,1) NOT NULL,
+  rate NUMERIC(10,2) NOT NULL, -- advances carry a negative rate (qty 1 × -3500)
+  seed_key TEXT UNIQUE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_factory_labour_date ON public.factory_labour (work_date);
+
+-- ------------------------------------------------------------------- assets
+CREATE TABLE IF NOT EXISTS public.factory_assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset TEXT NOT NULL,
+  category TEXT NOT NULL CHECK (category IN
+    ('Machinery','Machinery Tools','Mechanical Tools','Vehicles',
+     'Construction Tools','Electrical & Electronic Tools')),
+  qty NUMERIC(8,1) NOT NULL DEFAULT 1,
+  location TEXT NOT NULL DEFAULT 'Unknown'
+    CHECK (location IN ('Plant','RTO','VM','Split - see notes','Unknown')),
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (asset, location)
+);
+
+-- ------------------------------------------------------------ RLS + triggers
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'factory_products','factory_customers','factory_orders',
+    'factory_production_log','factory_production_plan','factory_trips',
+    'factory_deliveries','factory_labour','factory_assets']
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('DROP POLICY IF EXISTS "auth read %s" ON public.%I', t, t);
+    EXECUTE format(
+      'CREATE POLICY "auth read %s" ON public.%I FOR SELECT TO authenticated USING (true)', t, t);
+    EXECUTE format('DROP TRIGGER IF EXISTS trg_%s_updated_at ON public.%I', t, t);
+    EXECUTE format(
+      'CREATE TRIGGER trg_%s_updated_at BEFORE UPDATE ON public.%I
+       FOR EACH ROW EXECUTE FUNCTION public.set_updated_at()', t, t);
+  END LOOP;
+END $$;
+
+-- -------------------------------------------------------------------- views
+-- Live stock per product. free_stock is THE number a salesperson needs
+-- before promising a date. Semantics: committed = status 'Planned' only;
+-- 'Postponed' counts in neither delivered nor committed (badged in UI).
+CREATE OR REPLACE VIEW public.factory_stock_v
+WITH (security_invoker = true) AS
+SELECT
+  p.id, p.code, p.opening_stock, p.opening_counted_at, p.notes,
+  COALESCE(pl.produced, 0) AS produced,
+  COALESCE(d.delivered, 0) AS delivered,
+  COALESCE(d.committed, 0) AS committed,
+  COALESCE(p.opening_stock, 0) + COALESCE(pl.produced, 0)
+    - COALESCE(d.delivered, 0) AS stock_balance,
+  COALESCE(p.opening_stock, 0) + COALESCE(pl.produced, 0)
+    - COALESCE(d.delivered, 0) - COALESCE(d.committed, 0) AS free_stock,
+  ROUND(COALESCE(pl.produced, 0) / NULLIF(pl.bags, 0), 1) AS bricks_per_bag
+FROM public.factory_products p
+LEFT JOIN (
+  SELECT product_id, SUM(qty_produced) AS produced, SUM(cement_bags) AS bags
+  FROM public.factory_production_log GROUP BY product_id
+) pl ON pl.product_id = p.id
+LEFT JOIN (
+  SELECT product_id,
+    SUM(qty) FILTER (WHERE status = 'Delivered') AS delivered,
+    SUM(qty) FILTER (WHERE status = 'Planned')  AS committed
+  FROM public.factory_deliveries GROUP BY product_id
+) d ON d.product_id = p.id;
+
+-- Order fulfilment: delivered/balance derived from actual dispatches, never
+-- set by hand. Deliveries without order_id never advance any order.
+CREATE OR REPLACE VIEW public.factory_orders_v
+WITH (security_invoker = true) AS
+SELECT
+  o.id, o.customer_id, o.order_date, o.product_id, o.qty_ordered,
+  o.payment_status, o.notes, o.created_at, o.updated_at,
+  c.name AS customer_name, c.credit_hold,
+  p.code AS product_code,
+  COALESCE(dv.delivered, 0) AS delivered,
+  GREATEST(o.qty_ordered - COALESCE(dv.delivered, 0), 0) AS balance_due,
+  CASE
+    WHEN COALESCE(dv.delivered, 0) = 0 THEN 'Not started'
+    WHEN COALESCE(dv.delivered, 0) >= o.qty_ordered THEN 'Complete'
+    ELSE 'Partial'
+  END AS fulfilment
+FROM public.factory_orders o
+JOIN public.factory_customers c ON c.id = o.customer_id
+JOIN public.factory_products p ON p.id = o.product_id
+LEFT JOIN (
+  SELECT order_id, SUM(qty) AS delivered
+  FROM public.factory_deliveries
+  WHERE status = 'Delivered' AND order_id IS NOT NULL
+  GROUP BY order_id
+) dv ON dv.order_id = o.id;


### PR DESCRIPTION
Final Factory Ledger PR (stacked on #125 → #124 → #123).

Yard-side daily entry — stack group app/factory (no 7th tab), entered via cards on the Production and Deliveries tabs:

- **index**: free-stock cards (red when negative) + stock-take banner + role-gated actions (driver sees schedule only)
- **production**: today's log entry — product chips, qty, cement bags, downtime picker; server upserts per date+product (re-submits edit, never duplicate)
- **deliveries**: Sat–Fri week schedule grouped by day; one-tap Delivered/Postpone with optimistic update + toast; credit-hold rows blocked from dispatch
- **labour**: entry incl. Advance mode (qty locked 1, amount stored negative)

Hooks follow the app's optimistic+toast pattern; lib/factory.ts is the pure copy of the web helper (week fn, product meta, enums — keep in sync).

Verified: native tsc clean + expo export bundles.

After merge chain: rebuild the APK so the team gets the Factory screens.

Generated with Claude Code