### PR TITLE
fix(quote): multi-product on the customer page, currency on the total

### DIFF
--- a/apps/web/src/components/smart-quote/ui/InteractiveEstimate.tsx
+++ b/apps/web/src/components/smart-quote/ui/InteractiveEstimate.tsx
@@ -81,9 +81,45 @@ export function InteractiveEstimate({
     : t(language, "sq.ft", "சதுர அடி");
   const showTransport = pricing?.show_transport !== false;
 
+  // The lines the engineer actually quoted.
+  //
+  // This component was built when a quote was one product, and it still reads
+  // `default_product` / `default_area_sqft` — which are only ever the FIRST
+  // line. A two-product quote therefore showed the customer one product and a
+  // total for that product alone, while the PDF for the same quote showed
+  // both and a total roughly twice as large. Two documents, one quote, two
+  // prices; whichever the customer read second destroyed the first.
+  //
+  // Everything needed is already in pricing.items, so the lines are computed
+  // here rather than re-derived by the estimate endpoint, which prices one
+  // product per call.
+  const quotedLines = useMemo(() => {
+    const items = pricing?.items ?? [];
+    return items
+      .map((it) => {
+        const product = products.find((p) => p.id === it.product_id);
+        if (!product || !(it.rate > 0) || !(it.quantity > 0)) return null;
+        return {
+          id: it.product_id,
+          name: product.name,
+          unit: product.unit,
+          quantity: it.quantity,
+          rate: it.rate,
+          amount: it.rate * it.quantity,
+        };
+      })
+      .filter((l): l is NonNullable<typeof l> => l !== null);
+  }, [pricing?.items, products]);
+
+  // One line is still the calculator's job — it can price a single product
+  // live, and letting the customer move the quantity is the point of the page.
+  // More than one and the quote is fixed, so it is shown as quoted.
+  const isMultiLine = quotedLines.length > 1;
+  const quotedTotal = quotedLines.reduce((sum, l) => sum + l.amount, 0);
+
   // Debounced live estimate
   useEffect(() => {
-    if (!productId || !quantity || quantity <= 0) {
+    if (isMultiLine || !productId || !quantity || quantity <= 0) {
       setResult(null);
       return;
     }
@@ -108,7 +144,7 @@ export function InteractiveEstimate({
       }
     }, 350);
     return () => clearTimeout(handle);
-  }, [slug, productId, quantity, distanceKm, showTransport]);
+  }, [slug, productId, quantity, distanceKm, showTransport, isMultiLine]);
 
   const handleWhatsApp = useCallback(() => {
     const phone = pricing?.rep_phone;
@@ -139,14 +175,53 @@ export function InteractiveEstimate({
           t(language, "Your instant estimate", "உங்கள் உடனடி மதிப்பீடு")}
       </h2>
       <p className="mt-2 text-center text-sm text-slate-500">
-        {t(
-          language,
-          "Adjust the details to see your price — built from our live rates.",
-          "விவரங்களை மாற்றி உங்கள் விலையைப் பாருங்கள் — எங்கள் நேரடி விலையிலிருந்து.",
-        )}
+        {isMultiLine
+          ? t(
+              language,
+              "Prepared for you by our team — these are the products and rates quoted.",
+              "எங்கள் குழுவால் உங்களுக்காகத் தயாரிக்கப்பட்டது — இவை மேற்கோள் காட்டப்பட்ட தயாரிப்புகளும் விலைகளும்.",
+            )
+          : t(
+              language,
+              "Adjust the details to see your price — built from our live rates.",
+              "விவரங்களை மாற்றி உங்கள் விலையைப் பாருங்கள் — எங்கள் நேரடி விலையிலிருந்து.",
+            )}
       </p>
 
       <div className="mt-7 rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/50">
+        {isMultiLine ? (
+          <>
+            <ul className="divide-y divide-slate-100">
+              {quotedLines.map((l) => (
+                <li key={l.id} className="flex items-baseline justify-between gap-4 py-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-semibold text-slate-800">{l.name}</div>
+                    <div className="mt-0.5 text-xs text-slate-500">
+                      {l.quantity.toLocaleString("en-IN")}{" "}
+                      {l.unit === "piece"
+                        ? t(language, "bricks", "செங்கற்கள்")
+                        : t(language, "sq.ft", "சதுர அடி")}{" "}
+                      &times; {inr(l.rate)}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-sm font-semibold text-slate-900">
+                    {inr(l.amount)}
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-5 rounded-2xl bg-gradient-to-br from-slate-900 to-slate-800 p-5 text-white">
+              <div className="flex items-end justify-between gap-4">
+                <span className="text-sm text-slate-300">
+                  {t(language, "Your quote total", "உங்கள் மொத்தத் தொகை")}
+                </span>
+                <span className="whitespace-nowrap text-3xl font-bold">{inr(quotedTotal)}</span>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
         {/* Product selector */}
         {products.length > 1 && (
           <div className="mb-5">
@@ -253,6 +328,8 @@ export function InteractiveEstimate({
             </div>
           )}
         </div>
+          </>
+        )}
 
         {pricing?.price_note && (
           <p className="mt-3 text-center text-xs text-slate-400">{pricing.price_note}</p>
@@ -264,11 +341,17 @@ export function InteractiveEstimate({
           </p>
         )}
         <p className="mt-2 text-center text-[11px] text-slate-400">
-          {t(
-            language,
-            "Indicative estimate for materials & delivery. Final quote confirmed by our team.",
-            "பொருட்கள் & டெலிவரிக்கான தோராய மதிப்பீடு. இறுதி விலை எங்கள் குழுவால் உறுதி செய்யப்படும்.",
-          )}
+          {isMultiLine
+            ? t(
+                language,
+                "Quoted rates for materials. GST extra, as per actual.",
+                "பொருட்களுக்கான மேற்கோள் விலை. GST தனி, உண்மையின்படி.",
+              )
+            : t(
+                language,
+                "Indicative estimate for materials & delivery. Final quote confirmed by our team.",
+                "பொருட்கள் & டெலிவரிக்கான தோராய மதிப்பீடு. இறுதி விலை எங்கள் குழுவால் உறுதி செய்யப்படும்.",
+              )}
         </p>
 
         {/* WhatsApp CTA — hidden when the routed CTA section closes the page */}

--- a/apps/web/src/lib/quotation-html/template.html
+++ b/apps/web/src/lib/quotation-html/template.html
@@ -319,7 +319,13 @@
     background: var(--terracotta); color: #fff; padding: 4.2mm 3.5mm; border: none;
     font-family: var(--serif); font-size: 13pt; letter-spacing: 0.01em;
   }
-  .bill tr.grand td.r { color: #fff; font-size: 19pt; font-weight: 700; }
+  /* The total is one number and must read as one: adding the currency
+     pushed "Rs. 1,05,000" past the column and it broke after "Rs.".
+     Never wrap, and start a size smaller so a lakh-scale figure with a
+     prefix still fits the band. */
+  .bill tr.grand td.r {
+    color: #fff; font-size: 17pt; font-weight: 700; white-space: nowrap;
+  }
 
   /* — Conversion blocks — */
   .advance {
@@ -845,11 +851,23 @@
         <td class="r">${isPlaceholder(it.amount) ? esc(it.amount) : cur + " " + esc(it.amount)}</td>
       </tr>`).join("");
 
-  const rows = [`<tr class="sum"><td colspan="3" class="r">Subtotal</td><td class="r">${esc(CONFIG.subtotal)}</td></tr>`];
+  /* Totals carry the currency, same as the lines above them.
+     They did not, and the effect was absurd on the one number that matters:
+     every line read "Rs. 55" while the grand total read a bare "1,05,000".
+     A total without a unit is the last thing a commercial document should
+     print. Values that already carry a symbol are left alone, so a caller
+     passing "Rs. 1,05,000" does not end up with it twice. */
+  const withCur = (v) => {
+    const str = String(v ?? "");
+    if (!str || isPlaceholder(str)) return esc(str);
+    return /^(₹|Rs\.?)\s/i.test(str) ? esc(str) : cur + " " + esc(str);
+  };
+
+  const rows = [`<tr class="sum"><td colspan="3" class="r">Subtotal</td><td class="r">${withCur(CONFIG.subtotal)}</td></tr>`];
   if (CONFIG.showGst) {
-    rows.push(`<tr class="sum"><td colspan="3" class="r">GST @ ${esc(CONFIG.gstRate)}</td><td class="r">${esc(CONFIG.gstAmount)}</td></tr>`);
+    rows.push(`<tr class="sum"><td colspan="3" class="r">GST @ ${esc(CONFIG.gstRate)}</td><td class="r">${withCur(CONFIG.gstAmount)}</td></tr>`);
   }
-  rows.push(`<tr class="grand"><td colspan="3">Total project investment</td><td class="r">${esc(CONFIG.grandTotal)}</td></tr>`);
+  rows.push(`<tr class="grand"><td colspan="3">Total project investment</td><td class="r">${withCur(CONFIG.grandTotal)}</td></tr>`);
   document.getElementById("bill-foot").innerHTML = rows.join("");
 
   const note = document.getElementById("tax-note");


### PR DESCRIPTION
Found while checking the Justdial lead. The PDF handles multiple products correctly — the customer-facing link does not.

## The shared link and the PDF disagreed on price

`InteractiveEstimate` was built when a quote was one product and still reads `default_product` / `default_area_sqft`, which are only ever the **first** line.

Quote `OrgxE5Odp930` (Jagadeesh Jothi Nagar) quotes two products — 1,000 of the 8" at Rs. 55, 1,000 of the 6" at Rs. 50:

| | |
|---|---|
| PDF | Rs. 1,05,000 — both lines |
| Shared link | Rs. 55,000 — the 8" alone |

Whichever the customer read second destroyed the first.

`pricing.items` already holds everything, so the lines are computed in the component rather than asked of `/estimate`, which prices one product per call. **One line keeps the live calculator** — adjusting quantity is the point of that page. **More than one is shown as quoted**: the lines, their rates and the real total, with the estimate request skipped.

Sub-headline and footnote follow suit — "adjust the details" and "indicative estimate, final quote confirmed by our team" are true of a calculator and false of a quote an engineer has priced.

## The grand total had no currency at all

Every line read "Rs. 55"; the total read a bare "1,05,000". Totals now carry it, values that already have a symbol are left alone, and the total no longer wraps after "Rs.". Verified at both ends: Rs. 1,05,000 and Rs. 1,35,50,000 each hold one line.

## Not changed

The Justdial quote itself (`V4nvwrKFeztN`) has no `items` — it is priced on the legacy single-product fields, one product at Rs. 55 × 2,000. That is a valid one-product quote, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)