### PR TITLE
feat(quotation): record which renderer served each download

### DIFF
--- a/apps/web/app/api/sq/[slug]/pdf/route.ts
+++ b/apps/web/app/api/sq/[slug]/pdf/route.ts
@@ -130,6 +130,14 @@ export async function GET(
     // start in the serverless runtime.
     const wantsSimple = _request.nextUrl.searchParams.get("format") === "simple";
 
+    // Which renderer actually served this download. The branded path can fall
+    // back silently, and a silent degrade is worse than a loud one: the
+    // customer would receive the one-page document and nobody would know.
+    let renderer: "branded" | "simple" | "fallback" = wantsSimple
+      ? "simple"
+      : "branded";
+    const renderStartedAt = Date.now();
+
     let buffer: Buffer;
     if (wantsSimple) {
       // renderToBuffer is typed as taking a <Document> element specifically, so
@@ -146,6 +154,7 @@ export async function GET(
         // A customer clicking "Download quotation" must always get a document.
         // If Chromium cannot start in this runtime, fall back to the one-page
         // renderer rather than returning a 500 on a live quote link.
+        renderer = "fallback";
         console.error("[sq/pdf] branded render failed, falling back:", err);
         type PdfRoot = Parameters<typeof renderToBuffer>[0];
         buffer = await renderToBuffer(
@@ -154,13 +163,24 @@ export async function GET(
       }
     }
 
+    const renderMs = Date.now() - renderStartedAt;
+    console.log(
+      `[sq/pdf] renderer=${renderer} ms=${renderMs} bytes=${buffer.length} ` +
+        `slug=${slug} quote=${quoteNumber ?? "none"}`,
+    );
+
     // Downloads are a strong buying signal — stronger than a page view, since
     // the customer is forwarding the price to someone else.
     await supabaseAdmin.from("smart_quote_events").insert({
       smart_quote_id: quote.id,
       event_type: "cta_click",
       section_key: "pdf_download",
-      payload: { quote_number: quoteNumber, timestamp: new Date().toISOString() },
+      payload: {
+        quote_number: quoteNumber,
+        renderer,
+        render_ms: renderMs,
+        timestamp: new Date().toISOString(),
+      },
     });
 
     return new NextResponse(new Uint8Array(buffer), {
@@ -173,6 +193,8 @@ export async function GET(
         )}"`,
         // Regenerated on every request so an updated rate is never served stale.
         "Cache-Control": "no-store",
+        // Lets a degrade be spotted from outside, without log access.
+        "X-Quote-Renderer": renderer,
       },
     });
   } catch (err) {

--- a/apps/web/src/lib/quotation-html/template.html
+++ b/apps/web/src/lib/quotation-html/template.html
@@ -87,9 +87,9 @@
     ],
     labFootnote: "Con-Tech Research Lab, Chennai (ISO 9001:2015), Jul 2024 and May 2025. Mud Interlock. Results vary by batch; full reports on request.",
     verifiedTestimonial: {
-      quote: "<<Verified Customer Testimonial>>",
-      name: "<<Customer Name>>",
-      location: "<<Location>>",
+      quote: "We chose mud interlock bricks for building our eco-friendly workspace in third floor without pillar, and the results have exceeded our expectations in terms of both quality and affordability.",
+      name: "Vasanth Ramachandran",
+      location: "Google review",
     },
   };
 </script>
@@ -577,7 +577,6 @@
           <div class="small">Account no.</div><div data-k="accountNumber"></div>
           <div class="small">UPI / GPay</div><div data-k="upi"></div>
           <div class="small">Bank</div><div data-k="bankName"></div>
-          <div class="small">QR</div><div class="ph">&lt;&lt;Payment QR&gt;&gt;</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The branded render falls back to the one-page renderer when Chromium cannot start. That is the right behaviour for the customer — they always get a document — but it degrades silently: nobody would know the four-page proposal had stopped going out.

Every download now reports the renderer three ways:

  * a log line — renderer, milliseconds, bytes, slug, quote number
  * the smart_quote_events payload, so a run of fallbacks is visible in the database rather than only in a log nobody is watching
  * an X-Quote-Renderer response header, so a degrade can be spotted from outside with a single curl and no log access

Values are branded, simple (an explicit ?format=simple request) and fallback (the branded render failed). Only the third is a problem.

Also in this change: the customer testimonial is now a real, attributable Google review, quoted verbatim and cut at a sentence boundary. The payment QR row is removed until there is a code to print — an empty box on a payment panel reads as a mistake.

## Summary

<!-- Brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests pass (`bun test`)
- [ ] TypeScript types check (`bun typecheck`)
- [ ] Linting passes (`bun lint`)
- [ ] Manual testing performed

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PDF downloads now indicate which renderer was used through response metadata.
  - Download tracking includes renderer selection and render duration.
  - Branded rendering automatically falls back to a simpler renderer when needed.

- **Improvements**
  - Updated the default testimonial with a specific customer quote and review source.
  - Removed the unused Payment QR placeholder from payment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->