### PR TITLE
fix(quotation): let Chromium out of the webpack bundle, and never 500

### DIFF
--- a/apps/web/app/api/sq/[slug]/pdf/route.ts
+++ b/apps/web/app/api/sq/[slug]/pdf/route.ts
@@ -140,7 +140,18 @@ export async function GET(
         React.createElement(QuoteDocument, { data }) as unknown as PdfRoot,
       );
     } else {
-      buffer = await renderQuotationPdf(toQuotationConfig(data, quoteNumber));
+      try {
+        buffer = await renderQuotationPdf(toQuotationConfig(data, quoteNumber));
+      } catch (err) {
+        // A customer clicking "Download quotation" must always get a document.
+        // If Chromium cannot start in this runtime, fall back to the one-page
+        // renderer rather than returning a 500 on a live quote link.
+        console.error("[sq/pdf] branded render failed, falling back:", err);
+        type PdfRoot = Parameters<typeof renderToBuffer>[0];
+        buffer = await renderToBuffer(
+          React.createElement(QuoteDocument, { data }) as unknown as PdfRoot,
+        );
+      }
     }
 
     // Downloads are a strong buying signal — stronger than a page view, since

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -47,9 +47,13 @@ const nextConfig = {
     experimental: {
         // Loads instrumentation.ts (server-side Sentry init) on boot.
         instrumentationHook: true,
-        // The quotation PDF reads its .ttf files from disk at render time.
-        // Nothing imports them, so tracing cannot infer them — without this
-        // they are absent from the deployed function and the route throws.
+        // Chromium ships a real binary. Bundling it through webpack leaves the
+        // executable behind, so chromium.executablePath() resolves to nothing
+        // and the launch fails — which is exactly what production did.
+        serverComponentsExternalPackages: ["@sparticuz/chromium", "puppeteer-core"],
+        // The quotation reads its .ttf files, artwork and HTML template from
+        // disk at render time. Nothing imports them, so tracing cannot infer
+        // them — without this they are absent from the deployed function.
         outputFileTracingIncludes: {
             "/api/sq/[slug]/pdf": [
                 "./src/lib/pdf/fonts/**",


### PR DESCRIPTION
The branded render failed in production the moment it deployed: HTTP 500 in four seconds, which is a failed launch rather than a timeout. ?format=simple returned a valid PDF, so the route, the database reads and the traced fonts and artwork were all fine — the fault was isolated to Chromium.

@sparticuz/chromium ships an actual executable. Webpack bundles the JavaScript and leaves the binary behind, so chromium.executablePath() resolves to nothing. Marking it and puppeteer-core as server-external keeps the package on disk where executablePath() can find it.

Second change, independent of the first: a customer clicking "Download quotation" on a live link must always receive a document. The branded render is now wrapped so any failure logs and falls back to the one-page renderer instead of returning a 500. Production spent this window serving errors on a real quote link; that must not be possible again.

## Summary

<!-- Brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests pass (`bun test`)
- [ ] TypeScript types check (`bun typecheck`)
- [ ] Linting passes (`bun lint`)
- [ ] Manual testing performed

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
