### PR TITLE
fix(native): saved pricing now unlocks WhatsApp and PDF

### DIFF
--- a/apps/native/app/leads/[id].tsx
+++ b/apps/native/app/leads/[id].tsx
@@ -49,8 +49,20 @@ function SmartQuoteSection({
   const generate = useGenerateSmartQuote();
   const existing = useSmartQuote(leadId);
   const [pricingOpen, setPricingOpen] = useState(false);
-  // Freshly generated wins; otherwise whatever the lead already has.
-  const quote = generate.data?.data ?? existing.data ?? null;
+
+  // The query cache is the ONLY source of truth for the quote.
+  //
+  // This used to read `generate.data?.data ?? existing.data`. A mutation's
+  // `.data` is its last result and it survives for the life of the component,
+  // so once you generated a quote, that pre-price snapshot outranked the
+  // query for the rest of the visit. Saving a rate updates the query cache —
+  // and the screen went on rendering the stale object: the readiness gate
+  // stayed shut, WhatsApp and PDF stayed greyed out, and the editor reopened
+  // empty and asked for a price that was already in the database.
+  //
+  // useGenerateSmartQuote writes its result into this same cache on success,
+  // so nothing is lost by reading only from here.
+  const quote = existing.data ?? null;
   const slug = quote?.link_slug;
   const url = slug ? quoteUrl(slug) : null;
   const phone = contact.replace(/[^0-9]/g, '');


### PR DESCRIPTION
Set a rate, save it, and the quote stayed locked — amber banner still up, WhatsApp and PDF greyed out, and the editor reopening empty asking for a price that was already saved.

**The save was never the problem.** Checked production directly: quote `6evXltBJle05` holds `items: [{rate: 52, quantity: 1000, product_id: ...}]` plus `quoted_rate`, `default_product` and `default_area_sqft`. The row is correct and the API returns it.

The screen was reading a different object:

```js
const quote = generate.data?.data ?? existing.data ?? null;
```

`generate` is a mutation. A mutation's `.data` is its last result and it lives as long as the component, so generating a quote parked a pre-price snapshot ahead of the query for the rest of the visit. Saving a rate updates the *query* cache — which that expression only reaches when the mutation has never run. So readiness kept being computed against the quote as it looked before the price existed.

`useGenerateSmartQuote` already writes its result into the same query cache on success, so the mutation result was never needed for display. The screen now reads the cache and nothing else.

Reproduces on any lead generated and priced in one visit — the normal way the screen is used.

Needs an OTA to reach phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)