### PR TITLE
feat(quote): state the three-hour unloading allowance in clause 5

### DIFF
--- a/apps/web/src/lib/quotation-html/template.html
+++ b/apps/web/src/lib/quotation-html/template.html
@@ -92,7 +92,7 @@
       "Unloading is carried out alongside the vehicle. Carrying, stacking or shifting the material away from the unloading point is not included in this quotation.",
       "The customer is responsible for ensuring that, on the agreed delivery date, the approach road and the unloading area are clear, level, and firm enough to take a loaded vehicle, and that any permission required for the vehicle to reach the site has been obtained.",
       "Quantities are to be confirmed by the customer before dispatch. Material once dispatched is not taken back except in the case of a manufacturing defect.",
-      "If the vehicle cannot reach the delivery point, or cannot be unloaded within the free unloading time, because the site is not ready, any resulting waiting charges, return freight and re-delivery cost are to the customer's account.",
+      "Three hours of unloading time from the vehicle's arrival at site are included. If the vehicle cannot reach the delivery point, or is held beyond those three hours, because the site is not ready, any resulting waiting charges, return freight and re-delivery cost are to the customer's account.",
     ],
 
     // — Evidence ———————————————————————————————————————————


### PR DESCRIPTION
Clause 5 charged for time beyond "the free unloading time" without saying what that was. It is now stated: three hours from the vehicle's arrival at site, with waiting charges, return freight and re-delivery applying past that.

Allowance and charge sit in one sentence — split across two clauses they get read separately, and the one people remember is the one that does not mention money.

Rendered and measured: every page still ends inside its margin. Typecheck and lint pass; 456/457 tests, the one failure the pre-existing `KPICard` locale assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)