### PR TITLE
feat(smart-quote): per-quote terms, and both editors go multi-product

### DIFF
--- a/apps/native/src/components/QuotePricingEditor.tsx
+++ b/apps/native/src/components/QuotePricingEditor.tsx
@@ -56,6 +56,9 @@ export function QuotePricingEditor({
   const save = useSaveQuotePricing(leadId);
 
   const [lines, setLines] = useState<DraftLine[]>(() => toDraft(quote));
+  const [specialTerms, setSpecialTerms] = useState(
+    quote.pricing_config?.special_terms ?? '',
+  );
   const [distance, setDistance] = useState(
     quote.pricing_config?.default_distance_km != null
       ? String(quote.pricing_config.default_distance_km)
@@ -90,7 +93,12 @@ export function QuotePricingEditor({
     }
 
     save.mutate(
-      { quoteId: quote.id, items, distanceKm: distance ? Number(distance) : null },
+      {
+        quoteId: quote.id,
+        items,
+        distanceKm: distance ? Number(distance) : null,
+        specialTerms: specialTerms.trim() || null,
+      },
       {
         onSuccess: () => {
           toast.success('Pricing saved');
@@ -203,6 +211,24 @@ export function QuotePricingEditor({
           placeholder="108"
           className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
         />
+      </View>
+
+      <View className="mt-3">
+        <Text className="text-[10px] font-medium uppercase text-slate-400">
+          Terms for this project (one per line)
+        </Text>
+        <TextInput
+          value={specialTerms}
+          onChangeText={setSpecialTerms}
+          multiline
+          numberOfLines={3}
+          placeholder={'Delivery in two lots' + String.fromCharCode(10) + 'Rate held until 30 September'}
+          className="mt-1 min-h-[64px] rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
+          textAlignVertical="top"
+        />
+        <Text className="mt-1 text-[10px] text-slate-400">
+          Prints on this quotation only. The standing terms come from Settings.
+        </Text>
       </View>
 
       {total > 0 ? (

--- a/apps/native/src/hooks/use-smart-quote.ts
+++ b/apps/native/src/hooks/use-smart-quote.ts
@@ -153,6 +153,7 @@ export function useSaveQuotePricing(leadId: string) {
       quoteId: string;
       items: SmartQuoteLineItem[];
       distanceKm: number | null;
+      specialTerms: string | null;
     }) => {
       const [first] = vars.items;
       return api.patch<SmartQuote>(`/api/smart-quotes/${vars.quoteId}`, {
@@ -162,6 +163,7 @@ export function useSaveQuotePricing(leadId: string) {
           default_area_sqft: first?.quantity ?? null,
           quoted_rate: first?.rate ?? null,
           default_distance_km: vars.distanceKm,
+          special_terms: vars.specialTerms,
         },
       });
     },

--- a/apps/web/app/api/sq/[slug]/pdf/route.ts
+++ b/apps/web/app/api/sq/[slug]/pdf/route.ts
@@ -298,6 +298,7 @@ function toQuotationConfig(
     advancePercentage: 20,
     paymentTerms: data.terms.payment ?? "<<Payment Terms>>",
     unloadingResponsibility: "<<Responsibility>>",
+    specialTerms: data.terms.special,
 
     accountName: data.bank?.accountName ?? "<<Account Name>>",
     bankName: data.bank?.bankName ?? "<<Bank Name>>",

--- a/apps/web/src/components/leads/SmartQuoteReview.tsx
+++ b/apps/web/src/components/leads/SmartQuoteReview.tsx
@@ -39,26 +39,75 @@ function timeAgo(iso: string | null): string {
  * Staff-facing engagement strip + "review & tweak pricing before share" panel
  * for a generated Smart Quote.
  */
+/** A line being edited. Strings, because a half-typed number is not a number. */
+interface DraftLine {
+  productId: string;
+  quantity: string;
+  rate: string;
+}
+
+/**
+ * Read pricing_config back into editable rows.
+ *
+ * A quote written before multi-product keeps its single line in
+ * default_product / default_area_sqft / quoted_rate, so it is lifted into the
+ * same shape and edits exactly like a multi-product one.
+ */
+function toDraftLines(
+  pricing: Partial<SmartQuotePricingConfig>,
+): DraftLine[] {
+  if (pricing.items?.length) {
+    return pricing.items.map((i) => ({
+      productId: i.product_id,
+      quantity: String(i.quantity),
+      rate: String(i.rate),
+    }));
+  }
+  return [
+    {
+      productId: pricing.default_product ?? "",
+      quantity:
+        pricing.default_area_sqft != null ? String(pricing.default_area_sqft) : "",
+      rate: pricing.quoted_rate != null ? String(pricing.quoted_rate) : "",
+    },
+  ];
+}
+
 export function SmartQuoteReview({ quote }: { quote: SmartQuote }) {
   const queryClient = useQueryClient();
   const pricing = (quote.pricing_config ?? {}) as Partial<SmartQuotePricingConfig>;
 
   const [open, setOpen] = useState(false);
-  const [area, setArea] = useState<string>(
-    pricing.default_area_sqft != null ? String(pricing.default_area_sqft) : "",
-  );
   const [distance, setDistance] = useState<string>(
     pricing.default_distance_km != null ? String(pricing.default_distance_km) : "",
   );
   const [showTransport, setShowTransport] = useState<boolean>(
     pricing.show_transport !== false,
   );
-  // The engineer's rate per unit. Authoritative — when set, the customer's
-  // quote uses this and never the rate card.
-  const [rate, setRate] = useState<string>(
-    pricing.quoted_rate != null ? String(pricing.quoted_rate) : "",
+  // One row per priced product. The engineer's rate is authoritative: when
+  // set, the customer's quote uses it and never the rate card. A quote written
+  // before multi-product keeps its single line in default_product /
+  // default_area_sqft / quoted_rate, so it reads back into the same shape and
+  // edits identically.
+  const [lines, setLines] = useState<DraftLine[]>(() => toDraftLines(pricing));
+  const [specialTerms, setSpecialTerms] = useState<string>(
+    pricing.special_terms ?? "",
   );
-  const [product, setProduct] = useState<string>(pricing.default_product ?? "");
+
+  // Line 1, for the blocks below that still speak in a single rate — the
+  // wall-cost comparison and the estimate preview.
+  const area = lines[0]?.quantity ?? "";
+  const rate = lines[0]?.rate ?? "";
+  const product = lines[0]?.productId ?? "";
+
+  const updateLine = (i: number, patch: Partial<DraftLine>) =>
+    setLines((prev) => prev.map((l, n) => (n === i ? { ...l, ...patch } : l)));
+
+  const linesTotal = lines.reduce((sum, l) => {
+    const q = Number(l.quantity);
+    const r = Number(l.rate);
+    return sum + (q > 0 && r > 0 ? q * r : 0);
+  }, 0);
   const [repPhone, setRepPhone] = useState<string>(pricing.rep_phone ?? "");
   const [note, setNote] = useState<string>(pricing.price_note ?? "");
   const [saved, setSaved] = useState(false);
@@ -106,13 +155,23 @@ export function SmartQuoteReview({ quote }: { quote: SmartQuote }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           pricing_config: {
-            default_product: product || null,
-            default_area_sqft: area ? Number(area) : null,
-            quoted_rate: rate ? Number(rate) : null,
+            items: lines
+              .filter((l) => l.productId && Number(l.quantity) > 0 && Number(l.rate) > 0)
+              .map((l) => ({
+                product_id: l.productId,
+                quantity: Number(l.quantity),
+                rate: Number(l.rate),
+              })),
+            // Line 1 mirrored onto the original fields, which the paths that
+            // predate items[] still read.
+            default_product: lines[0]?.productId || null,
+            default_area_sqft: lines[0]?.quantity ? Number(lines[0].quantity) : null,
+            quoted_rate: lines[0]?.rate ? Number(lines[0].rate) : null,
             default_distance_km: distance ? Number(distance) : null,
             show_transport: showTransport,
             rep_phone: repPhone || null,
             price_note: note || null,
+            special_terms: specialTerms.trim() || null,
           },
         }),
       });
@@ -167,50 +226,83 @@ export function SmartQuoteReview({ quote }: { quote: SmartQuote }) {
 
       {open && (
         <div className="space-y-3 rounded-lg border border-slate-200 dark:border-slate-700 p-3">
-          {/* The three fields that ARE the quote. */}
-          <label className="block text-xs">
-            <span className="text-slate-500 dark:text-slate-400">Product</span>
-            <select
-              value={product}
-              onChange={(e) => setProduct(e.target.value)}
-              className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
+          {/* The lines that ARE the quote. One row per product. */}
+          {lines.map((line, i) => (
+            <div
+              key={i}
+              className="space-y-2 rounded-md border border-slate-200 dark:border-slate-700 p-2.5"
             >
-              <option value="">Select product…</option>
-              {(productList ?? []).map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="grid grid-cols-2 gap-3">
-            <label className="text-xs">
-              <span className="text-slate-500 dark:text-slate-400">Quantity</span>
-              <input
-                type="number"
-                value={area}
-                onChange={(e) => setArea(e.target.value)}
-                className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
-              />
-            </label>
-            <label className="text-xs">
-              <span className="text-slate-500 dark:text-slate-400">Rate (₹ per unit)</span>
-              <input
-                type="number"
-                value={rate}
-                onChange={(e) => setRate(e.target.value)}
-                placeholder="e.g. 42"
-                className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
-              />
-            </label>
-          </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-semibold text-slate-500 dark:text-slate-400">
+                  Line {i + 1}
+                </span>
+                {lines.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => setLines((prev) => prev.filter((_, n) => n !== i))}
+                    className="text-[11px] font-medium text-red-500 hover:underline"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+              <label className="block text-xs">
+                <span className="text-slate-500 dark:text-slate-400">Product</span>
+                <select
+                  value={line.productId}
+                  onChange={(e) => updateLine(i, { productId: e.target.value })}
+                  className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
+                >
+                  <option value="">Select product…</option>
+                  {(productList ?? []).map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="text-xs">
+                  <span className="text-slate-500 dark:text-slate-400">Quantity</span>
+                  <input
+                    type="number"
+                    value={line.quantity}
+                    onChange={(e) => updateLine(i, { quantity: e.target.value })}
+                    className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
+                  />
+                </label>
+                <label className="text-xs">
+                  <span className="text-slate-500 dark:text-slate-400">Rate (₹ per unit)</span>
+                  <input
+                    type="number"
+                    value={line.rate}
+                    onChange={(e) => updateLine(i, { rate: e.target.value })}
+                    placeholder="e.g. 42"
+                    className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
+                  />
+                </label>
+              </div>
+              {Number(line.quantity) > 0 && Number(line.rate) > 0 && (
+                <p className="text-[11px] text-slate-500 dark:text-slate-400">
+                  ₹{(Number(line.quantity) * Number(line.rate)).toLocaleString("en-IN")}
+                </p>
+              )}
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={() =>
+              setLines((prev) => [...prev, { productId: "", quantity: "", rate: "" }])
+            }
+            className="w-full rounded-md border border-dashed border-slate-300 dark:border-slate-600 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800"
+          >
+            + Add another product
+          </button>
+
           <p className="text-[11px] text-slate-500 dark:text-slate-400">
-            {rate
-              ? `This rate is the quote — ₹${rate}/unit × ${area || "?"} = ₹${
-                  rate && area
-                    ? (Number(rate) * Number(area)).toLocaleString("en-IN")
-                    : "—"
-                }. The rate card is not used.`
+            {linesTotal > 0
+              ? `Total ₹${linesTotal.toLocaleString("en-IN")}. Your rate is the quote — the rate card is not used.`
               : "Leave the rate blank to fall back to the rate card."}
           </p>
           <label className="block text-xs">
@@ -241,6 +333,22 @@ export function SmartQuoteReview({ quote }: { quote: SmartQuote }) {
               placeholder="e.g. Includes GST"
               className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
             />
+          </label>
+
+          <label className="block text-xs">
+            <span className="text-slate-500 dark:text-slate-400">
+              Terms for this project (one per line)
+            </span>
+            <textarea
+              value={specialTerms}
+              onChange={(e) => setSpecialTerms(e.target.value)}
+              rows={3}
+              placeholder={"Delivery in two lots" + String.fromCharCode(10) + "Rate held until 30 September"}
+              className="mt-1 w-full rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm"
+            />
+            <span className="mt-1 block text-[11px] text-slate-500 dark:text-slate-400">
+              Prints on this quotation only. The standing terms live in Settings.
+            </span>
           </label>
           <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
             <input

--- a/apps/web/src/lib/pdf/QuoteDocument.test.tsx
+++ b/apps/web/src/lib/pdf/QuoteDocument.test.tsx
@@ -54,6 +54,7 @@ const full: QuoteDocumentData = {
       "The price is inclusive of loading, unloading and transportation.",
       "Road access suitable for an Eicher vehicle is required at the site.",
     ],
+      special: [],
   },
   bank: {
     accountName: "Maiyuri Bricks",

--- a/apps/web/src/lib/pdf/QuoteDocument.tsx
+++ b/apps/web/src/lib/pdf/QuoteDocument.tsx
@@ -204,6 +204,8 @@ export interface QuoteDocumentData {
     delivery: string | null;
     /** Everything else, one term per line. */
     additional: string[];
+    /** Agreed with this customer only. Printed apart, so it reads as theirs. */
+    special: string[];
   };
   bank: BankDetails | null;
   rep: { name: string | null; phone: string | null };
@@ -507,8 +509,12 @@ export function QuoteDocument({ data }: { data: QuoteDocumentData }) {
     rep, footerNote, wallCost, objection, nextStep,
   } = data;
 
+  const specialTerms = terms.special ?? [];
   const hasTerms = Boolean(
-    terms.payment || terms.delivery || terms.additional.length,
+    terms.payment ||
+      terms.delivery ||
+      terms.additional.length ||
+      specialTerms.length,
   );
 
   const bankLines: Array<[string, string]> = bank
@@ -656,7 +662,7 @@ export function QuoteDocument({ data }: { data: QuoteDocumentData }) {
                 <Text style={s.termText}>Delivery: {terms.delivery}</Text>
               </View>
             ) : null}
-            {terms.additional.map((term, i) => (
+            {[...terms.additional, ...specialTerms].map((term, i) => (
               <View style={s.termItem} key={i}>
                 <Text style={s.termBullet}>
                   {i +

--- a/apps/web/src/lib/pdf/quote-document-data.test.ts
+++ b/apps/web/src/lib/pdf/quote-document-data.test.ts
@@ -469,3 +469,34 @@ describe("multi-product quotes", () => {
     expect(reason).toMatch(/Line 2/);
   });
 });
+
+describe("per-quote special terms", () => {
+  const withSpecial = (special: string | null) => ({
+    ...base,
+    quote: {
+      ...base.quote,
+      pricing_config: { ...base.quote.pricing_config, special_terms: special },
+    },
+  });
+
+  it("carries this quote's own terms, one per line", () => {
+    const { data } = buildQuoteDocumentData(
+      withSpecial("Delivery in two lots.\nRate held until 30 September."),
+    );
+    expect(data?.terms.special).toEqual([
+      "Delivery in two lots.",
+      "Rate held until 30 September.",
+    ]);
+  });
+
+  it("keeps them apart from the standing terms", () => {
+    const { data } = buildQuoteDocumentData(withSpecial("Site access via the rear gate."));
+    expect(data?.terms.additional).not.toContain("Site access via the rear gate.");
+    expect(data?.terms.additional.length).toBeGreaterThan(0);
+  });
+
+  it("is empty when the quote has none", () => {
+    expect(buildQuoteDocumentData(withSpecial(null)).data?.terms.special).toEqual([]);
+    expect(buildQuoteDocumentData(base).data?.terms.special).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/pdf/quote-document-data.ts
+++ b/apps/web/src/lib/pdf/quote-document-data.ts
@@ -354,6 +354,7 @@ export function buildQuoteDocumentData(
         payment: clean(factory?.payment_terms),
         delivery: clean(factory?.delivery_terms),
         additional: splitLines(factory?.additional_terms),
+        special: splitLines(pricing?.special_terms),
       },
       bank: buildBankDetails(factory),
       rep: {

--- a/apps/web/src/lib/quotation-html/render.ts
+++ b/apps/web/src/lib/quotation-html/render.ts
@@ -49,6 +49,8 @@ export interface QuotationConfig {
   advancePercentage: number;
   paymentTerms: string;
   unloadingResponsibility: string;
+  /** Terms agreed with this customer only, one per line. */
+  specialTerms: string[];
 
   accountName: string;
   bankName: string;

--- a/apps/web/src/lib/quotation-html/template.html
+++ b/apps/web/src/lib/quotation-html/template.html
@@ -61,6 +61,8 @@
     advancePercentage: 20,
     paymentTerms: "<<Payment Terms>>",
     unloadingResponsibility: "<<Responsibility>>",
+    // Terms for this quotation alone; the standing set lives in Settings.
+    specialTerms: [],
 
     // — Payment ————————————————————————————————————————————
     accountName: "<<Account Name>>",
@@ -762,6 +764,13 @@
         <div class="small">Production slot</div><div>Confirmed on receipt of advance</div>
         <div class="small">Unloading</div><div data-k="unloadingResponsibility"></div>
       </div>
+
+      <!-- Terms agreed with this customer alone. Set apart from the standing
+           terms so it is obvious which ones are theirs. -->
+      <div id="special-terms-block" style="display:none; margin-top:3mm;">
+        <div class="eyebrow" style="color:var(--terracotta);">Agreed for this project</div>
+        <ul class="ticks" id="special-terms-list" style="margin-top:1.5mm;"></ul>
+      </div>
     </div>
     <div>
       <div class="card">
@@ -870,4 +879,14 @@
     el.classList.remove("empty");
     el.innerHTML = `<img src="${src}" alt="" />`;
   });
+
+  /* Terms agreed with this customer only. The block stays hidden unless there
+     is something in it — an empty "Agreed for this project" heading would
+     read as an omission. */
+  const specials = Array.isArray(CONFIG.specialTerms) ? CONFIG.specialTerms.filter(Boolean) : [];
+  if (specials.length) {
+    document.getElementById("special-terms-block").style.display = "";
+    document.getElementById("special-terms-list").innerHTML =
+      specials.map((t) => `<li>${esc(t)}</li>`).join("");
+  }
 </script>

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -649,6 +649,8 @@ export const smartQuotePricingConfigSchema = z.object({
   locality_label: z.string().nullable().optional(),
   show_transport: z.boolean().default(true),
   price_note: z.string().nullable().optional(),
+  // Terms for this quotation alone; the standing set lives in factory_settings.
+  special_terms: z.string().max(2000).nullable().optional(),
   rep_phone: z.string().nullable().optional(),
   // Engineer-set rate per unit (₹). Authoritative when present.
   quoted_rate: z.number().positive().nullable().optional(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -632,6 +632,15 @@ export interface SmartQuotePricingConfig {
   locality_label: string | null; // human label for the delivery area
   show_transport: boolean; // include delivery in the headline total
   price_note: string | null; // optional caveat shown under the estimate
+  /**
+   * Terms that apply to THIS quotation only, one per line.
+   *
+   * factory_settings.additional_terms is the standing set and prints on every
+   * quotation. A term agreed with one customer — a staged delivery, a site
+   * condition, a price held to a date — must not be written there, because it
+   * would silently attach itself to everyone else's quote too.
+   */
+  special_terms?: string | null;
   rep_phone: string | null; // WhatsApp number for the CTA (E.164-ish digits)
   /**
    * Rate per unit (₹) set by the engineer in the app. When present this is


### PR DESCRIPTION
Finishes the multi-product work.

1. pricing_config.special_terms - terms agreed with one customer, printed under 'Agreed for this project', apart from the standing set in Settings. Hidden when empty.

2. The web staff panel becomes one row per line (product, quantity, rate, subtotal, add/remove) with a running total, matching the mobile editor. Both write items[] and mirror line 1 onto the legacy fields.

Also: the react-pdf fallback now tolerates a payload built before `special` existed - it is the path used when Chromium cannot start, so it must never throw.

Verified: 71 web tests, native tsc clean as CI runs it, web typecheck + build clean, and a rendered quotation with two priced lines and two agreed terms, five pages fitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple editable quote line items, including products, quantities, and rates.
  * Added per-quote special terms with validation and newline-separated entries.
  * Special terms now appear in generated quotation PDFs and HTML documents alongside existing terms.
  * Existing single-line pricing configurations continue to display correctly.
* **Tests**
  * Added coverage for preserving, separating, and omitting special terms as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->