### PR TITLE
fix: lead edit on mobile returned 405; clearer pricing fields; drop strip

### DIFF
--- a/apps/native/src/components/QuotePricingEditor.tsx
+++ b/apps/native/src/components/QuotePricingEditor.tsx
@@ -165,7 +165,8 @@ export function QuotePricingEditor({
                 value={line.quantity}
                 onChangeText={(v) => update(i, { quantity: v.replace(/[^0-9.]/g, '') })}
                 keyboardType="numeric"
-                placeholder="40000"
+                placeholder="e.g. 40000"
+                placeholderTextColor="#cbd5e1"
                 className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
               />
             </View>
@@ -177,7 +178,8 @@ export function QuotePricingEditor({
                 value={line.rate}
                 onChangeText={(v) => update(i, { rate: v.replace(/[^0-9.]/g, '') })}
                 keyboardType="numeric"
-                placeholder="52"
+                placeholder="e.g. 52"
+                placeholderTextColor="#cbd5e1"
                 className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm font-semibold text-ink"
               />
             </View>
@@ -187,7 +189,11 @@ export function QuotePricingEditor({
             <Text className="mt-1.5 text-xs text-slate-500">
               {nameOf(line.productId)} · {inr(Number(line.quantity) * Number(line.rate))}
             </Text>
-          ) : null}
+          ) : (
+            <Text className="mt-1.5 text-xs text-amber-600">
+              Not counted yet — this line needs a quantity and a rate.
+            </Text>
+          )}
         </View>
       ))}
 
