### PR TITLE
feat(native): set the price on the phone, multi-product

### DIFF
--- a/apps/native/app/leads/[id].tsx
+++ b/apps/native/app/leads/[id].tsx
@@ -14,6 +14,7 @@ import {
 import { useLead } from '@/hooks/use-leads';
 import { useAddNote, useLeadNotes } from '@/hooks/use-notes';
 import { usePromiseDate, useProductParams } from '@/hooks/use-ops-planning';
+import { QuotePricingEditor } from '@/components/QuotePricingEditor';
 import {
   getQuoteReadiness,
   quotePdfUrl,
@@ -47,6 +48,7 @@ function SmartQuoteSection({
 }) {
   const generate = useGenerateSmartQuote();
   const existing = useSmartQuote(leadId);
+  const [pricingOpen, setPricingOpen] = useState(false);
   // Freshly generated wins; otherwise whatever the lead already has.
   const quote = generate.data?.data ?? existing.data ?? null;
   const slug = quote?.link_slug;
@@ -82,10 +84,24 @@ function SmartQuoteSection({
             <View className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5">
               <Text className="text-xs font-semibold text-amber-700">Not ready to send</Text>
               <Text className="mt-0.5 text-xs text-amber-700">{readiness.reason}</Text>
-              <Text className="mt-1 text-[10px] text-amber-600">
-                Set the rate from the web app’s lead page, then share from here.
-              </Text>
             </View>
+          ) : null}
+
+          <Pressable
+            onPress={() => setPricingOpen((v) => !v)}
+            className="mt-2 items-center rounded-lg border border-brand py-2 active:opacity-70"
+          >
+            <Text className="text-sm font-bold text-ink">
+              {pricingOpen ? 'Close pricing' : readiness.ready ? '₹ Edit pricing' : '₹ Set the price'}
+            </Text>
+          </Pressable>
+
+          {pricingOpen && quote ? (
+            <QuotePricingEditor
+              quote={quote}
+              leadId={leadId}
+              onSaved={() => setPricingOpen(false)}
+            />
           ) : null}
           <View className="mt-2 flex-row gap-2">
             <Pressable

--- a/apps/native/src/components/QuotePricingEditor.tsx
+++ b/apps/native/src/components/QuotePricingEditor.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import type { SmartQuote, SmartQuoteLineItem } from '@maiyuri/shared';
+import { toast } from '@/lib/toast';
+import { useQuotableProducts, useSaveQuotePricing } from '@/hooks/use-smart-quote';
+
+/** A line being edited. Strings, because a half-typed number is not a number. */
+interface DraftLine {
+  productId: string | null;
+  quantity: string;
+  rate: string;
+}
+
+const inr = (n: number) => 'Rs. ' + Math.round(n).toLocaleString('en-IN');
+
+function toDraft(quote: SmartQuote | null): DraftLine[] {
+  const pricing = quote?.pricing_config;
+  const items = pricing?.items;
+  if (items?.length) {
+    return items.map((i) => ({
+      productId: i.product_id,
+      quantity: String(i.quantity),
+      rate: String(i.rate),
+    }));
+  }
+  // A quote written before multi-product still has its single line here.
+  if (pricing?.default_product) {
+    return [
+      {
+        productId: pricing.default_product,
+        quantity: pricing.default_area_sqft != null ? String(pricing.default_area_sqft) : '',
+        rate: pricing.quoted_rate != null ? String(pricing.quoted_rate) : '',
+      },
+    ];
+  }
+  return [{ productId: null, quantity: '', rate: '' }];
+}
+
+/**
+ * The engineer's price, set on the phone.
+ *
+ * This is the number the customer sees, so it is entered where the
+ * conversation happens — standing on the plot — rather than back at a desk.
+ * The quote stays unshareable until every line is priced.
+ */
+export function QuotePricingEditor({
+  quote,
+  leadId,
+  onSaved,
+}: {
+  quote: SmartQuote;
+  leadId: string;
+  onSaved?: () => void;
+}) {
+  const { data: products, isLoading: loadingProducts } = useQuotableProducts();
+  const save = useSaveQuotePricing(leadId);
+
+  const [lines, setLines] = useState<DraftLine[]>(() => toDraft(quote));
+  const [distance, setDistance] = useState(
+    quote.pricing_config?.default_distance_km != null
+      ? String(quote.pricing_config.default_distance_km)
+      : '',
+  );
+
+  const update = (i: number, patch: Partial<DraftLine>) =>
+    setLines((prev) => prev.map((l, n) => (n === i ? { ...l, ...patch } : l)));
+
+  const total = useMemo(
+    () =>
+      lines.reduce((sum, l) => {
+        const q = Number(l.quantity);
+        const r = Number(l.rate);
+        return sum + (q > 0 && r > 0 ? q * r : 0);
+      }, 0),
+    [lines],
+  );
+
+  const nameOf = (id: string | null) =>
+    products?.find((p) => p.id === id)?.name ?? 'Choose product';
+
+  function onSave() {
+    const items: SmartQuoteLineItem[] = [];
+    for (const [i, l] of lines.entries()) {
+      const quantity = Number(l.quantity);
+      const rate = Number(l.rate);
+      if (!l.productId) return toast.error(`Line ${i + 1}: choose a product`);
+      if (!(quantity > 0)) return toast.error(`Line ${i + 1}: enter a quantity`);
+      if (!(rate > 0)) return toast.error(`Line ${i + 1}: enter a rate`);
+      items.push({ product_id: l.productId, quantity, rate });
+    }
+
+    save.mutate(
+      { quoteId: quote.id, items, distanceKm: distance ? Number(distance) : null },
+      {
+        onSuccess: () => {
+          toast.success('Pricing saved');
+          onSaved?.();
+        },
+        onError: (e) => toast.error(e instanceof Error ? e.message : 'Save failed'),
+      },
+    );
+  }
+
+  return (
+    <View className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+      <Text className="text-sm font-bold text-ink">Set the price</Text>
+      <Text className="mt-0.5 text-xs text-slate-400">
+        Your rate is the quoted price — the rate card is not used.
+      </Text>
+
+      {loadingProducts ? (
+        <ActivityIndicator size="small" color="#94a3b8" className="mt-3" />
+      ) : null}
+
+      {lines.map((line, i) => (
+        <View key={i} className="mt-3 rounded-lg border border-slate-200 bg-white p-2.5">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-xs font-semibold text-slate-500">Line {i + 1}</Text>
+            {lines.length > 1 ? (
+              <Pressable
+                onPress={() => setLines((prev) => prev.filter((_, n) => n !== i))}
+                className="px-2 py-0.5 active:opacity-60"
+              >
+                <Text className="text-xs font-medium text-red-500">Remove</Text>
+              </Pressable>
+            ) : null}
+          </View>
+
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mt-2">
+            <View className="flex-row gap-1.5">
+              {(products ?? []).map((p) => (
+                <Pressable
+                  key={p.id}
+                  onPress={() => update(i, { productId: p.id })}
+                  className={`rounded-full border px-3 py-1.5 ${
+                    line.productId === p.id
+                      ? 'border-brand bg-brand/10'
+                      : 'border-slate-200 bg-white'
+                  }`}
+                >
+                  <Text
+                    className={`text-xs ${
+                      line.productId === p.id ? 'font-bold text-ink' : 'text-slate-600'
+                    }`}
+                  >
+                    {p.name}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </ScrollView>
+
+          <View className="mt-2 flex-row gap-2">
+            <View className="flex-1">
+              <Text className="text-[10px] font-medium uppercase text-slate-400">Quantity</Text>
+              <TextInput
+                value={line.quantity}
+                onChangeText={(v) => update(i, { quantity: v.replace(/[^0-9.]/g, '') })}
+                keyboardType="numeric"
+                placeholder="40000"
+                className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
+              />
+            </View>
+            <View className="flex-1">
+              <Text className="text-[10px] font-medium uppercase text-slate-400">
+                Rate (₹ per unit)
+              </Text>
+              <TextInput
+                value={line.rate}
+                onChangeText={(v) => update(i, { rate: v.replace(/[^0-9.]/g, '') })}
+                keyboardType="numeric"
+                placeholder="52"
+                className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm font-semibold text-ink"
+              />
+            </View>
+          </View>
+
+          {Number(line.quantity) > 0 && Number(line.rate) > 0 ? (
+            <Text className="mt-1.5 text-xs text-slate-500">
+              {nameOf(line.productId)} · {inr(Number(line.quantity) * Number(line.rate))}
+            </Text>
+          ) : null}
+        </View>
+      ))}
+
+      <Pressable
+        onPress={() =>
+          setLines((prev) => [...prev, { productId: null, quantity: '', rate: '' }])
+        }
+        className="mt-2 items-center rounded-lg border border-dashed border-slate-300 py-2 active:opacity-70"
+      >
+        <Text className="text-xs font-semibold text-slate-500">+ Add another product</Text>
+      </Pressable>
+
+      <View className="mt-3">
+        <Text className="text-[10px] font-medium uppercase text-slate-400">
+          Delivery distance (km)
+        </Text>
+        <TextInput
+          value={distance}
+          onChangeText={(v) => setDistance(v.replace(/[^0-9.]/g, ''))}
+          keyboardType="numeric"
+          placeholder="108"
+          className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
+        />
+      </View>
+
+      {total > 0 ? (
+        <View className="mt-3 flex-row items-center justify-between rounded-lg bg-ink px-3 py-2.5">
+          <Text className="text-xs font-medium text-white/70">Total</Text>
+          <Text className="text-base font-bold text-white">{inr(total)}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        disabled={save.isPending}
+        onPress={onSave}
+        className={`mt-3 items-center rounded-lg py-2.5 ${
+          save.isPending ? 'bg-slate-200' : 'bg-brand active:opacity-80'
+        }`}
+      >
+        <Text className="text-sm font-bold text-ink">
+          {save.isPending ? 'Saving…' : 'Save pricing'}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/native/src/hooks/use-smart-quote.ts
+++ b/apps/native/src/hooks/use-smart-quote.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { SmartQuote, SmartQuotePricingConfig } from '@maiyuri/shared';
+import type {
+  SmartQuote,
+  SmartQuoteLineItem,
+  SmartQuotePricingConfig,
+} from '@maiyuri/shared';
 import { api } from '@/lib/api';
 
 const BASE_URL =
@@ -30,6 +34,29 @@ export function quotePdfUrl(slug: string): string {
 export function getQuoteReadiness(
   pricing: Partial<SmartQuotePricingConfig> | null | undefined,
 ): { ready: boolean; reason: string | null } {
+  // Multi-product quotes are judged line by line, naming the line that fails:
+  // a half-priced quote is worse than an unpriced one, because the total
+  // still looks authoritative.
+  const items = pricing?.items;
+  if (items && items.length > 0) {
+    for (const [i, item] of items.entries()) {
+      const label = `Line ${i + 1}`;
+      if (!item.product_id) {
+        return { ready: false, reason: `${label}: choose the product being quoted.` };
+      }
+      if (item.rate == null || !(item.rate > 0)) {
+        return {
+          ready: false,
+          reason: `${label}: set the rate before sharing — without it the customer sees rate-card pricing, not yours.`,
+        };
+      }
+      if (item.quantity == null || !(item.quantity > 0)) {
+        return { ready: false, reason: `${label}: enter the quantity being quoted.` };
+      }
+    }
+    return { ready: true, reason: null };
+  }
+
   const rate = pricing?.quoted_rate;
   if (rate == null) {
     return {
@@ -87,6 +114,59 @@ export function useGenerateSmartQuote() {
       // keeps any other lead-derived views honest.
       queryClient.setQueryData(['smart-quote', vars.lead_id], res.data ?? null);
       void queryClient.invalidateQueries({ queryKey: ['leads', vars.lead_id] });
+    },
+  });
+}
+
+/** A product the engineer can quote. */
+export interface QuotableProduct {
+  id: string;
+  name: string;
+  unit: string | null;
+  category: string | null;
+}
+
+/** The live catalogue, for the line editor's product picker. */
+export function useQuotableProducts() {
+  return useQuery({
+    queryKey: ['products', 'quotable'],
+    queryFn: async () => {
+      const res = await api.get<QuotableProduct[]>('/api/products');
+      return res.data ?? [];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/**
+ * Save the engineer's pricing.
+ *
+ * The first line is mirrored onto default_product / default_area_sqft /
+ * quoted_rate. Those fields are what the older single-product paths still
+ * read, so a multi-product quote written here stays coherent for anything
+ * that has not learned about items[] yet.
+ */
+export function useSaveQuotePricing(leadId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: {
+      quoteId: string;
+      items: SmartQuoteLineItem[];
+      distanceKm: number | null;
+    }) => {
+      const [first] = vars.items;
+      return api.patch<SmartQuote>(`/api/smart-quotes/${vars.quoteId}`, {
+        pricing_config: {
+          items: vars.items,
+          default_product: first?.product_id ?? null,
+          default_area_sqft: first?.quantity ?? null,
+          quoted_rate: first?.rate ?? null,
+          default_distance_km: vars.distanceKm,
+        },
+      });
+    },
+    onSuccess: (res) => {
+      queryClient.setQueryData(['smart-quote', leadId], res.data ?? null);
     },
   });
 }

--- a/apps/web/app/api/smart-quotes/[id]/route.ts
+++ b/apps/web/app/api/smart-quotes/[id]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
-import { createSupabaseRouteClient } from "@/lib/supabase-server";
+import { getUserFromRequest } from "@/lib/supabase-server";
 import { success, error, notFound, forbidden, parseBody } from "@/lib/api-utils";
 import { updateSmartQuoteSchema, type SmartQuote } from "@maiyuri/shared";
 
@@ -23,10 +23,9 @@ export async function PATCH(
     const parsed = await parseBody(request, updateSmartQuoteSchema);
     if (parsed.error) return parsed.error;
 
-    const supabase = createSupabaseRouteClient(request);
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // Cookies for the web app, Bearer for the phone. This route was
+    // cookie-only, so every attempt to set a rate from mobile came back 401.
+    const user = await getUserFromRequest(request);
     if (!user) return error("Authentication required", 401);
 
     const { data: userData } = await supabaseAdmin


### PR DESCRIPTION
Adds a pricing editor to the mobile lead screen: one card per line with its own product, quantity and rate, a running total, and 'add another product'.

Also fixes a blocker: PATCH /api/smart-quotes/[id] was cookie-only, so any save from the phone would have returned 401. It now uses getUserFromRequest (cookies for web, Bearer for mobile).

Saving mirrors line 1 onto default_product / default_area_sqft / quoted_rate for paths that predate items[].

Verified as CI does: npm ci in apps/native then tsc --noEmit, zero errors. Web typecheck and build also clean.