### PR TITLE
feat(native): Smart Quote on the phone — existing quote, readiness ga…

### DIFF
--- a/apps/native/app/leads/[id].tsx
+++ b/apps/native/app/leads/[id].tsx
@@ -14,7 +14,13 @@ import {
 import { useLead } from '@/hooks/use-leads';
 import { useAddNote, useLeadNotes } from '@/hooks/use-notes';
 import { usePromiseDate, useProductParams } from '@/hooks/use-ops-planning';
-import { quoteUrl, useGenerateSmartQuote } from '@/hooks/use-smart-quote';
+import {
+  getQuoteReadiness,
+  quotePdfUrl,
+  quoteUrl,
+  useGenerateSmartQuote,
+  useSmartQuote,
+} from '@/hooks/use-smart-quote';
 import { QuickActionsModal } from '@/components/LeadQuickActions';
 import { toast } from '@/lib/toast';
 
@@ -40,25 +46,50 @@ function SmartQuoteSection({
   contact: string;
 }) {
   const generate = useGenerateSmartQuote();
-  const slug = generate.data?.data?.link_slug;
+  const existing = useSmartQuote(leadId);
+  // Freshly generated wins; otherwise whatever the lead already has.
+  const quote = generate.data?.data ?? existing.data ?? null;
+  const slug = quote?.link_slug;
   const url = slug ? quoteUrl(slug) : null;
   const phone = contact.replace(/[^0-9]/g, '');
+
+  // Same gate as the web staff UI: nothing reaches the customer until an
+  // engineer has set the rate. Preview stays open — staff may look, the
+  // customer may not.
+  const readiness = getQuoteReadiness(quote?.pricing_config);
 
   return (
     <View className="mx-5 mt-4 rounded-xl border border-slate-200 bg-white p-4">
       <Text className="text-base font-bold text-ink">🧾 Smart Quote</Text>
       <Text className="mt-0.5 text-xs text-slate-400">
         AI builds a personalised quote page for this customer — share the link
-        on WhatsApp.
+        or the PDF on WhatsApp.
       </Text>
+
+      {existing.isLoading && !url ? (
+        <View className="mt-3 flex-row items-center gap-2">
+          <ActivityIndicator size="small" color="#94a3b8" />
+          <Text className="text-xs text-slate-400">Checking for an existing quote…</Text>
+        </View>
+      ) : null}
 
       {url ? (
         <>
           <Text className="mt-2 text-xs text-sky-600" numberOfLines={1}>
             {url}
           </Text>
+          {!readiness.ready ? (
+            <View className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5">
+              <Text className="text-xs font-semibold text-amber-700">Not ready to send</Text>
+              <Text className="mt-0.5 text-xs text-amber-700">{readiness.reason}</Text>
+              <Text className="mt-1 text-[10px] text-amber-600">
+                Set the rate from the web app’s lead page, then share from here.
+              </Text>
+            </View>
+          ) : null}
           <View className="mt-2 flex-row gap-2">
             <Pressable
+              disabled={!readiness.ready}
               onPress={() =>
                 Linking.openURL(
                   `https://wa.me/${phone}?text=${encodeURIComponent(
@@ -66,9 +97,34 @@ function SmartQuoteSection({
                   )}`,
                 )
               }
-              className="flex-1 items-center rounded-lg bg-green-500 py-2.5 active:opacity-80"
+              className={`flex-1 items-center rounded-lg py-2.5 ${
+                readiness.ready ? 'bg-green-500 active:opacity-80' : 'bg-slate-200'
+              }`}
             >
-              <Text className="text-sm font-semibold text-white">📲 Send on WhatsApp</Text>
+              <Text
+                className={`text-sm font-semibold ${
+                  readiness.ready ? 'text-white' : 'text-slate-400'
+                }`}
+              >
+                📲 WhatsApp
+              </Text>
+            </Pressable>
+            <Pressable
+              disabled={!readiness.ready}
+              onPress={() => slug && Linking.openURL(quotePdfUrl(slug))}
+              className={`flex-1 items-center rounded-lg py-2.5 ${
+                readiness.ready
+                  ? 'border border-brand bg-white active:opacity-70'
+                  : 'bg-slate-200'
+              }`}
+            >
+              <Text
+                className={`text-sm font-semibold ${
+                  readiness.ready ? 'text-ink' : 'text-slate-400'
+                }`}
+              >
+                📄 PDF
+              </Text>
             </Pressable>
             <Pressable
               onPress={() => Linking.openURL(url)}
@@ -92,7 +148,7 @@ function SmartQuoteSection({
             </Text>
           </Pressable>
         </>
-      ) : (
+      ) : existing.isLoading ? null : (
         <Pressable
           disabled={generate.isPending}
           onPress={() =>

--- a/apps/native/src/hooks/use-smart-quote.ts
+++ b/apps/native/src/hooks/use-smart-quote.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { SmartQuote } from '@maiyuri/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { SmartQuote, SmartQuotePricingConfig } from '@maiyuri/shared';
 import { api } from '@/lib/api';
 
 const BASE_URL =
@@ -8,6 +8,68 @@ const BASE_URL =
 /** Public share URL for a generated Smart Quote. */
 export function quoteUrl(slug: string): string {
   return `${BASE_URL}/sq/${slug}`;
+}
+
+/**
+ * The branded quotation PDF. Public in the same sense as the quote page — the
+ * unguessable slug is the capability — so opening it in the device browser
+ * downloads the document without any auth handshake.
+ */
+export function quotePdfUrl(slug: string): string {
+  return `${BASE_URL}/api/sq/${slug}/pdf`;
+}
+
+/**
+ * Is this quote safe to put in a customer's hands?
+ *
+ * Mirror of apps/web/src/lib/pricing/quote-readiness.ts, which is the
+ * authority on this rule: a quote with no engineer rate silently falls back
+ * to the rate card, so the customer would see a price nobody authorised.
+ * The web staff UI blocks sharing for the same reasons with the same words.
+ */
+export function getQuoteReadiness(
+  pricing: Partial<SmartQuotePricingConfig> | null | undefined,
+): { ready: boolean; reason: string | null } {
+  const rate = pricing?.quoted_rate;
+  if (rate == null) {
+    return {
+      ready: false,
+      reason:
+        'Set the rate before sharing — without it the customer sees rate-card pricing, not yours.',
+    };
+  }
+  if (!(rate > 0)) {
+    return { ready: false, reason: 'Rate must be greater than ₹0.' };
+  }
+  if (!pricing?.default_product) {
+    return { ready: false, reason: 'Choose the product being quoted before sharing.' };
+  }
+  const quantity = pricing?.default_area_sqft;
+  if (quantity == null || !(quantity > 0)) {
+    return { ready: false, reason: 'Enter the quantity being quoted before sharing.' };
+  }
+  return { ready: true, reason: null };
+}
+
+/**
+ * The lead's existing Smart Quote, or null when none has been generated.
+ *
+ * A plain GET, deliberately separate from the generate mutation: without it
+ * the phone showed no link for a lead that already had a quote, and a second
+ * tap on "Generate" was one AI run away from re-writing a page the customer
+ * may already have open.
+ */
+export function useSmartQuote(leadId: string) {
+  return useQuery({
+    queryKey: ['smart-quote', leadId],
+    queryFn: async () => {
+      const res = await api.get<SmartQuote[]>('/api/smart-quotes', {
+        lead_id: leadId,
+      });
+      return res.data?.[0] ?? null;
+    },
+    retry: false,
+  });
 }
 
 /**
@@ -20,7 +82,11 @@ export function useGenerateSmartQuote() {
   return useMutation({
     mutationFn: (opts: { lead_id: string; regenerate?: boolean }) =>
       api.post<SmartQuote>('/api/smart-quotes/generate', opts),
-    onSuccess: (_res, vars) =>
-      void queryClient.invalidateQueries({ queryKey: ['leads', vars.lead_id] }),
+    onSuccess: (res, vars) => {
+      // The fresh quote replaces the cached one immediately; the invalidate
+      // keeps any other lead-derived views honest.
+      queryClient.setQueryData(['smart-quote', vars.lead_id], res.data ?? null);
+      void queryClient.invalidateQueries({ queryKey: ['leads', vars.lead_id] });
+    },
   });
 }


### PR DESCRIPTION
…te, PDF

The phone's Smart Quote section could generate, but that was all it could do. Three gaps closed against the web staff UI:

1. It never loaded the existing quote. The link only appeared after generating in-session, so a lead that already had a quote showed a "Generate" button — one optimistic tap from re-writing a page the customer may already have open. A plain GET now loads the stored quote on mount, same as the web.

2. It had no readiness gate. Staff could WhatsApp a link whose page still showed rate-card pricing — exactly what quote-readiness.ts exists to prevent. The same gate now runs on the phone with the same words: WhatsApp and PDF stay disabled until the engineer's rate, product and quantity are set, with an amber banner saying why. Open stays enabled — staff may look; the customer may not.

3. No PDF. A PDF button opens the branded quotation through the device browser — the slug is the capability, so no auth handshake — where it can be saved or shared as a file. No new native dependencies, so no dev-client rebuild.

The readiness check is a documented mirror of
apps/web/src/lib/pricing/quote-readiness.ts, which remains the authority.

## Summary

<!-- Brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests pass (`bun test`)
- [ ] TypeScript types check (`bun typecheck`)
- [ ] Linting passes (`bun lint`)
- [ ] Manual testing performed

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