@@ -208,7 +214,8 @@ export function QuotePricingEditor({
           value={distance}
           onChangeText={(v) => setDistance(v.replace(/[^0-9.]/g, ''))}
           keyboardType="numeric"
-          placeholder="108"
+          placeholder="e.g. 108"
+          placeholderTextColor="#cbd5e1"
           className="mt-1 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
         />
       </View>
@@ -222,7 +229,8 @@ export function QuotePricingEditor({
           onChangeText={setSpecialTerms}
           multiline
           numberOfLines={3}
-          placeholder={'Delivery in two lots' + String.fromCharCode(10) + 'Rate held until 30 September'}
+          placeholder={'e.g. Delivery in two lots' + String.fromCharCode(10) + 'Rate held until 30 September'}
+          placeholderTextColor="#cbd5e1"
           className="mt-1 min-h-[64px] rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-ink"
           textAlignVertical="top"
         />

--- a/apps/web/app/api/leads/[id]/route.ts
+++ b/apps/web/app/api/leads/[id]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
-import { createSupabaseRouteClient } from "@/lib/supabase-server";
+import { getUserFromRequest } from "@/lib/supabase-server";
 import { success, error, notFound, parseBody } from "@/lib/api-utils";
 import {
   filterByPushPref,
@@ -54,11 +54,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const parsed = await parseBody(request, updateLeadSchema);
     if (parsed.error) return parsed.error;
 
-    // Get the authenticated user (optional - for archived_by tracking)
-    const supabase = createSupabaseRouteClient(request);
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    // Get the authenticated user (optional - for archived_by tracking).
+    // Cookies for the browser, Bearer for the phone: this was cookie-only, so
+    // an edit made on mobile was recorded against nobody.
+    const user = await getUserFromRequest(request);
 
     // Get current lead state to detect pipeline transitions
     const { data: currentLead } = await supabaseAdmin
@@ -296,3 +295,14 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     return error("Internal server error", 500);
   }
 }
+
+/**
+ * PATCH is the same operation as PUT here.
+ *
+ * The mobile app sends PATCH, which is the honest verb: this handler strips
+ * undefined keys and writes only what was supplied, so it has always been a
+ * partial update despite the name. Without this export Next answers 405, and
+ * every lead edited from a phone failed — silently, because the client only
+ * surfaced a generic error.
+ */
+export const PATCH = PUT;

--- a/apps/web/app/api/smart-quotes/[id]/route.ts
+++ b/apps/web/app/api/smart-quotes/[id]/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase-admin";
 import { getUserFromRequest } from "@/lib/supabase-server";
+import { canWorkOnLead } from "@/lib/sales-access";
 import { success, error, notFound, forbidden, parseBody } from "@/lib/api-utils";
 import { updateSmartQuoteSchema, type SmartQuote } from "@maiyuri/shared";
 
@@ -44,8 +45,7 @@ export async function PATCH(
     if (!quote) return notFound("Quote not found");
 
     const lead = (quote as { lead?: { assigned_staff?: string; created_by?: string } }).lead;
-    const isFounder = userData.role === "founder";
-    if (!isFounder && lead?.assigned_staff !== user.id && lead?.created_by !== user.id) {
+    if (!canWorkOnLead(userData.role, user.id, lead ?? null)) {
       return forbidden("You don't have access to this quote");
     }
 

--- a/apps/web/app/api/smart-quotes/generate/route.ts
+++ b/apps/web/app/api/smart-quotes/generate/route.ts
@@ -16,6 +16,7 @@ import {
   generateLinkSlug,
 } from "@/lib/smart-quote-ai";
 import { buildPricingConfig } from "@/lib/pricing/seed-pricing-config";
+import { canWorkOnLead } from "@/lib/sales-access";
 
 /**
  * POST /api/smart-quotes/generate
@@ -80,14 +81,10 @@ export async function POST(request: NextRequest) {
       return notFound("Lead not found");
     }
 
-    // Check access (founders + the machine pipeline have full access,
-    // others need assignment)
-    const isFounder = userData?.role === "founder";
+    // Sales roles reach every lead; everyone else keeps the ownership rule.
+    // The machine pipeline (call-recording auto-draft) has full access.
     const hasAccess =
-      isMachine ||
-      isFounder ||
-      (user != null &&
-        (lead.assigned_staff === user.id || lead.created_by === user.id));
+      isMachine || canWorkOnLead(userData?.role, user?.id, lead);
 
     if (!hasAccess) {
       return forbidden("You don't have access to this lead");

--- a/apps/web/src/lib/__tests__/sales-access.test.ts
+++ b/apps/web/src/lib/__tests__/sales-access.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { canWorkOnLead, hasFullSalesAccess } from "../sales-access";
+
+const lead = { assigned_staff: "owner-id", created_by: "creator-id" };
+
+describe("sales access", () => {
+  it("lets the sales-facing roles work on any lead", () => {
+    for (const role of ["founder", "owner", "sales", "engineer"]) {
+      expect(hasFullSalesAccess(role)).toBe(true);
+      expect(canWorkOnLead(role, "someone-else", lead)).toBe(true);
+    }
+  });
+
+  it("keeps back-office roles to their own leads", () => {
+    for (const role of ["accountant", "driver", "production_supervisor"]) {
+      expect(hasFullSalesAccess(role)).toBe(false);
+      expect(canWorkOnLead(role, "someone-else", lead)).toBe(false);
+      expect(canWorkOnLead(role, "owner-id", lead)).toBe(true);
+      expect(canWorkOnLead(role, "creator-id", lead)).toBe(true);
+    }
+  });
+
+  it("refuses when the role or lead is unknown", () => {
+    expect(canWorkOnLead(null, "someone", lead)).toBe(false);
+    expect(canWorkOnLead("accountant", "someone", null)).toBe(false);
+    expect(canWorkOnLead("accountant", null, lead)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/quotation-html/template.html
+++ b/apps/web/src/lib/quotation-html/template.html
@@ -732,13 +732,6 @@
     <div class="lede" style="font-size:10pt;">Your recommended Maiyuri solution</div>
   </div>
 
-  <div class="grid g4" style="margin-top:4mm;">
-    <div><div class="eyebrow">External wall</div><p class="small" style="margin-top:1.5mm;" data-k="externalWallProduct"></p></div>
-    <div><div class="eyebrow">Internal wall</div><p class="small" style="margin-top:1.5mm;" data-k="internalWallProduct"></p></div>
-    <div><div class="eyebrow">Estimated quantity</div><p class="small" style="margin-top:1.5mm;" data-k="estimatedQuantity"></p></div>
-    <div><div class="eyebrow">Dispatch timeline</div><p class="small" style="margin-top:1.5mm;" data-k="deliveryTimeline"></p></div>
-  </div>
-
   <table class="bill" style="margin-top:4mm;">
     <thead>
       <tr>

--- a/apps/web/src/lib/sales-access.ts
+++ b/apps/web/src/lib/sales-access.ts
@@ -1,0 +1,47 @@
+import type { UserRole } from "@maiyuri/shared";
+
+/**
+ * Who may work on any lead's commercial side, not just their own.
+ *
+ * The rest of the app already assumes this: GET /api/leads returns every lead
+ * to any signed-in user, and the leads list, quotes list and dashboards are
+ * open to all staff. Only quote generation and quote pricing were gated to
+ * "founder, or the person the lead is assigned to" — so a salesperson could
+ * open a colleague's lead, read it, and then be refused when setting the rate.
+ * That was an inconsistency rather than a policy.
+ *
+ *   founder / owner — run the business
+ *   sales           — the sales function is theirs by definition
+ *   engineer        — the rate on a quotation IS the engineer's rate; the
+ *                     readiness gate refuses to share a quote without it, so
+ *                     an engineer who cannot price any lead cannot do the job
+ *
+ * Deliberately excluded: accountant, driver, production_supervisor. They keep
+ * the previous rule and reach only leads assigned to or created by them.
+ */
+export const FULL_SALES_ACCESS_ROLES: ReadonlySet<string> = new Set<UserRole>([
+  "founder",
+  "owner",
+  "sales",
+  "engineer",
+]);
+
+/** True when this role may act on every lead's quote, not just its own. */
+export function hasFullSalesAccess(role: string | null | undefined): boolean {
+  return !!role && FULL_SALES_ACCESS_ROLES.has(role);
+}
+
+/**
+ * May this user act on this lead's quote?
+ *
+ * Roles without blanket access fall back to the original ownership rule.
+ */
+export function canWorkOnLead(
+  role: string | null | undefined,
+  userId: string | null | undefined,
+  lead: { assigned_staff?: string | null; created_by?: string | null } | null,
+): boolean {
+  if (hasFullSalesAccess(role)) return true;
+  if (!userId || !lead) return false;
+  return lead.assigned_staff === userId || lead.created_by === userId;
+}


### PR DESCRIPTION
Three fixes from device testing.

1. Lead edit from the app never worked: the client sends PATCH to /api/leads/[id], which only exported GET/PUT/DELETE, so Next answered 405. PUT already behaves as a partial update, so PATCH is exported as the same handler. Its user lookup was cookie-only too, so mobile edits were attributed to nobody - now Bearer-capable.

2. The rate placeholder was literally '52', indistinguishable from a real rate on a phone, so an unpriced line looked priced and the total looked wrong. Placeholders are now 'e.g. 52' in grey, and an incomplete line says 'Not counted yet'.

3. Removed the external/internal wall + quantity + dispatch strip from the commercial page.

Verified: web typecheck + build, native tsc, five pages fit, strip text absent from the PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially updating leads through the PATCH endpoint.
  * Lead updates now support authentication through browser sessions and mobile access tokens.

* **Changes**
  * Simplified commercial proposals by removing the recommendation summary section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->