### PR TITLE
fix(factory): add /factory to middleware protectedRoutes

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -27,6 +27,7 @@ const protectedRoutes = [
   "/rate-card",
   "/approvals",
   "/production",
+  "/factory",
   "/deliveries",
   "/coaching",
   "/reports",


### PR DESCRIPTION
One-line parity fix: every dashboard page redirects anonymous visitors to /login except /factory, which served its page shell. No data was exposed (/api/factory/* is auth-gated, verified 401). Found during post-merge live verification.

Generated with Claude Code