### PR TITLE
feat(smart-quote): a quotation can price more than one product

### DIFF
--- a/apps/web/app/api/sq/[slug]/pdf/route.ts
+++ b/apps/web/app/api/sq/[slug]/pdf/route.ts
@@ -73,14 +73,24 @@ export async function GET(
         .maybeSingle(),
     ]);
 
-    const [{ data: product }, { data: rep }] = await Promise.all([
-      pricing.default_product
+    // Every product the quote prices: the items when it is multi-product,
+    // otherwise just the single default. One query either way.
+    const productIds = Array.from(
+      new Set(
+        (pricing.items?.length
+          ? pricing.items.map((i) => i.product_id)
+          : [pricing.default_product]
+        ).filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    const [{ data: products }, { data: rep }] = await Promise.all([
+      productIds.length
         ? supabaseAdmin
             .from("products")
-            .select("name, unit, hsn_code")
-            .eq("id", pricing.default_product)
-            .maybeSingle()
-        : Promise.resolve({ data: null }),
+            .select("id, name, unit, hsn_code")
+            .in("id", productIds)
+        : Promise.resolve({ data: [] }),
       lead?.assigned_staff
         ? supabaseAdmin
             .from("users")
@@ -89,6 +99,20 @@ export async function GET(
             .maybeSingle()
         : Promise.resolve({ data: null }),
     ]);
+
+    type ProductRow = {
+      id: string;
+      name: string | null;
+      unit: string | null;
+      hsn_code: string | null;
+    };
+    const productRows = (products ?? []) as ProductRow[];
+    const productsById = Object.fromEntries(
+      productRows.map((p) => [p.id, p]),
+    );
+    const product = pricing.default_product
+      ? (productsById[pricing.default_product] ?? null)
+      : (productRows[0] ?? null);
 
     const { data, reason } = buildQuoteDocumentData({
       quote: {
@@ -100,6 +124,7 @@ export async function GET(
       lead: lead ?? null,
       factory: factory ?? null,
       product: product ?? null,
+      productsById,
       rep: rep ?? null,
       wallCostConfig: quote.wall_cost_config,
       copyMap: quote.copy_map,

--- a/apps/web/src/lib/pdf/quote-document-data.test.ts
+++ b/apps/web/src/lib/pdf/quote-document-data.test.ts
@@ -389,3 +389,83 @@ describe("quoteFilename", () => {
     expect(quoteFilename(null, "Murali")).toBe("Maiyuri-Quote-Murali.pdf");
   });
 });
+
+describe("multi-product quotes", () => {
+  const twoLines: QuoteDocumentSources = {
+    ...base,
+    quote: {
+      ...base.quote,
+      pricing_config: {
+        ...base.quote.pricing_config,
+        items: [
+          { product_id: "prod-1", quantity: 40_000, rate: 52 },
+          { product_id: "prod-2", quantity: 5_000, rate: 44 },
+        ],
+      },
+    },
+    productsById: {
+      "prod-1": { name: '8" Mud Interlock', unit: "piece", hsn_code: "681011" },
+      "prod-2": { name: '6" Mud Interlock', unit: "piece", hsn_code: "681011" },
+    },
+  };
+
+  it("prints one line per item, each at its own rate", () => {
+    const { data } = buildQuoteDocumentData(twoLines);
+    expect(data?.lines).toHaveLength(2);
+    expect(data?.lines[0]).toMatchObject({
+      product: '8" Mud Interlock',
+      quantity: 40_000,
+      rate: 52,
+      amount: 2_080_000,
+    });
+    expect(data?.lines[1]).toMatchObject({
+      product: '6" Mud Interlock',
+      rate: 44,
+      amount: 220_000,
+    });
+  });
+
+  it("totals every line, not just the first", () => {
+    const { data } = buildQuoteDocumentData(twoLines);
+    expect(data?.total).toBe(2_080_000 + 220_000);
+  });
+
+  it("drops a line whose product has been deleted rather than printing a nameless charge", () => {
+    const { data } = buildQuoteDocumentData({
+      ...twoLines,
+      productsById: { "prod-1": { name: '8" Mud Interlock', unit: "piece", hsn_code: null } },
+    });
+    expect(data?.lines).toHaveLength(1);
+    expect(data?.total).toBe(2_080_000);
+  });
+
+  it("refuses the document when every quoted product has gone", () => {
+    const { data, reason } = buildQuoteDocumentData({ ...twoLines, productsById: {} });
+    expect(data).toBeNull();
+    expect(reason).toMatch(/no longer exist/i);
+  });
+
+  it("leaves single-product quotes exactly as they were", () => {
+    const { data } = buildQuoteDocumentData(base);
+    expect(data?.lines).toHaveLength(1);
+    expect(data?.total).toBe(32 * 5000);
+  });
+
+  it("blocks sharing when any line is unpriced, naming the line", () => {
+    const { data, reason } = buildQuoteDocumentData({
+      ...twoLines,
+      quote: {
+        ...twoLines.quote,
+        pricing_config: {
+          ...twoLines.quote.pricing_config,
+          items: [
+            { product_id: "prod-1", quantity: 40_000, rate: 52 },
+            { product_id: "prod-2", quantity: 5_000, rate: 0 },
+          ],
+        },
+      },
+    });
+    expect(data).toBeNull();
+    expect(reason).toMatch(/Line 2/);
+  });
+});

--- a/apps/web/src/lib/pdf/quote-document-data.ts
+++ b/apps/web/src/lib/pdf/quote-document-data.ts
@@ -61,11 +61,24 @@ export interface QuoteDocumentSources {
     quote_footer_note?: string | null;
   } | null;
   /** The quoted product, resolved from `pricing_config.default_product`. */
+  /**
+   * The single quoted product. Still the only thing a one-product quote
+   * needs, and still what the caller passes for those.
+   */
   product: {
     name?: string | null;
     unit?: string | null;
     hsn_code?: string | null;
   } | null;
+  /**
+   * Every product referenced by pricing_config.items, keyed by id. Only
+   * required for multi-product quotes; a missing entry drops that line rather
+   * than printing a nameless charge.
+   */
+  productsById?: Record<
+    string,
+    { name?: string | null; unit?: string | null; hsn_code?: string | null }
+  > | null;
   /** The staff member who owns the lead — signs the quotation. */
   rep: { name?: string | null; phone?: string | null } | null;
   /** Per-quote snapshot of the founder's build costs, for page 2. */
@@ -243,7 +256,7 @@ export function buildArgument(copyMap: SmartQuoteCopyMap | null | undefined): {
 export function buildQuoteDocumentData(
   sources: QuoteDocumentSources,
 ): QuoteDocumentResult {
-  const { quote, lead, factory, product, rep, wallCostConfig, copyMap } =
+  const { quote, lead, factory, product, productsById, rep, wallCostConfig, copyMap } =
     sources;
   const pricing = quote.pricing_config ?? null;
 
@@ -253,15 +266,41 @@ export function buildQuoteDocumentData(
   if (!readiness.ready) {
     return { data: null, reason: readiness.reason };
   }
-  if (!product) {
+  // Multi-product quotes price line by line; single-product quotes keep the
+  // original three fields and render exactly as before.
+  const items = pricing?.items?.length ? pricing.items : null;
+
+  const lines = items
+    ? items.flatMap((item) => {
+        const p = productsById?.[item.product_id];
+        // A line whose product has been deleted is dropped rather than
+        // printed as an unnamed charge on a commercial document.
+        if (!p) return [];
+        return [
+          {
+            product: clean(p.name) ?? "Interlocking bricks",
+            unit: clean(p.unit) ?? "unit",
+            quantity: item.quantity,
+            rate: item.rate,
+            amount: item.rate * item.quantity,
+            hsnCode: clean(p.hsn_code),
+          },
+        ];
+      })
+    : null;
+
+  if (items && (!lines || lines.length === 0)) {
+    return { data: null, reason: "The quoted products no longer exist." };
+  }
+  if (!items && !product) {
     return { data: null, reason: "The quoted product no longer exists." };
   }
 
   // Non-null by the readiness check above; asserted once, here.
   const rate = pricing?.quoted_rate as number;
   const quantity = pricing?.default_area_sqft as number;
-  const unit = clean(product.unit) ?? "unit";
-  const productName = clean(product.name) ?? "Interlocking bricks";
+  const unit = clean(product?.unit) ?? "unit";
+  const productName = clean(product?.name) ?? "Interlocking bricks";
 
   const customerName = clean(lead?.name) ?? "Customer";
   const quotedOn = formatQuoteDate(quote.created_at);
@@ -291,17 +330,19 @@ export function buildQuoteDocumentData(
         phone: clean(lead?.contact),
         location: clean(lead?.site_location) ?? clean(lead?.site_region),
       },
-      lines: [
+      lines: lines ?? [
         {
           product: productName,
           unit,
           quantity,
           rate,
           amount: rate * quantity,
-          hsnCode: clean(product.hsn_code),
+          hsnCode: clean(product?.hsn_code),
         },
       ],
-      total: rate * quantity,
+      total: lines
+        ? lines.reduce((sum, l) => sum + l.amount, 0)
+        : rate * quantity,
       // The engineer's rate is quoted delivered — that is the whole point of
       // "the price is the price". `show_transport: false` means the business
       // deliberately quoted ex-factory on this one.

--- a/apps/web/src/lib/pricing/quote-readiness.ts
+++ b/apps/web/src/lib/pricing/quote-readiness.ts
@@ -18,6 +18,30 @@ export interface QuoteReadiness {
 export function getQuoteReadiness(
   pricing: Partial<SmartQuotePricingConfig> | null | undefined,
 ): QuoteReadiness {
+  // Multi-product quotes are judged line by line. The same rule applies to
+  // each: a line the engineer has not priced cannot go to a customer, and a
+  // half-priced quote is worse than an unpriced one because the total looks
+  // authoritative.
+  const items = pricing?.items;
+  if (items && items.length > 0) {
+    for (const [i, item] of items.entries()) {
+      const label = `Line ${i + 1}`;
+      if (!item.product_id) {
+        return { ready: false, reason: `${label}: choose the product being quoted.` };
+      }
+      if (item.rate == null || !(item.rate > 0)) {
+        return {
+          ready: false,
+          reason: `${label}: set the rate before sharing — without it the customer sees rate-card pricing, not yours.`,
+        };
+      }
+      if (item.quantity == null || !(item.quantity > 0)) {
+        return { ready: false, reason: `${label}: enter the quantity being quoted.` };
+      }
+    }
+    return { ready: true, reason: null };
+  }
+
   const rate = pricing?.quoted_rate;
   if (rate == null) {
     return {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -631,8 +631,18 @@ export const smartQuoteObjectionSeveritySchema = z.enum([
 export const smartQuoteImageScopeSchema = z.enum(["template", "lead_override"]);
 
 // Smart Quote 2.0 — interactive pricing config (staff-editable)
+/** One priced line: product, quantity, and the engineer's rate for it. */
+export const smartQuoteLineItemSchema = z.object({
+  product_id: z.string().uuid(),
+  quantity: z.number().positive(),
+  rate: z.number().positive(),
+});
+
 export const smartQuotePricingConfigSchema = z.object({
   allowed_products: z.array(z.string().uuid()).default([]),
+  // Multi-product quotes. Capped because these print on one A4 table, and a
+  // quotation with fifty lines is a bill of materials, not a quotation.
+  items: z.array(smartQuoteLineItemSchema).max(12).optional(),
   default_product: z.string().uuid().nullable().optional(),
   default_area_sqft: z.number().positive().nullable().optional(),
   default_distance_km: z.number().min(0).nullable().optional(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -597,9 +597,35 @@ export interface SmartQuoteCopyMap {
   ta: Record<string, string>;
 }
 
+/**
+ * One priced line on the quotation.
+ *
+ * A house needs 8" for the external walls and 6" for the internal ones — which
+ * the proposal recommends on its own pages — so a quote has to carry more than
+ * one product. Each line holds its own rate: the engineer prices per product,
+ * not per quote.
+ */
+export interface SmartQuoteLineItem {
+  product_id: string;
+  quantity: number;
+  /** Rate per unit (₹) for this line, set by the engineer. */
+  rate: number;
+}
+
 // Smart Quote 2.0 — interactive instant-estimate config (staff-reviewed)
 export interface SmartQuotePricingConfig {
   allowed_products: string[]; // product ids offered on the quote
+  /**
+   * The quoted lines, when the quote prices more than one product.
+   *
+   * Absent on every quote written before multi-product, and optional after:
+   * a single-product quote may keep using default_product / default_area_sqft
+   * / quoted_rate below and renders exactly as it did. When `items` is present
+   * and non-empty it is authoritative for the document, and those three fields
+   * mirror its first line so the customer-facing interactive estimate — which
+   * prices one product at a time — keeps working unchanged.
+   */
+  items?: SmartQuoteLineItem[];
   default_product: string | null; // the quoted product
   default_area_sqft: number | null; // the quoted quantity, in the product's unit
   default_distance_km: number | null; // delivery distance for transport calc


### PR DESCRIPTION
Adds optional `pricing_config.items[]` so one quote can price 8" external and 6" internal walls at their own rates.

No migration — `pricing_config` is already JSONB. Single-product quotes render identically; a test pins that.

Readiness is judged per line and names the failing line. A line whose product was deleted is dropped rather than printed as a nameless charge. Capped at 12 lines.

Verified: 68 tests pass, typecheck clean, `next build` 79/79, and a two-line quotation totals 23,00,000 rather than the first line's 20,80,000.

Staff editors deliberately excluded — nothing writes `items[]` yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-product quotes with individual quantities and rates.
  * Quote PDFs now include separate lines, product details, and totals for each quoted product.
  * Added validation to ensure quoted products, quantities, and rates are valid.

* **Bug Fixes**
  * Removed deleted or unavailable products from generated quotes.
  * Added clear errors for missing products, unpriced items, or invalid quote lines.
  * Preserved existing behavior for single-product quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->