### PR TITLE
feat(smart-quote): quote a lead before anyone has called them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # The mobile app addresses the API by string, so nothing type-checks a
+      # call site against its route. Two bugs reached production that way: a
+      # route missing the verb the app sends (405) and a route authenticating
+      # from cookies only (401 for a Bearer token). Both were invisible on a
+      # phone. This closes that gap.
+      - name: Mobile API contract
+        run: node scripts/check-mobile-api.mjs
+
       - name: Run tests
         run: npm run test
         env:

--- a/apps/web/app/api/smart-quotes/generate/route.ts
+++ b/apps/web/app/api/smart-quotes/generate/route.ts
@@ -13,6 +13,7 @@ import {
 import { generateSmartQuoteSchema, type SmartQuote } from "@maiyuri/shared";
 import {
   generateSmartQuoteContent,
+  buildBaselineQuoteContent,
   generateLinkSlug,
 } from "@/lib/smart-quote-ai";
 import { buildPricingConfig } from "@/lib/pricing/seed-pricing-config";
@@ -72,7 +73,7 @@ export async function POST(request: NextRequest) {
     const { data: lead, error: leadError } = await supabaseAdmin
       .from("leads")
       .select(
-        "id, name, assigned_staff, created_by, product_interests, site_location, area",
+        "id, name, assigned_staff, created_by, product_interests, site_location, area, language_preference",
       )
       .eq("id", lead_id)
       .single();
@@ -134,18 +135,16 @@ export async function POST(request: NextRequest) {
             .join("\n\n---\n\n")
         : null;
 
-    if (!combinedTranscript) {
-      return error(
-        "No transcripts available. Upload call recordings first.",
-        400,
-      );
-    }
-
-    // Generate Smart Quote content using AI pipeline
-    const aiResult = await generateSmartQuoteContent(
-      combinedTranscript,
-      lead.name,
-    );
+    // A new enquiry has no recorded call, and quoting does not depend on one:
+    // the engineer knows the price and the customer wants it today. Without a
+    // transcript the quote is built from the standard copy, with the insight
+    // fields left "unknown" rather than invented. Regenerating after the first
+    // call replaces all of it with the real reading.
+    const aiResult = combinedTranscript
+      ? await generateSmartQuoteContent(combinedTranscript, lead.name)
+      : buildBaselineQuoteContent(
+          lead.language_preference === "ta" ? "ta" : "en",
+        );
 
     // Generate unique slug
     const linkSlug = generateLinkSlug(12);

--- a/apps/web/src/lib/__tests__/baseline-quote.test.ts
+++ b/apps/web/src/lib/__tests__/baseline-quote.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildBaselineQuoteContent } from "../smart-quote-ai";
+
+describe("quoting a lead we have not spoken to", () => {
+  it("produces a usable quote with no transcript", () => {
+    const r = buildBaselineQuoteContent();
+    expect(r.strategy.page_config.pages.length).toBeGreaterThan(0);
+    expect(Object.keys(r.copyMap.en ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it("invents no persona, angle or objection", () => {
+    const r = buildBaselineQuoteContent();
+    expect(r.insights.persona).toBe("unknown");
+    expect(r.insights.language_detected).toBe("unknown");
+    expect(r.insights.primary_angle).toBeNull();
+    expect(r.insights.secondary_angle).toBeNull();
+    expect(r.insights.top_objections).toEqual([]);
+    expect(r.insights.risk_flags).toEqual([]);
+  });
+
+  it("honours the lead's language preference", () => {
+    expect(buildBaselineQuoteContent("ta").strategy.language_default).toBe("ta");
+    expect(buildBaselineQuoteContent().strategy.language_default).toBe("en");
+  });
+});

--- a/apps/web/src/lib/smart-quote-ai.ts
+++ b/apps/web/src/lib/smart-quote-ai.ts
@@ -550,6 +550,55 @@ function getDefaultCopyMap(route: SmartQuoteRoute): SmartQuoteCopyMap {
  * @param leadName - Optional lead name for personalization
  * @returns Complete Smart Quote AI result with insights, strategy, and copy
  */
+/**
+ * A quotation for a lead we have not spoken to yet.
+ *
+ * The AI pipeline reads call transcripts. A brand-new enquiry has none, and
+ * the route used to refuse outright — "No transcripts available. Upload call
+ * recordings first." — which blocked the ordinary case: a lead arrives, the
+ * engineer knows the price, and a quotation should go out today. Nothing about
+ * quoting depends on having recorded a call.
+ *
+ * So the quote is built from the same defaults the AI falls back to whenever
+ * it fails or returns nothing usable. The customer-facing copy is the standard
+ * copy; the insight fields say "unknown" rather than inventing a persona,
+ * urgency or objection nobody has evidence for. Regenerating after the first
+ * call replaces all of it with the real reading.
+ */
+export function buildBaselineQuoteContent(
+  language: SmartQuoteLanguage = "en",
+): SmartQuoteAIResult {
+  const route: SmartQuoteRoute = "technical_call";
+  return {
+    insights: {
+      language_detected: "unknown",
+      persona: "unknown",
+      stage: "warm",
+      // Neutral midpoints. These drive presentation only, and asserting
+      // interest or urgency we have not heard would be a fabrication.
+      scores: { interest: 0.5, urgency: 0.5, price_sensitivity: 0.5, trust: 0.5 },
+      primary_angle: null,
+      secondary_angle: null,
+      top_objections: [],
+      risk_flags: [],
+    },
+    strategy: {
+      language_default: language,
+      route_decision: route,
+      page_config: {
+        pages: [
+          { key: "entry", blocks: getDefaultBlocks("entry") },
+          { key: "climate", blocks: getDefaultBlocks("climate") },
+          { key: "cost", blocks: getDefaultBlocks("cost") },
+          { key: "objection", blocks: getDefaultBlocks("objection") },
+          { key: "cta", blocks: getDefaultBlocks("cta") },
+        ],
+      },
+    },
+    copyMap: getDefaultCopyMap(route),
+  };
+}
+
 export async function generateSmartQuoteContent(
   transcript: string,
   leadName?: string | null,

--- a/scripts/check-mobile-api.mjs
+++ b/scripts/check-mobile-api.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Every endpoint the mobile app calls must exist, answer the verb it sends,
+ * and be reachable with a Bearer token.
+ *
+ * Two failure modes have reached production, both silent on a phone:
+ *
+ *   1. The client sends a verb the route does not export. Next answers 405
+ *      and the client shows a generic error, so it looks like nothing
+ *      happened at all. Editing a lead was broken this way — the app sent
+ *      PATCH to a route exporting only GET, PUT and DELETE.
+ *
+ *   2. The route authenticates from cookies only. The phone has no cookie
+ *      jar and sends `Authorization: Bearer`, so it gets 401 no matter who
+ *      is signed in.
+ *
+ * Neither is a type error: the path is a string, so nothing connects the call
+ * site to the route file. This does.
+ *
+ * Limits worth knowing. It only sees calls written literally as
+ * api.get('/api/…'); a path assembled at runtime is invisible to it. And it
+ * proves reachability, not correctness — a route can answer perfectly and
+ * still do the wrong thing.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const NATIVE = path.join(ROOT, "apps", "native");
+const API = path.join(ROOT, "apps", "web", "app", "api");
+
+const VERBS = ["GET", "POST", "PATCH", "PUT", "DELETE"];
+
+/** Every source file under a directory, skipping installed and build output. */
+function sourceFiles(dir) {
+  const out = [];
+  const walk = (d) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      const p = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (/\.(ts|tsx)$/.test(entry.name)) out.push(p);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** api.patch<T>('/api/leads/${id}') -> { verb: PATCH, path: /api/leads/* } */
+function collectCalls() {
+  const calls = new Map();
+  const rx = /api\.(get|post|patch|put|delete)\s*(?:<[^>]*>)?\s*\(\s*[`'"]([^`'"]+)/g;
+  for (const file of sourceFiles(NATIVE)) {
+    const src = fs.readFileSync(file, "utf8");
+    for (const [, verb, raw] of src.matchAll(rx)) {
+      const clean = raw.split("?")[0].replace(/\$\{[^}]*\}/g, "*").trim();
+      if (!clean.startsWith("/api")) continue;
+      if (!calls.has(clean)) calls.set(clean, { verbs: new Set(), files: new Set() });
+      calls.get(clean).verbs.add(verb.toUpperCase());
+      calls.get(clean).files.add(path.relative(ROOT, file).replaceAll("\\", "/"));
+    }
+  }
+  return calls;
+}
+
+/** Walk app/api segment by segment; a wildcard segment takes the [param] dir. */
+function resolveRoute(urlPath) {
+  const segs = urlPath.replace(/^\/api\/?/, "").split("/").filter(Boolean);
+  let dir = API;
+  for (const seg of segs) {
+    const literal = path.join(dir, seg);
+    if (fs.existsSync(literal) && fs.statSync(literal).isDirectory()) {
+      dir = literal;
+      continue;
+    }
+    const dynamic = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .find((e) => e.isDirectory() && e.name.startsWith("["));
+    if (!dynamic) return null;
+    dir = path.join(dir, dynamic.name);
+  }
+  const file = path.join(dir, "route.ts");
+  return fs.existsSync(file) ? file : null;
+}
+
+function exportedVerbs(src) {
+  const found = new Set();
+  for (const [, v] of src.matchAll(
+    /export\s+(?:async\s+)?function\s+(GET|POST|PATCH|PUT|DELETE)\b/g,
+  )) found.add(v);
+  // `export const PATCH = PUT` is a legitimate alias, not a missing handler.
+  for (const [, v] of src.matchAll(
+    /export\s+const\s+(GET|POST|PATCH|PUT|DELETE)\s*=/g,
+  )) found.add(v);
+  return found;
+}
+
+const calls = collectCalls();
+const problems = [];
+
+for (const [urlPath, { verbs, files }] of [...calls].sort()) {
+  const routeFile = resolveRoute(urlPath);
+  const where = [...files].sort()[0];
+
+  if (!routeFile) {
+    problems.push(
+      `${urlPath}\n    calls ${[...verbs].sort().join(", ")} from ${where}\n` +
+        `    no route file found under apps/web/app/api`,
+    );
+    continue;
+  }
+
+  const src = fs.readFileSync(routeFile, "utf8");
+  const rel = path.relative(ROOT, routeFile).replaceAll("\\", "/");
+  const missing = [...verbs].filter((v) => !exportedVerbs(src).has(v)).sort();
+
+  if (missing.length) {
+    problems.push(
+      `${urlPath}\n    app sends ${missing.join(", ")} — ${rel} does not export it\n` +
+        `    called from ${where}\n` +
+        `    Next answers 405. Export the verb (an alias such as ` +
+        `\`export const PATCH = PUT\` is fine when the handler already does a partial update).`,
+    );
+  }
+
+  // The phone sends a Bearer token and has no cookies. getUserFromRequest
+  // handles both; createSupabaseRouteClient alone reads cookies only.
+  if (src.includes("createSupabaseRouteClient") && !src.includes("getUserFromRequest")) {
+    problems.push(
+      `${urlPath}\n    ${rel} authenticates from cookies only\n` +
+        `    called from ${where}\n` +
+        `    The app sends Authorization: Bearer, so this returns 401. ` +
+        `Use getUserFromRequest(request).`,
+    );
+  }
+}
+
+const label = `${calls.size} mobile endpoint(s) checked`;
+if (problems.length) {
+  console.error(`\n✗ ${label} — ${problems.length} problem(s):\n`);
+  for (const p of problems) console.error(`  ${p}\n`);
+  process.exit(1);
+}
+console.log(`✓ ${label}: every verb is exported and reachable with a Bearer token.`);


### PR DESCRIPTION
A new enquiry had no call recording, so generating a quote was refused outright - blocking the ordinary case where the engineer already knows the price.

Without a transcript the quote now uses the same defaults the AI pipeline already falls back to. Insight fields stay 'unknown' rather than inventing a persona or objection. Regenerating after the first call replaces it with the real reading.

Also adds the mobile API contract check to CI: it resolves all 62 endpoints the app calls and fails the build if a route is missing the verb the client sends, or authenticates from cookies only. Verified both ways - passes on main, fails with the exact call site when the PATCH alias is removed.