### PR TITLE
feat(ops-control): Phase 1 — masters, configuration and audit

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -58,6 +58,7 @@ const navigation: NavItem[] = [
     key: "production",
   },
   { name: "Plan", href: "/planning", icon: ProductionIcon, key: "planning" },
+  { name: "Ops Control", href: "/ops", icon: ProductionIcon, key: "ops" },
   { name: "Projects", href: "/projects", icon: ProductionIcon, key: "projects" },
   { name: "Reimbursements", href: "/expenses", icon: KPIIcon, key: "expenses" },
   { name: "Rate Card", href: "/rate-card", icon: KPIIcon, key: "rate-card" },
@@ -109,7 +110,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
   ],
   sales: ["dashboard", "onehub", "leads", "quotes", "tasks", "settings", "knowledge", "coaching"],
   driver: ["dashboard", "onehub", "deliveries", "settings"],
-  production_supervisor: ["dashboard", "onehub", "factory", "production", "planning", "deliveries", "settings", "projects", "coaching"],
+  production_supervisor: ["dashboard", "onehub", "factory", "production", "planning", "ops", "deliveries", "settings", "projects", "coaching"],
 };
 
 function getNavigationForRole(role: UserRole | undefined): NavItem[] {

--- a/apps/web/app/(dashboard)/ops/layout.tsx
+++ b/apps/web/app/(dashboard)/ops/layout.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+// Phase 1 ships Masters only. Demand, Production, Dispatch, Labour and
+// Analytics land in later phases (see the implementation roadmap) — they are
+// deliberately absent rather than stubbed, so the nav never promises a screen
+// that does not work.
+const TABS = [{ href: "/ops/masters", label: "Masters" }];
+
+export default function OpsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+          Operations Control
+        </h1>
+        <p className="text-sm text-slate-500">
+          Demand, production, dispatch and labour control. Odoo remains the ERP
+          and the authoritative physical inventory.
+        </p>
+      </div>
+
+      <nav className="flex flex-wrap gap-1.5">
+        {TABS.map((t) => {
+          const active = pathname.startsWith(t.href);
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              className={`rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
+              }`}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/ops/masters/page.tsx
+++ b/apps/web/app/(dashboard)/ops/masters/page.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+/**
+ * Operations Control — Masters.
+ *
+ * Phase 1 of the Production, Fulfilment & Dispatch Control PRD. Every
+ * operational value the system uses is configured here; nothing is hard-coded.
+ *
+ * The empty states matter as much as the tables: labour rates and cement
+ * ratios ship deliberately UNSET (PRD §100 — the PRD's Rs.7/Rs.6 and
+ * 140-bricks-per-bag figures are illustrative and must come from the
+ * business), so this screen has to say so plainly rather than looking broken.
+ */
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Spinner } from "@maiyuri/ui";
+
+type Tab = "rates" | "standards" | "capacities" | "reasons" | "mapping" | "settings";
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "rates", label: "Activity rates" },
+  { key: "standards", label: "Cement standards" },
+  { key: "capacities", label: "Vehicle capacity" },
+  { key: "reasons", label: "Deviation reasons" },
+  { key: "mapping", label: "Odoo product mapping" },
+  { key: "settings", label: "Operational settings" },
+];
+
+interface Envelope<T> {
+  data: T | null;
+  error: string | null;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  const body = (await res.json()) as Envelope<T>;
+  if (!res.ok || body.error) throw new Error(body.error ?? "Request failed");
+  return body.data as T;
+}
+
+interface NamedProduct {
+  id: string;
+  name: string;
+}
+interface RateRow {
+  id: string;
+  activity_code: string;
+  rate: number;
+  uom: string;
+  effective_from: string;
+  effective_to: string | null;
+  active: boolean;
+  finished_goods: NamedProduct | null;
+}
+interface StandardRow {
+  id: string;
+  material: string;
+  standard_yield: number;
+  tolerance_pct: number | null;
+  effective_from: string;
+  effective_to: string | null;
+  finished_goods: NamedProduct | null;
+}
+interface CapacityRow {
+  id: string;
+  full_load_qty: number;
+  effective_from: string;
+  effective_to: string | null;
+  oc_vehicles: { id: string; vehicle_type: string } | null;
+  finished_goods: NamedProduct | null;
+}
+interface ReasonRow {
+  id: string;
+  scope: string;
+  code: string;
+  label: string;
+}
+interface MappingRow {
+  id: string;
+  odoo_product_id: number;
+  odoo_product_name: string | null;
+  finished_goods: NamedProduct | null;
+}
+interface MappingPayload {
+  mappings: MappingRow[];
+  finished_goods: { id: string; name: string; odoo_product_id: number | null }[];
+}
+interface SettingsRow {
+  default_shifts_per_day: number;
+  normal_max_trips_per_day: number;
+  load_green_min_pct: number;
+  load_yellow_min_pct: number;
+  load_red_above_pct: number;
+  cement_bag_kg: number;
+  cement_bag_step: number;
+  ratio_amber_tolerance_pct: number;
+  ratio_red_tolerance_pct: number;
+  production_wage_basis: string;
+  output_per_person_basis: string;
+}
+
+const BASE = "/api/ops-control/masters";
+
+function period(from: string, to: string | null): string {
+  return to ? `${from} → ${to}` : `${from} → current`;
+}
+
+function Table({
+  headers,
+  children,
+}: {
+  headers: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wider text-slate-400 dark:border-slate-700">
+            {headers.map((h) => (
+              <th key={h} className="px-4 py-3 font-medium">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+function Empty({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td colSpan={colSpan} className="px-4 py-10 text-center text-slate-400">
+        {children}
+      </td>
+    </tr>
+  );
+}
+
+function Panel({
+  title,
+  description,
+  isLoading,
+  error,
+  children,
+}: {
+  title: string;
+  description: string;
+  isLoading: boolean;
+  error: unknown;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className="space-y-3 p-4">
+      <div>
+        <h2 className="font-semibold text-slate-900 dark:text-white">{title}</h2>
+        <p className="text-sm text-slate-500">{description}</p>
+      </div>
+      {isLoading ? (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      ) : error ? (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300">
+          {(error as Error).message}
+        </p>
+      ) : (
+        children
+      )}
+    </Card>
+  );
+}
+
+function RatesPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "rates"],
+    queryFn: () => fetchJson<RateRow[]>(`${BASE}/activity-rates`),
+  });
+  return (
+    <Panel
+      title="Activity rates"
+      description="Per product, per activity, effective-dated. A rate is never edited in place — close the current period and open a new one, so past weeks keep paying the rate that applied then."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <Table headers={["Product", "Activity", "Rate", "Period", "Status"]}>
+        {(q.data ?? []).length === 0 ? (
+          <Empty colSpan={5}>
+            No rates configured yet. Production, loading and unloading rates must
+            be entered by the business before labour can be calculated.
+          </Empty>
+        ) : (
+          q.data!.map((r) => (
+            <tr key={r.id} className="border-b border-slate-50 dark:border-slate-700/50">
+              <td className="px-4 py-3">{r.finished_goods?.name ?? "—"}</td>
+              <td className="px-4 py-3 capitalize">{r.activity_code}</td>
+              <td className="px-4 py-3 tabular-nums">
+                ₹{Number(r.rate).toFixed(2)}
+                <span className="text-slate-400"> / {r.uom.replace("per_", "")}</span>
+              </td>
+              <td className="px-4 py-3 tabular-nums text-slate-500">
+                {period(r.effective_from, r.effective_to)}
+              </td>
+              <td className="px-4 py-3">
+                {r.active ? (
+                  <span className="text-emerald-600">Active</span>
+                ) : (
+                  <span className="text-slate-400">Superseded</span>
+                )}
+              </td>
+            </tr>
+          ))
+        )}
+      </Table>
+    </Panel>
+  );
+}
+
+function StandardsPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "standards"],
+    queryFn: () => fetchJson<StandardRow[]>(`${BASE}/consumption-standards`),
+  });
+  return (
+    <Panel
+      title="Cement consumption standards"
+      description="Expected bricks per 50 kg bag, per product. Actual ratio always uses gross production — rejected bricks consumed cement too."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <Table headers={["Product", "Material", "Bricks / bag", "Tolerance", "Period"]}>
+        {(q.data ?? []).length === 0 ? (
+          <Empty colSpan={5}>
+            No standards configured yet. Ratios differ by product and must be
+            supplied by the business — none are assumed.
+          </Empty>
+        ) : (
+          q.data!.map((s) => (
+            <tr key={s.id} className="border-b border-slate-50 dark:border-slate-700/50">
+              <td className="px-4 py-3">{s.finished_goods?.name ?? "—"}</td>
+              <td className="px-4 py-3 capitalize">{s.material}</td>
+              <td className="px-4 py-3 tabular-nums">{Number(s.standard_yield).toFixed(1)}</td>
+              <td className="px-4 py-3 tabular-nums text-slate-500">
+                {s.tolerance_pct === null ? "Global default" : `±${s.tolerance_pct}%`}
+              </td>
+              <td className="px-4 py-3 tabular-nums text-slate-500">
+                {period(s.effective_from, s.effective_to)}
+              </td>
+            </tr>
+          ))
+        )}
+      </Table>
+    </Panel>
+  );
+}
+
+function CapacitiesPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "capacities"],
+    queryFn: () => fetchJson<CapacityRow[]>(`${BASE}/vehicle-capacities`),
+  });
+  return (
+    <Panel
+      title="Vehicle capacity"
+      description="Maximum normal full load per vehicle and product. This is an operating standard, not a hard limit — exceeding it warns in red and still saves."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <Table headers={["Vehicle", "Product", "Full load", "Period"]}>
+        {(q.data ?? []).length === 0 ? (
+          <Empty colSpan={4}>No vehicle capacities configured.</Empty>
+        ) : (
+          q.data!.map((c) => (
+            <tr key={c.id} className="border-b border-slate-50 dark:border-slate-700/50">
+              <td className="px-4 py-3">{c.oc_vehicles?.vehicle_type ?? "—"}</td>
+              <td className="px-4 py-3">{c.finished_goods?.name ?? "—"}</td>
+              <td className="px-4 py-3 tabular-nums">
+                {Number(c.full_load_qty).toLocaleString("en-IN")}
+              </td>
+              <td className="px-4 py-3 tabular-nums text-slate-500">
+                {period(c.effective_from, c.effective_to)}
+              </td>
+            </tr>
+          ))
+        )}
+      </Table>
+    </Panel>
+  );
+}
+
+function ReasonsPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "reasons"],
+    queryFn: () => fetchJson<ReasonRow[]>(`${BASE}/deviation-reasons`),
+  });
+  const rows = q.data ?? [];
+  const production = rows.filter((r) => r.scope === "production");
+  const delivery = rows.filter((r) => r.scope === "delivery");
+  return (
+    <Panel
+      title="Deviation reasons"
+      description="Why production or a delivery differed from plan. Kept as configurable masters so a new reason is configuration, not a migration."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        {[
+          { label: "Production", items: production },
+          { label: "Delivery", items: delivery },
+        ].map((group) => (
+          <div key={group.label}>
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-400">
+              {group.label}
+            </h3>
+            <ul className="space-y-1 text-sm">
+              {group.items.length === 0 ? (
+                <li className="text-slate-400">None configured.</li>
+              ) : (
+                group.items.map((r) => (
+                  <li
+                    key={r.id}
+                    className="rounded-lg bg-slate-50 px-3 py-1.5 dark:bg-slate-900/40"
+                  >
+                    {r.label}
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}
+
+function MappingPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "mapping"],
+    queryFn: () => fetchJson<MappingPayload>(`${BASE}/product-mapping`),
+  });
+  const mappings = q.data?.mappings ?? [];
+  return (
+    <Panel
+      title="Odoo product mapping"
+      description="Links an Odoo product to a Maiyuri finished good. Only mapped products count as demand — service lines such as Loading and Unloading carry brick-sized quantities and must never enter the plan."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <p className="rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+        Unmapped Odoo products with open demand are listed here once sales-order
+        line sync ships in Phase 2. Until then this shows the links already
+        resolved from Odoo product ids.
+      </p>
+      <Table headers={["Odoo product", "Odoo id", "Maiyuri finished good"]}>
+        {mappings.length === 0 ? (
+          <Empty colSpan={3}>No product mappings yet.</Empty>
+        ) : (
+          mappings.map((m) => (
+            <tr key={m.id} className="border-b border-slate-50 dark:border-slate-700/50">
+              <td className="px-4 py-3">{m.odoo_product_name ?? "—"}</td>
+              <td className="px-4 py-3 tabular-nums text-slate-500">{m.odoo_product_id}</td>
+              <td className="px-4 py-3">{m.finished_goods?.name ?? "—"}</td>
+            </tr>
+          ))
+        )}
+      </Table>
+    </Panel>
+  );
+}
+
+function SettingsPanel() {
+  const q = useQuery({
+    queryKey: ["oc", "settings"],
+    queryFn: () => fetchJson<SettingsRow>(`${BASE}/settings`),
+  });
+  const s = q.data;
+  const rows: { label: string; value: string }[] = s
+    ? [
+        { label: "Default shifts per day", value: String(s.default_shifts_per_day) },
+        { label: "Normal maximum trips per day", value: String(s.normal_max_trips_per_day) },
+        { label: "Full load — green from", value: `${s.load_green_min_pct}%` },
+        { label: "Partial load — yellow from", value: `${s.load_yellow_min_pct}%` },
+        { label: "Overload — red above", value: `${s.load_red_above_pct}%` },
+        { label: "Cement bag weight", value: `${s.cement_bag_kg} kg` },
+        { label: "Cement entry step", value: `${s.cement_bag_step} bag` },
+        { label: "Ratio tolerance — amber", value: `±${s.ratio_amber_tolerance_pct}%` },
+        { label: "Ratio tolerance — red", value: `±${s.ratio_red_tolerance_pct}%` },
+        { label: "Production wage basis", value: s.production_wage_basis },
+        { label: "Output per person-shift basis", value: s.output_per_person_basis },
+      ]
+    : [];
+  return (
+    <Panel
+      title="Operational settings"
+      description="The thresholds every warning bands against. Changing one changes how the whole system reads — restricted to founder and owner, and audited."
+      isLoading={q.isLoading}
+      error={q.error}
+    >
+      <Table headers={["Setting", "Value"]}>
+        {rows.map((r) => (
+          <tr key={r.label} className="border-b border-slate-50 dark:border-slate-700/50">
+            <td className="px-4 py-3 text-slate-600 dark:text-slate-300">{r.label}</td>
+            <td className="px-4 py-3 font-medium tabular-nums">{r.value}</td>
+          </tr>
+        ))}
+      </Table>
+      <p className="text-xs text-slate-400">
+        The cement ratio always uses gross production; the labour wage basis is
+        configured separately and is deliberately not the same setting.
+      </p>
+    </Panel>
+  );
+}
+
+export default function OpsMastersPage() {
+  const [tab, setTab] = useState<Tab>("rates");
+  return (
+    <div className="space-y-4">
+      <nav className="flex flex-wrap gap-1.5">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={`rounded-full px-3 py-1.5 text-sm transition-colors ${
+              tab === t.key
+                ? "bg-slate-200 font-medium text-slate-900 dark:bg-slate-700 dark:text-white"
+                : "text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      {tab === "rates" && <RatesPanel />}
+      {tab === "standards" && <StandardsPanel />}
+      {tab === "capacities" && <CapacitiesPanel />}
+      {tab === "reasons" && <ReasonsPanel />}
+      {tab === "mapping" && <MappingPanel />}
+      {tab === "settings" && <SettingsPanel />}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/ops/page.tsx
+++ b/apps/web/app/(dashboard)/ops/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+// Phase 1 has one screen; /ops lands on it rather than showing an empty shell.
+export default function OpsIndexPage() {
+  redirect("/ops/masters");
+}

--- a/apps/web/app/api/ops-control/masters/__tests__/masters-routes.test.ts
+++ b/apps/web/app/api/ops-control/masters/__tests__/masters-routes.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Operations Control masters API tests.
+ *
+ * These routes use the service-role client, which bypasses RLS, so the role
+ * gate in the handler is the only thing standing between a driver and the
+ * labour rate master. That is what these tests are mostly about.
+ *
+ * Also covers the two behaviours the PRD is strict on:
+ *  - overlapping effective periods are a data-integrity failure and BLOCK (§88)
+ *  - a rate change is audited with its before value (§74)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// --- Mocks --------------------------------------------------------------
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase-server", () => ({
+  getUserFromRequest: (...args: unknown[]) => mockGetUser(...args),
+}));
+
+/** Per-table queue of results the mocked client should return. */
+const results: Record<string, unknown[]> = {};
+const inserted: Record<string, unknown[]> = {};
+
+function queue(table: string, result: unknown) {
+  (results[table] ??= []).push(result);
+}
+function nextResult(table: string) {
+  return (results[table] ?? []).shift() ?? { data: null, error: null };
+}
+
+/**
+ * A chainable stub: every builder method returns the same object, and the
+ * terminal awaits (single/maybeSingle/then) resolve the queued result.
+ */
+function builder(table: string) {
+  const chain: Record<string, unknown> = {};
+  const passthrough = [
+    "select", "eq", "order", "limit", "gte", "lte", "update", "upsert", "insert",
+  ];
+  for (const method of passthrough) {
+    chain[method] = (...args: unknown[]) => {
+      if (method === "insert" || method === "upsert") {
+        (inserted[table] ??= []).push(args[0]);
+      }
+      return chain;
+    };
+  }
+  chain.single = () => Promise.resolve(nextResult(table));
+  chain.maybeSingle = () => Promise.resolve(nextResult(table));
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(nextResult(table)).then(resolve);
+  return chain;
+}
+
+vi.mock("@/lib/supabase-admin", () => ({
+  supabaseAdmin: { from: (table: string) => builder(table) },
+}));
+
+import { POST as ratesPost, GET as ratesGet } from "../activity-rates/route";
+import { POST as mappingPost } from "../product-mapping/route";
+import { PATCH as settingsPatch } from "../settings/route";
+
+function req(url: string, body?: Record<string, unknown>, method = "POST"): NextRequest {
+  return new NextRequest(`http://localhost${url}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+/** Sign in as a role by queueing the users-table lookup requireProductionRole does. */
+function signInAs(role: string) {
+  mockGetUser.mockResolvedValue({ id: "user-1" });
+  queue("users", { data: { role }, error: null });
+}
+
+const VALID_RATE = {
+  finished_good_id: "11111111-1111-1111-1111-111111111111",
+  activity_code: "production",
+  rate: 7,
+  effective_from: "2026-01-01",
+  effective_to: "2026-08-31",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(results)) delete results[key];
+  for (const key of Object.keys(inserted)) delete inserted[key];
+});
+
+describe("POST /api/ops-control/masters/activity-rates — authorization", () => {
+  it("rejects an unauthenticated request", async () => {
+    mockGetUser.mockResolvedValue(null);
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", VALID_RATE));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a driver — rates are not theirs to set", async () => {
+    signInAs("driver");
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", VALID_RATE));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a production_supervisor — rate changes are founder/owner only", async () => {
+    // Supervisors record production; they do not change what labour is paid.
+    signInAs("production_supervisor");
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", VALID_RATE));
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a founder", async () => {
+    signInAs("founder");
+    queue("oc_activity_rates", { data: { id: "rate-1" }, error: null });
+    queue("oc_audit_events", { data: null, error: null });
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", VALID_RATE));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/ops-control/masters/activity-rates — validation", () => {
+  it("rejects a negative rate", async () => {
+    signInAs("founder");
+    const res = await ratesPost(
+      req("/api/ops-control/masters/activity-rates", { ...VALID_RATE, rate: -1 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a period that ends before it starts", async () => {
+    signInAs("founder");
+    const res = await ratesPost(
+      req("/api/ops-control/masters/activity-rates", {
+        ...VALID_RATE,
+        effective_from: "2026-09-01",
+        effective_to: "2026-08-01",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 with a usable message when periods overlap (PRD §88)", async () => {
+    signInAs("founder");
+    // 23P01 = exclusion_violation, raised by the EXCLUDE constraint.
+    queue("oc_activity_rates", { data: null, error: { code: "23P01", message: "conflicting key value" } });
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", VALID_RATE));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/overlaps an existing rate/i);
+  });
+
+  it("accepts an open-ended period (effective_to omitted)", async () => {
+    signInAs("founder");
+    queue("oc_activity_rates", { data: { id: "rate-2" }, error: null });
+    queue("oc_audit_events", { data: null, error: null });
+    const { effective_to: _drop, ...openEnded } = VALID_RATE;
+    const res = await ratesPost(req("/api/ops-control/masters/activity-rates", openEnded));
+    expect(res.status).toBe(200);
+    expect(inserted.oc_activity_rates?.[0]).toMatchObject({ effective_to: null });
+  });
+});
+
+describe("GET /api/ops-control/masters/activity-rates", () => {
+  it("is readable without a write role — the UI needs it to band values", async () => {
+    queue("oc_activity_rates", { data: [], error: null });
+    const res = await ratesGet(req("/api/ops-control/masters/activity-rates", undefined, "GET"));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/ops-control/masters/product-mapping", () => {
+  const MAPPING = {
+    odoo_product_id: 8,
+    odoo_product_name: "CIB-10*8*5-Single Press",
+    finished_good_id: "11111111-1111-1111-1111-111111111111",
+  };
+
+  it("rejects a sales user", async () => {
+    signInAs("sales");
+    const res = await mappingPost(req("/api/ops-control/masters/product-mapping", MAPPING));
+    expect(res.status).toBe(403);
+  });
+
+  it("maps an unmapped Odoo product so its demand becomes visible", async () => {
+    signInAs("owner");
+    queue("oc_product_mapping", { data: null, error: null }); // no existing mapping
+    queue("oc_product_mapping", { data: { id: "map-1" }, error: null }); // upsert result
+    queue("oc_audit_events", { data: null, error: null });
+    const res = await mappingPost(req("/api/ops-control/masters/product-mapping", MAPPING));
+    expect(res.status).toBe(200);
+    expect(inserted.oc_product_mapping?.[0]).toMatchObject({ odoo_product_id: 8 });
+  });
+
+  it("rejects a non-numeric odoo_product_id", async () => {
+    signInAs("owner");
+    const res = await mappingPost(
+      req("/api/ops-control/masters/product-mapping", { ...MAPPING, odoo_product_id: "eight" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/ops-control/masters/settings", () => {
+  it("rejects an empty body rather than issuing a no-op update", async () => {
+    signInAs("founder");
+    const res = await settingsPatch(req("/api/ops-control/masters/settings", {}, "PATCH"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a yellow threshold above green", async () => {
+    signInAs("founder");
+    const res = await settingsPatch(
+      req(
+        "/api/ops-control/masters/settings",
+        { load_green_min_pct: 90, load_yellow_min_pct: 95 },
+        "PATCH",
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an amber tolerance above red", async () => {
+    signInAs("founder");
+    const res = await settingsPatch(
+      req(
+        "/api/ops-control/masters/settings",
+        { ratio_amber_tolerance_pct: 20, ratio_red_tolerance_pct: 10 },
+        "PATCH",
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid shift count — V1 supports one or two only", async () => {
+    signInAs("founder");
+    const res = await settingsPatch(
+      req("/api/ops-control/masters/settings", { default_shifts_per_day: 3 }, "PATCH"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/ops-control/masters/activity-rates/[id]/route.ts
+++ b/apps/web/app/api/ops-control/masters/activity-rates/[id]/route.ts
@@ -1,0 +1,68 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, notFound, parseBody } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { updateOcActivityRateSchema } from "@maiyuri/shared";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// PATCH /api/ops-control/masters/activity-rates/[id]
+//
+// Closing a period (setting effective_to) or deactivating a rate is allowed.
+// Editing the RATE VALUE of a period that has already been used is not
+// prevented here, but it is audited with the before value — PRD §67 requires
+// that a change affecting an approved labour settlement is visible, and Phase 6
+// will refuse it outright once settlements exist.
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const { id } = await params;
+    const parsed = await parseBody(request, updateOcActivityRateSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data: before } = await supabaseAdmin
+      .from("oc_activity_rates")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (!before) return notFound("Activity rate");
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_activity_rates")
+      .update({ ...parsed.data, modified_by: auth.user.id })
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (dbError) {
+      if (dbError.code === "23P01") {
+        return error(
+          "That period would overlap an existing rate for the same product and activity.",
+          409,
+        );
+      }
+      return error(`Failed to update rate: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_activity_rates",
+      entity_id: id,
+      action: parsed.data.active === false ? "deactivated" : "updated",
+      before_value: before,
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] activity-rates PATCH failed:", err);
+    return error("Failed to update activity rate", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/activity-rates/route.ts
+++ b/apps/web/app/api/ops-control/masters/activity-rates/route.ts
@@ -1,0 +1,84 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcActivityRateSchema } from "@maiyuri/shared";
+
+const SELECT = "*, finished_goods(id, name)";
+
+// GET /api/ops-control/masters/activity-rates?finished_good_id&activity_code&active
+export async function GET(request: NextRequest) {
+  try {
+    const { finished_good_id, activity_code, active } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("oc_activity_rates")
+      .select(SELECT)
+      .order("finished_good_id")
+      .order("activity_code")
+      .order("effective_from", { ascending: false });
+
+    if (finished_good_id) query = query.eq("finished_good_id", finished_good_id);
+    if (activity_code) query = query.eq("activity_code", activity_code);
+    if (active === "true") query = query.eq("active", true);
+
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load activity rates", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] activity-rates GET failed:", err);
+    return error("Failed to load activity rates", 500);
+  }
+}
+
+// POST /api/ops-control/masters/activity-rates
+//
+// Rates are effective-dated and never edited in place: to change a rate you
+// close the current period and open a new one, so August keeps paying the
+// August rate (PRD §60). Overlapping periods are rejected by a database
+// EXCLUDE constraint — a data-integrity failure, so it blocks (PRD §88).
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcActivityRateSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_activity_rates")
+      .insert({
+        ...parsed.data,
+        effective_to: parsed.data.effective_to ?? null,
+        created_by: auth.user.id,
+        modified_by: auth.user.id,
+      })
+      .select(SELECT)
+      .single();
+
+    if (dbError) {
+      // 23P01 = exclusion_violation: the new period overlaps an existing one.
+      if (dbError.code === "23P01") {
+        return error(
+          "This rate period overlaps an existing rate for the same product and activity. Close the current period first.",
+          409,
+        );
+      }
+      return error(`Failed to create rate: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_activity_rates",
+      entity_id: (data as { id: string }).id,
+      action: "created",
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] activity-rates POST failed:", err);
+    return error("Failed to create activity rate", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/activity-types/route.ts
+++ b/apps/web/app/api/ops-control/masters/activity-types/route.ts
@@ -1,0 +1,22 @@
+export const dynamic = "force-dynamic";
+
+import { success, error } from "@/lib/api-utils";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+// GET /api/ops-control/masters/activity-types
+// Read-only in Phase 1: production/loading/unloading are seeded. The table
+// exists so further activities are configuration, not a migration (PRD §57).
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_activity_types")
+      .select("*")
+      .eq("active", true)
+      .order("sort_order");
+    if (dbError) return error("Failed to load activity types", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] activity-types GET failed:", err);
+    return error("Failed to load activity types", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/consumption-standards/route.ts
+++ b/apps/web/app/api/ops-control/masters/consumption-standards/route.ts
@@ -1,0 +1,81 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcConsumptionStandardSchema } from "@maiyuri/shared";
+
+const SELECT = "*, finished_goods(id, name)";
+
+// GET /api/ops-control/masters/consumption-standards?finished_good_id&active
+export async function GET(request: NextRequest) {
+  try {
+    const { finished_good_id, active } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("oc_consumption_standards")
+      .select(SELECT)
+      .order("finished_good_id")
+      .order("effective_from", { ascending: false });
+
+    if (finished_good_id) query = query.eq("finished_good_id", finished_good_id);
+    if (active === "true") query = query.eq("active", true);
+
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load consumption standards", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] consumption-standards GET failed:", err);
+    return error("Failed to load consumption standards", 500);
+  }
+}
+
+// POST /api/ops-control/masters/consumption-standards
+//
+// standard_yield is "bricks produced per 50 kg bag" (PRD §34). Effective-dated
+// so an August production record always evaluates against August's recipe even
+// after the mix changes in September (AC-C06).
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcConsumptionStandardSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_consumption_standards")
+      .insert({
+        ...parsed.data,
+        effective_to: parsed.data.effective_to ?? null,
+        tolerance_pct: parsed.data.tolerance_pct ?? null,
+        created_by: auth.user.id,
+        modified_by: auth.user.id,
+      })
+      .select(SELECT)
+      .single();
+
+    if (dbError) {
+      if (dbError.code === "23P01") {
+        return error(
+          "This period overlaps an existing standard for the same product and material. Close the current period first.",
+          409,
+        );
+      }
+      return error(`Failed to create standard: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_consumption_standards",
+      entity_id: (data as { id: string }).id,
+      action: "created",
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] consumption-standards POST failed:", err);
+    return error("Failed to create consumption standard", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/deviation-reasons/route.ts
+++ b/apps/web/app/api/ops-control/masters/deviation-reasons/route.ts
@@ -1,0 +1,68 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcDeviationReasonSchema } from "@maiyuri/shared";
+
+// GET /api/ops-control/masters/deviation-reasons?scope=production|delivery
+// Scoped so the production and delivery pickers never show each other's
+// reasons (PRD §29, §55).
+export async function GET(request: NextRequest) {
+  try {
+    const { scope, active } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("oc_deviation_reasons")
+      .select("*")
+      .order("scope")
+      .order("sort_order");
+
+    if (scope) query = query.eq("scope", scope);
+    if (active !== "false") query = query.eq("active", true);
+
+    const { data, error: dbError } = await query;
+    if (dbError) return error("Failed to load deviation reasons", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] deviation-reasons GET failed:", err);
+    return error("Failed to load deviation reasons", 500);
+  }
+}
+
+// POST /api/ops-control/masters/deviation-reasons
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcDeviationReasonSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_deviation_reasons")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+
+    if (dbError) {
+      if (dbError.code === "23505") {
+        return error("That reason code already exists for this scope", 409);
+      }
+      return error(`Failed to create reason: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_deviation_reasons",
+      entity_id: (data as { id: string }).id,
+      action: "created",
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] deviation-reasons POST failed:", err);
+    return error("Failed to create deviation reason", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/product-mapping/route.ts
+++ b/apps/web/app/api/ops-control/masters/product-mapping/route.ts
@@ -1,0 +1,97 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcProductMappingSchema } from "@maiyuri/shared";
+
+// GET /api/ops-control/masters/product-mapping
+//
+// Returns the mappings alongside the finished goods available to map to.
+// Phase 2 adds the unmapped-demand list from oc_sales_order_lines; this route
+// is the mapping half of that screen and is deliberately kept pure:
+// odoo_product_id -> finished_good_id, nothing else. Line classification
+// (product/service/note/unmapped) is a separate responsibility that reads
+// Odoo's own display_type and product type during the sales-order sync.
+export async function GET() {
+  try {
+    const [mappings, goods] = await Promise.all([
+      supabaseAdmin
+        .from("oc_product_mapping")
+        .select("*, finished_goods(id, name)")
+        .order("odoo_product_id"),
+      supabaseAdmin
+        .from("finished_goods")
+        .select("id, name, odoo_product_id")
+        .eq("is_active", true)
+        .order("name"),
+    ]);
+
+    if (mappings.error) return error("Failed to load product mappings", 500);
+    if (goods.error) return error("Failed to load finished goods", 500);
+
+    return success({
+      mappings: mappings.data ?? [],
+      finished_goods: goods.data ?? [],
+    });
+  } catch (err) {
+    console.error("[OpsControl] product-mapping GET failed:", err);
+    return error("Failed to load product mappings", 500);
+  }
+}
+
+// POST /api/ops-control/masters/product-mapping
+//
+// Mapping an Odoo product makes its open demand visible to planning. This
+// matters concretely: brick SKUs with real open orders currently carry no
+// product link and are therefore invisible in the plan.
+//
+// Upsert on odoo_product_id — re-pointing a product at a different finished
+// good is a correction, not a duplicate, and is audited with the before value.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcProductMappingSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data: before } = await supabaseAdmin
+      .from("oc_product_mapping")
+      .select("*")
+      .eq("odoo_product_id", parsed.data.odoo_product_id)
+      .maybeSingle();
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_product_mapping")
+      .upsert(
+        {
+          ...parsed.data,
+          mapped_by: auth.user.id,
+          mapped_at: new Date().toISOString(),
+        },
+        { onConflict: "odoo_product_id" },
+      )
+      .select("*, finished_goods(id, name)")
+      .single();
+
+    if (dbError) {
+      return error(`Failed to save product mapping: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_product_mapping",
+      entity_id: (data as { id: string }).id,
+      action: before ? "updated" : "created",
+      before_value: before ?? null,
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] product-mapping POST failed:", err);
+    return error("Failed to save product mapping", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/settings/route.ts
+++ b/apps/web/app/api/ops-control/masters/settings/route.ts
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { getOcSettings } from "@/lib/ops-control/settings";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { updateOcSettingsSchema } from "@maiyuri/shared";
+
+// GET /api/ops-control/masters/settings — the operational thresholds every
+// calculation reads. Any authenticated user may read them; they drive UI
+// banding as well as server-side rules.
+export async function GET() {
+  try {
+    return success(await getOcSettings());
+  } catch (err) {
+    console.error("[OpsControl] settings GET failed:", err);
+    return error("Failed to load operational settings", 500);
+  }
+}
+
+// PATCH /api/ops-control/masters/settings
+// Changing a threshold changes how every warning bands, so this is restricted
+// to founder/owner and audited with the before/after values (PRD §74).
+export async function PATCH(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, updateOcSettingsSchema);
+    if (parsed.error) return parsed.error;
+
+    const before = await getOcSettings();
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_settings")
+      .update({ ...parsed.data, updated_by: auth.user.id })
+      .eq("id", 1)
+      .select("*")
+      .single();
+
+    if (dbError) {
+      // The CHECK constraints (yellow <= green, amber <= red) surface here.
+      return error(`Failed to update settings: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_settings",
+      entity_id: "1",
+      action: "updated",
+      before_value: before,
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(await getOcSettings());
+  } catch (err) {
+    console.error("[OpsControl] settings PATCH failed:", err);
+    return error("Failed to update operational settings", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/vehicle-capacities/route.ts
+++ b/apps/web/app/api/ops-control/masters/vehicle-capacities/route.ts
@@ -1,0 +1,80 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody, parseQuery } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcVehicleCapacitySchema } from "@maiyuri/shared";
+
+const SELECT = "*, oc_vehicles(id, vehicle_type), finished_goods(id, name)";
+
+// GET /api/ops-control/masters/vehicle-capacities?vehicle_id&active
+export async function GET(request: NextRequest) {
+  try {
+    const { vehicle_id, active } = parseQuery(request);
+    let query = supabaseAdmin
+      .from("oc_vehicle_capacities")
+      .select(SELECT)
+      .order("vehicle_id")
+      .order("effective_from", { ascending: false });
+
+    if (vehicle_id) query = query.eq("vehicle_id", vehicle_id);
+    if (active === "true") query = query.eq("active", true);
+
+    const { data, error: dbError } = await query.limit(500);
+    if (dbError) return error("Failed to load vehicle capacities", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] vehicle-capacities GET failed:", err);
+    return error("Failed to load vehicle capacities", 500);
+  }
+}
+
+// POST /api/ops-control/masters/vehicle-capacities
+//
+// full_load_qty is the maximum NORMAL load, not a legal maximum: a trip that
+// exceeds it shows a red warning and still saves (PRD §45, AC-T07). Capacity
+// is effective-dated so historical utilisation stays reproducible.
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcVehicleCapacitySchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_vehicle_capacities")
+      .insert({
+        ...parsed.data,
+        effective_to: parsed.data.effective_to ?? null,
+        created_by: auth.user.id,
+        modified_by: auth.user.id,
+      })
+      .select(SELECT)
+      .single();
+
+    if (dbError) {
+      if (dbError.code === "23P01") {
+        return error(
+          "This period overlaps an existing capacity for the same vehicle and product. Close the current period first.",
+          409,
+        );
+      }
+      return error(`Failed to create capacity: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_vehicle_capacities",
+      entity_id: (data as { id: string }).id,
+      action: "created",
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] vehicle-capacities POST failed:", err);
+    return error("Failed to create vehicle capacity", 500);
+  }
+}

--- a/apps/web/app/api/ops-control/masters/vehicles/route.ts
+++ b/apps/web/app/api/ops-control/masters/vehicles/route.ts
@@ -1,0 +1,61 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireProductionRole, PRODUCTION_DELETE_ROLES } from "@/lib/production-auth";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { logOcAudit } from "@/lib/ops-control/audit";
+import { createOcVehicleSchema } from "@maiyuri/shared";
+
+// GET /api/ops-control/masters/vehicles
+export async function GET() {
+  try {
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_vehicles")
+      .select("*")
+      .order("vehicle_type");
+    if (dbError) return error("Failed to load vehicles", 500);
+    return success(data ?? []);
+  } catch (err) {
+    console.error("[OpsControl] vehicles GET failed:", err);
+    return error("Failed to load vehicles", 500);
+  }
+}
+
+// POST /api/ops-control/masters/vehicles
+// V1 runs one standard vehicle; the master exists so adding a second is
+// configuration rather than a migration (PRD §41).
+export async function POST(request: NextRequest) {
+  const auth = await requireProductionRole(request, PRODUCTION_DELETE_ROLES);
+  if (auth.errorResponse) return auth.errorResponse;
+  try {
+    const parsed = await parseBody(request, createOcVehicleSchema);
+    if (parsed.error) return parsed.error;
+
+    const { data, error: dbError } = await supabaseAdmin
+      .from("oc_vehicles")
+      .insert(parsed.data)
+      .select("*")
+      .single();
+
+    if (dbError) {
+      if (dbError.code === "23505") {
+        return error("A vehicle with that type already exists", 409);
+      }
+      return error(`Failed to create vehicle: ${dbError.message}`, 400);
+    }
+
+    await logOcAudit({
+      entity: "oc_vehicles",
+      entity_id: (data as { id: string }).id,
+      action: "created",
+      after_value: parsed.data,
+      performed_by: auth.user.id,
+    });
+
+    return success(data);
+  } catch (err) {
+    console.error("[OpsControl] vehicles POST failed:", err);
+    return error("Failed to create vehicle", 500);
+  }
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -22,6 +22,7 @@ const protectedRoutes = [
   "/leads",
   "/quotes",
   "/planning",
+  "/ops", // Operations Control — startsWith, so this covers every /ops/* page
   "/projects",
   "/expenses",
   "/rate-card",

--- a/apps/web/src/lib/ops-control/audit.ts
+++ b/apps/web/src/lib/ops-control/audit.ts
@@ -1,0 +1,67 @@
+/**
+ * Operations Control — append-only audit trail (PRD §74).
+ *
+ * Modelled on logWorkEvent() in my-work-service.ts: best-effort, never blocks
+ * the operation it records. An audit write failing must not roll back a
+ * production entry the factory has already made physically.
+ *
+ * PRD §74 requires auditing at minimum: rate changes, consumption-standard
+ * changes, vehicle-capacity changes, stock allocation and reallocation,
+ * production allocation and reallocation, delivery schedule revisions,
+ * customer confirmation, actual production and delivery edits, trip overrides,
+ * labour approval and labour-period reopening.
+ */
+
+import { supabaseAdmin } from "@/lib/supabase-admin";
+
+/** Entities audited by this module. Kept as a union so a typo in a route
+ *  becomes a compile error rather than an unsearchable audit row. */
+export type OcAuditEntity =
+  | "oc_settings"
+  | "oc_activity_rates"
+  | "oc_activity_types"
+  | "oc_consumption_standards"
+  | "oc_vehicles"
+  | "oc_vehicle_capacities"
+  | "oc_deviation_reasons"
+  | "oc_product_mapping"
+  | "oc_product_classification_overrides";
+
+export type OcAuditAction =
+  | "created"
+  | "updated"
+  | "deactivated"
+  | "deleted"
+  | "superseded";
+
+export interface OcAuditEntry {
+  entity: OcAuditEntity;
+  /** TEXT rather than uuid: the settings singleton's key is not a uuid. */
+  entity_id: string | null;
+  action: OcAuditAction;
+  before_value?: unknown;
+  after_value?: unknown;
+  reason?: string | null;
+  performed_by?: string | null;
+}
+
+/**
+ * Record an audit event. Failures are logged and swallowed.
+ */
+export async function logOcAudit(entry: OcAuditEntry): Promise<void> {
+  const { error } = await supabaseAdmin.from("oc_audit_events").insert({
+    entity: entry.entity,
+    entity_id: entry.entity_id,
+    action: entry.action,
+    before_value: entry.before_value ?? null,
+    after_value: entry.after_value ?? null,
+    reason: entry.reason ?? null,
+    performed_by: entry.performed_by ?? null,
+  });
+  if (error) {
+    console.error(
+      `[OpsControl] Failed to log audit event ${entry.entity}.${entry.action}:`,
+      error,
+    );
+  }
+}

--- a/apps/web/src/lib/ops-control/rates.test.ts
+++ b/apps/web/src/lib/ops-control/rates.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import {
+  isEffectiveOn,
+  resolveEffective,
+  resolveRate,
+  resolveConsumptionStandard,
+  resolveVehicleCapacity,
+  calculateLabourAmount,
+  type ActivityRate,
+  type ConsumptionStandard,
+  type VehicleCapacity,
+} from "./rates";
+
+const FG_8 = "11111111-1111-1111-1111-111111111111";
+const FG_6 = "22222222-2222-2222-2222-222222222222";
+const VEHICLE = "33333333-3333-3333-3333-333333333333";
+
+function rate(over: Partial<ActivityRate> & { id: string }): ActivityRate {
+  return {
+    finished_good_id: FG_8,
+    activity_code: "production",
+    rate: 7,
+    uom: "per_brick",
+    effective_from: "2026-01-01",
+    effective_to: null,
+    active: true,
+    ...over,
+  };
+}
+
+describe("isEffectiveOn", () => {
+  const row = rate({ id: "r1", effective_from: "2026-01-01", effective_to: "2026-08-31" });
+
+  it("includes both ends of the period", () => {
+    expect(isEffectiveOn(row, "2026-01-01")).toBe(true);
+    expect(isEffectiveOn(row, "2026-08-31")).toBe(true);
+  });
+
+  it("excludes dates outside the period", () => {
+    expect(isEffectiveOn(row, "2025-12-31")).toBe(false);
+    expect(isEffectiveOn(row, "2026-09-01")).toBe(false);
+  });
+
+  it("treats a null effective_to as still in force", () => {
+    const open = rate({ id: "r2", effective_from: "2026-09-01", effective_to: null });
+    expect(isEffectiveOn(open, "2030-01-01")).toBe(true);
+  });
+
+  it("ignores inactive rows so a superseded rate never applies", () => {
+    expect(isEffectiveOn({ ...row, active: false }, "2026-05-01")).toBe(false);
+  });
+});
+
+describe("resolveRate — PRD §60 effective dating", () => {
+  // The PRD's worked example: Rs.7 until 31 Aug, Rs.7.50 from 1 Sep.
+  const rates = [
+    rate({ id: "aug", rate: 7, effective_from: "2026-01-01", effective_to: "2026-08-31" }),
+    rate({ id: "sep", rate: 7.5, effective_from: "2026-09-01", effective_to: null }),
+  ];
+
+  it("an August record still uses Rs.7 after the September rate exists", () => {
+    expect(resolveRate(rates, FG_8, "production", "2026-08-15")?.rate).toBe(7);
+  });
+
+  it("resolves the boundary day 31 Aug to the old rate", () => {
+    expect(resolveRate(rates, FG_8, "production", "2026-08-31")?.rate).toBe(7);
+  });
+
+  it("resolves 1 Sep to the new rate", () => {
+    expect(resolveRate(rates, FG_8, "production", "2026-09-01")?.rate).toBe(7.5);
+  });
+
+  it("returns the snapshot needed to reproduce the calculation", () => {
+    expect(resolveRate(rates, FG_8, "production", "2026-08-15")).toEqual({
+      rate: 7,
+      rate_id: "aug",
+      rate_effective_from: "2026-01-01",
+      uom: "per_brick",
+    });
+  });
+
+  it("does not leak another product's rate", () => {
+    expect(resolveRate(rates, FG_6, "production", "2026-08-15")).toBeNull();
+  });
+
+  it("does not leak another activity's rate", () => {
+    expect(resolveRate(rates, FG_8, "loading", "2026-08-15")).toBeNull();
+  });
+
+  it("returns null when nothing is configured rather than defaulting to zero", () => {
+    // A silent zero would understate wages owed, so the caller must handle null.
+    expect(resolveRate([], FG_8, "production", "2026-08-15")).toBeNull();
+    expect(resolveRate(rates, FG_8, "production", "2025-06-01")).toBeNull();
+  });
+
+  it("prefers the later start if periods ever overlap", () => {
+    // The DB prevents this; the tie-break is defensive.
+    const overlapping = [
+      rate({ id: "old", rate: 7, effective_from: "2026-01-01", effective_to: "2026-12-31" }),
+      rate({ id: "new", rate: 9, effective_from: "2026-06-01", effective_to: "2026-12-31" }),
+    ];
+    expect(resolveRate(overlapping, FG_8, "production", "2026-08-15")?.rate).toBe(9);
+  });
+});
+
+describe("resolveEffective", () => {
+  it("returns null when no row matches", () => {
+    expect(resolveEffective([], "2026-08-15")).toBeNull();
+  });
+});
+
+describe("resolveConsumptionStandard", () => {
+  const standards: ConsumptionStandard[] = [
+    {
+      id: "s1",
+      finished_good_id: FG_8,
+      material: "cement",
+      standard_yield: 140,
+      tolerance_pct: 5,
+      effective_from: "2026-08-01",
+      effective_to: "2026-08-31",
+      active: true,
+    },
+    {
+      id: "s2",
+      finished_good_id: FG_8,
+      material: "cement",
+      standard_yield: 145,
+      tolerance_pct: 5,
+      effective_from: "2026-09-01",
+      effective_to: null,
+      active: true,
+    },
+  ];
+
+  it("an August production record evaluates against August's recipe", () => {
+    expect(
+      resolveConsumptionStandard(standards, FG_8, "cement", "2026-08-20")?.standard_yield,
+    ).toBe(140);
+  });
+
+  it("September uses the new recipe", () => {
+    expect(
+      resolveConsumptionStandard(standards, FG_8, "cement", "2026-09-20")?.standard_yield,
+    ).toBe(145);
+  });
+
+  it("does not match a different material", () => {
+    expect(resolveConsumptionStandard(standards, FG_8, "sand", "2026-08-20")).toBeNull();
+  });
+});
+
+describe("resolveVehicleCapacity", () => {
+  const capacities: VehicleCapacity[] = [
+    {
+      id: "c8",
+      vehicle_id: VEHICLE,
+      finished_good_id: FG_8,
+      full_load_qty: 900,
+      effective_from: "2026-01-01",
+      effective_to: null,
+      active: true,
+    },
+    {
+      id: "c6",
+      vehicle_id: VEHICLE,
+      finished_good_id: FG_6,
+      full_load_qty: 1000,
+      effective_from: "2026-01-01",
+      effective_to: null,
+      active: true,
+    },
+  ];
+
+  // PRD AC-T04 / AC-T05
+  it('resolves 8" capacity to 900', () => {
+    expect(resolveVehicleCapacity(capacities, VEHICLE, FG_8, "2026-08-22")?.full_load_qty).toBe(900);
+  });
+
+  it('resolves 6" capacity to 1000', () => {
+    expect(resolveVehicleCapacity(capacities, VEHICLE, FG_6, "2026-08-22")?.full_load_qty).toBe(1000);
+  });
+
+  it("returns null for an unconfigured product, rather than guessing", () => {
+    // Solid Blocks are deliberately unseeded — loading them must prompt config.
+    expect(resolveVehicleCapacity(capacities, VEHICLE, "unknown-fg", "2026-08-22")).toBeNull();
+  });
+});
+
+describe("calculateLabourAmount", () => {
+  const snapshot = { rate: 7, rate_id: "aug", rate_effective_from: "2026-01-01", uom: "per_brick" };
+
+  it("multiplies eligible quantity by the snapshotted rate", () => {
+    expect(calculateLabourAmount(1200, snapshot)).toBe(8400);
+  });
+
+  it("rounds to paise", () => {
+    expect(calculateLabourAmount(333, { ...snapshot, rate: 7.005 })).toBe(2332.67);
+  });
+
+  it("handles a zero quantity", () => {
+    expect(calculateLabourAmount(0, snapshot)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/ops-control/rates.ts
+++ b/apps/web/src/lib/ops-control/rates.ts
@@ -1,0 +1,155 @@
+/**
+ * Operations Control — effective-dated rate and standard resolution.
+ *
+ * Pure functions only: no database, no clock, no I/O, so every rule here is
+ * directly testable (PRD §98 — critical formulas must not depend on frontend
+ * logic and must be tested independently).
+ *
+ * PRD §60: "August operational records must continue using Rs.7. Historical
+ * calculations must never silently change because the current master was
+ * updated." That is enforced twice — here at resolution time, and again by the
+ * snapshot written onto every labour ledger entry (PRD §61).
+ */
+
+/** The shape any effective-dated master row shares. */
+export interface EffectiveDated {
+  id: string;
+  effective_from: string; // YYYY-MM-DD
+  effective_to: string | null; // null = still in force
+  active: boolean;
+}
+
+export interface ActivityRate extends EffectiveDated {
+  finished_good_id: string;
+  activity_code: string;
+  rate: number;
+  uom: string;
+}
+
+export interface ConsumptionStandard extends EffectiveDated {
+  finished_good_id: string;
+  material: string;
+  standard_yield: number;
+  tolerance_pct: number | null;
+}
+
+export interface VehicleCapacity extends EffectiveDated {
+  vehicle_id: string;
+  finished_good_id: string;
+  full_load_qty: number;
+}
+
+/**
+ * The snapshot stored on a ledger entry so an approved settlement stays
+ * reproducible even after the master changes (PRD §61).
+ */
+export interface RateSnapshot {
+  rate: number;
+  rate_id: string;
+  rate_effective_from: string;
+  uom: string;
+}
+
+/**
+ * Is `onDate` inside this row's effective period?
+ *
+ * Both ends are INCLUSIVE, matching the database EXCLUDE constraint's
+ * `daterange(effective_from, effective_to, '[]')`. A row ending 31 Aug still
+ * applies ON 31 Aug; one starting 1 Sep applies from 1 Sep. The two do not
+ * overlap, which is why both can be active at once.
+ *
+ * Dates are compared as ISO strings, never as Date objects: `new Date(iso)`
+ * parses as UTC midnight, which is the previous day in IST and would silently
+ * shift every boundary by one day.
+ */
+export function isEffectiveOn(row: EffectiveDated, onDate: string): boolean {
+  if (!row.active) return false;
+  if (onDate < row.effective_from) return false;
+  if (row.effective_to !== null && onDate > row.effective_to) return false;
+  return true;
+}
+
+/**
+ * Pick the row in force on a date. The database prevents overlapping active
+ * periods, but this is defensive: if two ever overlap, the one that started
+ * most recently wins, which is the least surprising reading.
+ */
+export function resolveEffective<T extends EffectiveDated>(
+  rows: readonly T[],
+  onDate: string,
+): T | null {
+  let best: T | null = null;
+  for (const row of rows) {
+    if (!isEffectiveOn(row, onDate)) continue;
+    if (best === null || row.effective_from > best.effective_from) best = row;
+  }
+  return best;
+}
+
+/**
+ * Resolve the labour rate for a product + activity on a date.
+ * Returns null when no rate is configured — the caller must surface that
+ * rather than defaulting, because a silent zero would understate wages owed.
+ */
+export function resolveRate(
+  rates: readonly ActivityRate[],
+  finishedGoodId: string,
+  activityCode: string,
+  onDate: string,
+): RateSnapshot | null {
+  const candidates = rates.filter(
+    (r) => r.finished_good_id === finishedGoodId && r.activity_code === activityCode,
+  );
+  const match = resolveEffective(candidates, onDate);
+  if (!match) return null;
+  return {
+    rate: match.rate,
+    rate_id: match.id,
+    rate_effective_from: match.effective_from,
+    uom: match.uom,
+  };
+}
+
+/** Resolve the cement standard for a product + material on a date. */
+export function resolveConsumptionStandard(
+  standards: readonly ConsumptionStandard[],
+  finishedGoodId: string,
+  material: string,
+  onDate: string,
+): ConsumptionStandard | null {
+  return resolveEffective(
+    standards.filter(
+      (s) => s.finished_good_id === finishedGoodId && s.material === material,
+    ),
+    onDate,
+  );
+}
+
+/** Resolve a vehicle's full-load capacity for a product on a date. */
+export function resolveVehicleCapacity(
+  capacities: readonly VehicleCapacity[],
+  vehicleId: string,
+  finishedGoodId: string,
+  onDate: string,
+): VehicleCapacity | null {
+  return resolveEffective(
+    capacities.filter(
+      (c) => c.vehicle_id === vehicleId && c.finished_good_id === finishedGoodId,
+    ),
+    onDate,
+  );
+}
+
+/**
+ * Labour amount for one activity line (PRD §62):
+ *   eligible actual quantity x applicable product activity rate.
+ *
+ * Rounded to paise. Returns the snapshot alongside so the caller can persist
+ * both together — an amount without its rate is not reproducible.
+ */
+export function calculateLabourAmount(
+  eligibleQty: number,
+  snapshot: RateSnapshot,
+): number {
+  return Math.round(eligibleQty * snapshot.rate * 100) / 100;
+}

--- a/apps/web/src/lib/ops-control/settings.test.ts
+++ b/apps/web/src/lib/ops-control/settings.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isValidBagQuantity, OC_SETTINGS_FALLBACK } from "./settings";
+
+describe("isValidBagQuantity — PRD §32 / AC-C01", () => {
+  it("accepts the PRD's worked examples at a 0.5 step", () => {
+    // "Valid examples: 3, 3.5, 4, 4.5"
+    for (const bags of [3, 3.5, 4, 4.5]) {
+      expect(isValidBagQuantity(bags, 0.5)).toBe(true);
+    }
+  });
+
+  it("rejects quantities off the step", () => {
+    expect(isValidBagQuantity(4.3, 0.5)).toBe(false);
+    expect(isValidBagQuantity(0.25, 0.5)).toBe(false);
+  });
+
+  it("accepts zero", () => {
+    expect(isValidBagQuantity(0, 0.5)).toBe(true);
+  });
+
+  it("rejects negatives — that is a data-integrity failure (PRD §88)", () => {
+    expect(isValidBagQuantity(-0.5, 0.5)).toBe(false);
+  });
+
+  it("honours a reconfigured step rather than assuming 0.5", () => {
+    expect(isValidBagQuantity(4.25, 0.25)).toBe(true);
+    expect(isValidBagQuantity(4.25, 0.5)).toBe(false);
+    expect(isValidBagQuantity(4, 1)).toBe(true);
+    expect(isValidBagQuantity(4.5, 1)).toBe(false);
+  });
+
+  it("does not trip over floating-point representation", () => {
+    // 4.5 / 0.1 is 44.999... in IEEE754; integer scaling avoids a false reject.
+    expect(isValidBagQuantity(4.5, 0.1)).toBe(true);
+    expect(isValidBagQuantity(0.3, 0.1)).toBe(true);
+  });
+
+  it("rejects a nonsensical step instead of dividing by zero", () => {
+    expect(isValidBagQuantity(4, 0)).toBe(false);
+    expect(isValidBagQuantity(4, -0.5)).toBe(false);
+  });
+
+  it("rejects NaN", () => {
+    expect(isValidBagQuantity(Number.NaN, 0.5)).toBe(false);
+  });
+});
+
+describe("OC_SETTINGS_FALLBACK — PRD §100 seeded defaults", () => {
+  it("matches the PRD's current operating defaults", () => {
+    expect(OC_SETTINGS_FALLBACK.default_shifts_per_day).toBe(2);
+    expect(OC_SETTINGS_FALLBACK.normal_max_trips_per_day).toBe(2);
+    expect(OC_SETTINGS_FALLBACK.cement_bag_kg).toBe(50);
+    expect(OC_SETTINGS_FALLBACK.cement_bag_step).toBe(0.5);
+  });
+
+  it("carries no labour rate or cement ratio — those must be configured", () => {
+    // AC-L02: no Rs.7/Rs.6 anywhere. A fallback rate would defeat the master.
+    const keys = Object.keys(OC_SETTINGS_FALLBACK);
+    expect(keys.some((k) => k.includes("rate"))).toBe(false);
+    expect(keys.some((k) => k.includes("yield"))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ops-control/settings.ts
+++ b/apps/web/src/lib/ops-control/settings.ts
@@ -1,0 +1,88 @@
+/**
+ * Operations Control — operational settings accessor.
+ *
+ * Every threshold the PRD calls "configurable" lives in the oc_settings
+ * singleton (PRD §81, §100). Nothing in this module may hard-code an
+ * operational value; callers read from here instead.
+ */
+
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import type { OcSettings } from "@maiyuri/shared";
+
+/**
+ * Column defaults, mirroring the migration. Used ONLY when the singleton row
+ * cannot be read, so a transient database problem degrades to documented
+ * behaviour rather than an exception mid-shift.
+ *
+ * These are the PRD §100 seeded operating defaults — NOT business values.
+ * Labour rates and cement ratios deliberately have no fallback anywhere: they
+ * must come from configuration, and their absence is surfaced, never guessed.
+ */
+export const OC_SETTINGS_FALLBACK: OcSettings = {
+  default_shifts_per_day: 2,
+  normal_max_trips_per_day: 2,
+  load_green_min_pct: 95,
+  load_yellow_min_pct: 80,
+  load_red_above_pct: 100,
+  cement_bag_kg: 50,
+  cement_bag_step: 0.5,
+  ratio_amber_tolerance_pct: 5,
+  ratio_red_tolerance_pct: 10,
+  production_wage_basis: "accepted",
+  output_per_person_basis: "accepted",
+};
+
+/** Numeric columns arrive from PostgREST as strings; coerce them once here. */
+function coerce(row: Record<string, unknown>): OcSettings {
+  const num = (key: keyof OcSettings, fallback: number) => {
+    const value = Number(row[key]);
+    return Number.isFinite(value) ? value : fallback;
+  };
+  return {
+    default_shifts_per_day:
+      num("default_shifts_per_day", 2) === 1 ? 1 : 2,
+    normal_max_trips_per_day: num("normal_max_trips_per_day", 2),
+    load_green_min_pct: num("load_green_min_pct", 95),
+    load_yellow_min_pct: num("load_yellow_min_pct", 80),
+    load_red_above_pct: num("load_red_above_pct", 100),
+    cement_bag_kg: num("cement_bag_kg", 50),
+    cement_bag_step: num("cement_bag_step", 0.5),
+    ratio_amber_tolerance_pct: num("ratio_amber_tolerance_pct", 5),
+    ratio_red_tolerance_pct: num("ratio_red_tolerance_pct", 10),
+    production_wage_basis:
+      row.production_wage_basis === "gross" ? "gross" : "accepted",
+    output_per_person_basis:
+      row.output_per_person_basis === "gross" ? "gross" : "accepted",
+  };
+}
+
+export async function getOcSettings(): Promise<OcSettings> {
+  const { data, error } = await supabaseAdmin
+    .from("oc_settings")
+    .select("*")
+    .eq("id", 1)
+    .maybeSingle();
+
+  if (error || !data) {
+    if (error) console.error("[OpsControl] Failed to load settings:", error);
+    return OC_SETTINGS_FALLBACK;
+  }
+  return coerce(data as Record<string, unknown>);
+}
+
+/**
+ * Is a cement bag quantity a legal multiple of the configured step?
+ * PRD §32: 3, 3.5, 4, 4.5 are valid at a 0.5 step. The step is configurable,
+ * so this is checked in the API rather than by a database CHECK.
+ *
+ * Uses integer arithmetic — 0.1 + 0.2 style float error would reject valid
+ * entries such as 4.5 at a 0.1 step.
+ */
+export function isValidBagQuantity(bags: number, step: number): boolean {
+  if (!Number.isFinite(bags) || bags < 0) return false;
+  if (!Number.isFinite(step) || step <= 0) return false;
+  const scale = 1000;
+  const scaledBags = Math.round(bags * scale);
+  const scaledStep = Math.round(step * scale);
+  return scaledBags % scaledStep === 0;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from "./schemas";
 export * from "./utils";
 export * from "./taxonomy";
 export * from "./work";
+export * from "./ops-control";

--- a/packages/shared/src/ops-control.ts
+++ b/packages/shared/src/ops-control.ts
@@ -1,0 +1,237 @@
+/**
+ * Operations Control (oc_) — Phase 1 shared types + zod schemas.
+ *
+ * Data model: supabase/migrations/20260822090000_ops_control_masters.sql
+ * PRD: "Production, Fulfilment & Dispatch Control" v1.0
+ *
+ * The same schemas validate both the API body and the React Hook Form, so a
+ * rule is expressed once. Business VALUES (rates, cement ratios, capacities)
+ * never appear here — PRD §100 requires them to come from configuration.
+ */
+
+import { z } from "zod";
+
+// ============================================
+// Enums
+// ============================================
+
+/** Where a labour activity reads its eligible quantity from (PRD §62). */
+export const ocQuantitySourceSchema = z.enum([
+  "production_actual",
+  "trip_load",
+  "delivery_stop",
+]);
+export type OcQuantitySource = z.infer<typeof ocQuantitySourceSchema>;
+
+/** Basis for a quantity used in a calculation. The cement ratio is ALWAYS
+ *  gross (PRD §35); the labour wage basis is configurable (PRD §63). They are
+ *  deliberately not the same setting. */
+export const ocQuantityBasisSchema = z.enum(["gross", "accepted"]);
+export type OcQuantityBasis = z.infer<typeof ocQuantityBasisSchema>;
+
+/** Deviation reason masters are scoped so production and delivery pickers
+ *  stay separate (PRD §29, §55). */
+export const ocDeviationScopeSchema = z.enum(["production", "delivery"]);
+export type OcDeviationScope = z.infer<typeof ocDeviationScopeSchema>;
+
+/** Classification of an Odoo sales-order line. Only `product` is demand:
+ *  service lines such as Loading carry brick-sized quantities that would
+ *  otherwise corrupt the plan. */
+export const ocLineKindSchema = z.enum([
+  "product",
+  "service",
+  "note",
+  "unmapped",
+]);
+export type OcLineKind = z.infer<typeof ocLineKindSchema>;
+
+/** Severity model for the warning framework (PRD §72). Warnings warn; only
+ *  data-integrity failures block. */
+export const ocSeveritySchema = z.enum([
+  "info",
+  "green",
+  "yellow",
+  "orange",
+  "red",
+]);
+export type OcSeverity = z.infer<typeof ocSeveritySchema>;
+
+// ============================================
+// Shared field helpers
+// ============================================
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected a YYYY-MM-DD date");
+
+/** An effective period. Open-ended (`effective_to: null`) means "still in
+ *  force". Periods are INCLUSIVE at both ends, so a rate ending 31 Aug and one
+ *  starting 1 Sep do not overlap — matching the database EXCLUDE constraint. */
+const effectivePeriod = {
+  effective_from: isoDate,
+  effective_to: isoDate.nullable().optional(),
+};
+
+const effectivePeriodOrdered = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.refine(
+    (v: unknown) => {
+      const { effective_from, effective_to } = v as {
+        effective_from: string;
+        effective_to?: string | null;
+      };
+      return !effective_to || effective_to >= effective_from;
+    },
+    { message: "effective_to must not be before effective_from", path: ["effective_to"] },
+  );
+
+// ============================================
+// Settings (PRD §81 "Operational Settings")
+// ============================================
+
+export const ocSettingsSchema = z.object({
+  default_shifts_per_day: z.union([z.literal(1), z.literal(2)]),
+  normal_max_trips_per_day: z.number().int().positive(),
+  load_green_min_pct: z.number().min(0),
+  load_yellow_min_pct: z.number().min(0),
+  load_red_above_pct: z.number().min(0),
+  cement_bag_kg: z.number().positive(),
+  cement_bag_step: z.number().positive(),
+  ratio_amber_tolerance_pct: z.number().min(0),
+  ratio_red_tolerance_pct: z.number().min(0),
+  production_wage_basis: ocQuantityBasisSchema,
+  output_per_person_basis: ocQuantityBasisSchema,
+});
+export type OcSettings = z.infer<typeof ocSettingsSchema>;
+
+export const updateOcSettingsSchema = ocSettingsSchema
+  .partial()
+  .refine((v) => Object.keys(v).length > 0, "No settings supplied")
+  .refine(
+    (v) =>
+      v.load_yellow_min_pct === undefined ||
+      v.load_green_min_pct === undefined ||
+      v.load_yellow_min_pct <= v.load_green_min_pct,
+    { message: "Yellow threshold must be at or below green", path: ["load_yellow_min_pct"] },
+  )
+  .refine(
+    (v) =>
+      v.ratio_amber_tolerance_pct === undefined ||
+      v.ratio_red_tolerance_pct === undefined ||
+      v.ratio_amber_tolerance_pct <= v.ratio_red_tolerance_pct,
+    { message: "Amber tolerance must be at or below red", path: ["ratio_amber_tolerance_pct"] },
+  );
+export type UpdateOcSettingsInput = z.infer<typeof updateOcSettingsSchema>;
+
+// ============================================
+// Activity rates (PRD §56-61)
+// ============================================
+
+export const createOcActivityRateSchema = effectivePeriodOrdered(
+  z.object({
+    finished_good_id: z.string().uuid(),
+    activity_code: z.string().min(1),
+    rate: z.number().min(0, "Rate cannot be negative"),
+    uom: z.string().default("per_brick"),
+    notes: z.string().nullable().optional(),
+    ...effectivePeriod,
+  }),
+);
+export type CreateOcActivityRateInput = z.infer<typeof createOcActivityRateSchema>;
+
+export const updateOcActivityRateSchema = z.object({
+  rate: z.number().min(0).optional(),
+  effective_to: isoDate.nullable().optional(),
+  active: z.boolean().optional(),
+  notes: z.string().nullable().optional(),
+});
+export type UpdateOcActivityRateInput = z.infer<typeof updateOcActivityRateSchema>;
+
+// ============================================
+// Consumption standards (PRD §34-37)
+// ============================================
+
+export const createOcConsumptionStandardSchema = effectivePeriodOrdered(
+  z.object({
+    finished_good_id: z.string().uuid(),
+    material: z.string().default("cement"),
+    /** Bricks produced per one 50 kg bag. */
+    standard_yield: z.number().positive("Standard yield must be greater than zero"),
+    uom: z.string().default("50kg_bag"),
+    /** Per-product override; null falls back to the global tolerance. */
+    tolerance_pct: z.number().min(0).nullable().optional(),
+    notes: z.string().nullable().optional(),
+    ...effectivePeriod,
+  }),
+);
+export type CreateOcConsumptionStandardInput = z.infer<
+  typeof createOcConsumptionStandardSchema
+>;
+
+// ============================================
+// Vehicles and capacities (PRD §41-42)
+// ============================================
+
+export const createOcVehicleSchema = z.object({
+  vehicle_type: z.string().min(1),
+  description: z.string().nullable().optional(),
+  registration: z.string().nullable().optional(),
+});
+export type CreateOcVehicleInput = z.infer<typeof createOcVehicleSchema>;
+
+export const createOcVehicleCapacitySchema = effectivePeriodOrdered(
+  z.object({
+    vehicle_id: z.string().uuid(),
+    finished_good_id: z.string().uuid(),
+    /** Maximum NORMAL full load. Exceeding it warns; it never blocks (PRD §45). */
+    full_load_qty: z.number().int().positive(),
+    notes: z.string().nullable().optional(),
+    ...effectivePeriod,
+  }),
+);
+export type CreateOcVehicleCapacityInput = z.infer<
+  typeof createOcVehicleCapacitySchema
+>;
+
+// ============================================
+// Deviation reasons (PRD §29, §55)
+// ============================================
+
+export const createOcDeviationReasonSchema = z.object({
+  scope: ocDeviationScopeSchema,
+  code: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9_]+$/, "Use lower-case letters, digits and underscores"),
+  label: z.string().min(1),
+  sort_order: z.number().int().default(0),
+});
+export type CreateOcDeviationReasonInput = z.infer<
+  typeof createOcDeviationReasonSchema
+>;
+
+// ============================================
+// Product mapping (Odoo product -> finished good)
+// ============================================
+
+/** Mapping is PURELY odoo_product_id -> finished_good_id. Line classification
+ *  is a separate responsibility that reads Odoo's own display_type and product
+ *  type during the sales-order sync. */
+export const createOcProductMappingSchema = z.object({
+  odoo_product_id: z.number().int().positive(),
+  odoo_product_name: z.string().nullable().optional(),
+  finished_good_id: z.string().uuid(),
+  notes: z.string().nullable().optional(),
+});
+export type CreateOcProductMappingInput = z.infer<
+  typeof createOcProductMappingSchema
+>;
+
+export const createOcClassificationOverrideSchema = z.object({
+  odoo_product_id: z.number().int().positive(),
+  odoo_product_name: z.string().nullable().optional(),
+  line_kind: ocLineKindSchema,
+  reason: z.string().nullable().optional(),
+});
+export type CreateOcClassificationOverrideInput = z.infer<
+  typeof createOcClassificationOverrideSchema
+>;

--- a/supabase/migrations/20260822090000_ops_control_masters.sql
+++ b/supabase/migrations/20260822090000_ops_control_masters.sql
@@ -1,0 +1,366 @@
+-- ============================================================================
+-- Operations Control (oc_) — Phase 1: masters, configuration and audit
+--
+-- The `oc_` prefix is "operations control". It deliberately sits ALONGSIDE the
+-- existing factory_* ledger and the ops_plan* AI planner; neither is modified.
+-- Each module gets a dated production cutover, after which the corresponding
+-- factory_* entry screen becomes read-only (see the implementation roadmap).
+--
+-- Guiding principle: Odoo remains the ERP and the authoritative physical
+-- inventory. These tables hold operational configuration only.
+--
+-- PRD: "Production, Fulfilment & Dispatch Control" v1.0.
+--   §56-61  activity rate master, effective dating, rate snapshot
+--   §34-37  consumption standards + tolerance banding
+--   §41-46  vehicle + capacity master, utilisation thresholds
+--   §29,§55 configurable deviation reasons
+--   §81     master configuration screens
+--   §100    seeded operating defaults
+--
+-- NOTHING that the business may change is a CHECK enum — it is a seeded master
+-- row. Workflow statuses and structural discriminators stay as CHECKs.
+--
+-- NO rate values and NO cement ratios are seeded: PRD §100 requires both to be
+-- supplied by the business through configuration. The PRD's illustrative
+-- Rs.7 / Rs.6 / 140-per-bag figures must never reach the database.
+--
+-- Conventions follow 20260714120000_expenses.sql and 20260808120000_factory_ledger.sql:
+-- shared set_updated_at() trigger, RLS on with a permissive authenticated-read
+-- policy; ALL writes go through service-role API routes which are the real gate.
+-- ============================================================================
+
+-- Needed for the EXCLUDE constraints that stop overlapping effective periods
+-- (equality on a uuid/text column combined with range overlap).
+CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
+
+-- shared updated_at helper (idempotent — also defined by earlier migrations)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+-- ------------------------------------------------------------- settings -----
+-- Single row (id = 1), mirroring planning_settings. Every operational
+-- threshold the PRD calls "configurable" lives here so no business rule is
+-- ever hard-coded in TypeScript.
+CREATE TABLE IF NOT EXISTS public.oc_settings (
+  id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+
+  -- production (PRD §21, §22)
+  default_shifts_per_day INTEGER NOT NULL DEFAULT 2
+    CHECK (default_shifts_per_day IN (1, 2)),
+
+  -- dispatch (PRD §40, §46)
+  normal_max_trips_per_day INTEGER NOT NULL DEFAULT 2
+    CHECK (normal_max_trips_per_day > 0),
+  load_green_min_pct NUMERIC(5,2) NOT NULL DEFAULT 95,
+  load_yellow_min_pct NUMERIC(5,2) NOT NULL DEFAULT 80,
+  load_red_above_pct NUMERIC(5,2) NOT NULL DEFAULT 100,
+
+  -- cement (PRD §32, §37) — a bag is 50 kg, consumption comes in 0.5 steps
+  cement_bag_kg NUMERIC(6,2) NOT NULL DEFAULT 50 CHECK (cement_bag_kg > 0),
+  cement_bag_step NUMERIC(4,2) NOT NULL DEFAULT 0.5 CHECK (cement_bag_step > 0),
+  ratio_amber_tolerance_pct NUMERIC(5,2) NOT NULL DEFAULT 5,
+  ratio_red_tolerance_pct NUMERIC(5,2) NOT NULL DEFAULT 10,
+
+  -- labour (PRD §63) — wage basis is NOT the same as the cement-ratio basis,
+  -- which is always gross. Kept configurable and deliberately separate.
+  production_wage_basis TEXT NOT NULL DEFAULT 'accepted'
+    CHECK (production_wage_basis IN ('gross', 'accepted')),
+  -- reporting basis for output-per-person-shift (PRD §30)
+  output_per_person_basis TEXT NOT NULL DEFAULT 'accepted'
+    CHECK (output_per_person_basis IN ('gross', 'accepted')),
+
+  updated_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (load_yellow_min_pct <= load_green_min_pct),
+  CHECK (ratio_amber_tolerance_pct <= ratio_red_tolerance_pct)
+);
+INSERT INTO public.oc_settings (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- ------------------------------------------------------- activity types -----
+-- PRD §57: Production / Loading / Unloading initially, "architecture should
+-- allow additional activity types later" — hence a master, not a CHECK enum.
+CREATE TABLE IF NOT EXISTS public.oc_activity_types (
+  code TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  -- where the eligible quantity is read from when the ledger is built
+  quantity_source TEXT NOT NULL
+    CHECK (quantity_source IN ('production_actual', 'trip_load', 'delivery_stop')),
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.oc_activity_types (code, label, quantity_source, sort_order) VALUES
+  ('production', 'Production', 'production_actual', 1),
+  ('loading',    'Loading',    'trip_load',        2),
+  ('unloading',  'Unloading',  'delivery_stop',    3)
+ON CONFLICT (code) DO NOTHING;
+
+-- ------------------------------------------------------- activity rates -----
+-- PRD §58-61. Rates are per product AND per activity, effective-dated, and
+-- snapshotted onto every ledger entry so approved history is reproducible.
+-- NO VALUES SEEDED — PRD §100 and AC-L02.
+CREATE TABLE IF NOT EXISTS public.oc_activity_rates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  finished_good_id UUID NOT NULL REFERENCES public.finished_goods(id) ON DELETE CASCADE,
+  activity_code TEXT NOT NULL REFERENCES public.oc_activity_types(code),
+  rate NUMERIC(10,2) NOT NULL CHECK (rate >= 0),
+  uom TEXT NOT NULL DEFAULT 'per_brick',
+  effective_from DATE NOT NULL,
+  effective_to DATE,                       -- NULL = still in force
+  active BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  modified_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (effective_to IS NULL OR effective_to >= effective_from),
+
+  -- PRD §88: overlapping rate periods are a data-integrity error and BLOCK.
+  -- Inclusive range: a rate ending 31 Aug and one starting 1 Sep do not overlap.
+  EXCLUDE USING gist (
+    finished_good_id WITH =,
+    activity_code WITH =,
+    daterange(effective_from, effective_to, '[]') WITH &&
+  ) WHERE (active)
+);
+CREATE INDEX IF NOT EXISTS idx_oc_activity_rates_lookup
+  ON public.oc_activity_rates (finished_good_id, activity_code, effective_from DESC);
+
+-- ------------------------------------------------ consumption standards -----
+-- PRD §34-36. "Expected number of bricks produced per 50 kg bag", per product,
+-- effective-dated so an August record always evaluates against August's recipe.
+-- NO VALUES SEEDED — PRD §34 "do not hard-code example values".
+CREATE TABLE IF NOT EXISTS public.oc_consumption_standards (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  finished_good_id UUID NOT NULL REFERENCES public.finished_goods(id) ON DELETE CASCADE,
+  material TEXT NOT NULL DEFAULT 'cement',
+  -- bricks produced per one unit of material (one 50 kg bag)
+  standard_yield NUMERIC(10,2) NOT NULL CHECK (standard_yield > 0),
+  uom TEXT NOT NULL DEFAULT '50kg_bag',
+  -- per-product override; NULL falls back to oc_settings tolerances
+  tolerance_pct NUMERIC(5,2) CHECK (tolerance_pct IS NULL OR tolerance_pct >= 0),
+  effective_from DATE NOT NULL,
+  effective_to DATE,
+  active BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  modified_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (effective_to IS NULL OR effective_to >= effective_from),
+
+  EXCLUDE USING gist (
+    finished_good_id WITH =,
+    material WITH =,
+    daterange(effective_from, effective_to, '[]') WITH &&
+  ) WHERE (active)
+);
+CREATE INDEX IF NOT EXISTS idx_oc_consumption_standards_lookup
+  ON public.oc_consumption_standards (finished_good_id, material, effective_from DESC);
+
+-- ------------------------------------------------------------ vehicles -----
+-- PRD §41: V1 has one standard vehicle; the architecture must support more.
+CREATE TABLE IF NOT EXISTS public.oc_vehicles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  vehicle_type TEXT NOT NULL UNIQUE,
+  description TEXT,
+  registration TEXT,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The vehicle the factory ledger already records most trips against.
+INSERT INTO public.oc_vehicles (vehicle_type, description)
+VALUES ('407 Eicher', 'Standard delivery vehicle')
+ON CONFLICT (vehicle_type) DO NOTHING;
+
+-- -------------------------------------------------- vehicle capacities -----
+-- PRD §42: capacity must NOT be hard-coded. Effective-dated like every other
+-- operational standard, so historical utilisation stays reproducible.
+CREATE TABLE IF NOT EXISTS public.oc_vehicle_capacities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  vehicle_id UUID NOT NULL REFERENCES public.oc_vehicles(id) ON DELETE CASCADE,
+  finished_good_id UUID NOT NULL REFERENCES public.finished_goods(id) ON DELETE CASCADE,
+  -- maximum NORMAL full load; exceeding it warns, it never blocks (PRD §45)
+  full_load_qty NUMERIC(10,0) NOT NULL CHECK (full_load_qty > 0),
+  effective_from DATE NOT NULL,
+  effective_to DATE,
+  active BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  modified_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (effective_to IS NULL OR effective_to >= effective_from),
+
+  EXCLUDE USING gist (
+    vehicle_id WITH =,
+    finished_good_id WITH =,
+    daterange(effective_from, effective_to, '[]') WITH &&
+  ) WHERE (active)
+);
+CREATE INDEX IF NOT EXISTS idx_oc_vehicle_capacities_lookup
+  ON public.oc_vehicle_capacities (vehicle_id, finished_good_id, effective_from DESC);
+
+-- Seed the current standard configuration (PRD §100, AC-T04/AC-T05):
+--   6-inch brick = 1,000 per full load, 8-inch brick = 900.
+-- Size is derived from the Odoo product name (…*8*… / …*6*…) rather than
+-- pasting UUIDs, so this stays correct if ids differ per environment.
+-- Products whose size cannot be inferred (e.g. Solid Blocks) get no capacity
+-- and must be configured by the business before they can be loaded.
+INSERT INTO public.oc_vehicle_capacities
+  (vehicle_id, finished_good_id, full_load_qty, effective_from, notes)
+SELECT v.id, fg.id,
+       CASE WHEN fg.name LIKE '%*8*%' THEN 900 ELSE 1000 END,
+       CURRENT_DATE,
+       'Seeded from PRD current standard configuration'
+FROM public.oc_vehicles v
+CROSS JOIN public.finished_goods fg
+WHERE v.vehicle_type = '407 Eicher'
+  AND (fg.name LIKE '%*8*%' OR fg.name LIKE '%*6*%')
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------- deviation reasons -----
+-- PRD §29 and §55: "maintain configurable reason master".
+CREATE TABLE IF NOT EXISTS public.oc_deviation_reasons (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope TEXT NOT NULL CHECK (scope IN ('production', 'delivery')),
+  code TEXT NOT NULL,
+  label TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (scope, code)
+);
+
+INSERT INTO public.oc_deviation_reasons (scope, code, label, sort_order) VALUES
+  ('production', 'machine_breakdown',   'Machine breakdown',           1),
+  ('production', 'electricity_failure', 'Electricity failure',         2),
+  ('production', 'labour_shortage',     'Labour shortage',             3),
+  ('production', 'material_shortage',   'Raw-material shortage',       4),
+  ('production', 'weather',             'Weather / rain',              5),
+  ('production', 'quality_issue',       'Quality issue',               6),
+  ('production', 'production_change',   'Production change',           7),
+  ('production', 'customer_change',     'Customer requirement change', 8),
+  ('production', 'planned_maintenance', 'Planned maintenance',         9),
+  ('production', 'other',               'Other',                      99),
+  ('delivery',   'customer_postponed',  'Customer postponed',          1),
+  ('delivery',   'vehicle_unavailable', 'Vehicle unavailable',         2),
+  ('delivery',   'production_shortage', 'Production shortage',         3),
+  ('delivery',   'stock_shortage',      'Stock shortage',              4),
+  ('delivery',   'loading_delay',       'Loading delay',               5),
+  ('delivery',   'site_inaccessible',   'Site inaccessible',           6),
+  ('delivery',   'payment_pending',     'Payment pending',             7),
+  ('delivery',   'customer_unavailable','Customer unavailable',        8),
+  ('delivery',   'weather',             'Weather',                     9),
+  ('delivery',   'route_delay',         'Route delay',                10),
+  ('delivery',   'quantity_changed',    'Quantity changed',           11),
+  ('delivery',   'other',               'Other',                      99)
+ON CONFLICT (scope, code) DO NOTHING;
+
+-- ------------------------------------------------------ product mapping -----
+-- Odoo product -> Maiyuri finished good. PURELY a mapping: line classification
+-- (product / service / note / unmapped) is a separate responsibility that reads
+-- Odoo's own display_type and product type during the sales-order sync.
+--
+-- This exists because real brick demand is currently invisible: at the time of
+-- writing, "CIB-10*8*5-Single Press" (992 open units) and
+-- "6 by 6\" Cement Interlock Bricks" (900) carry open demand with no product
+-- link, while service lines such as Loading and Unloading carry brick-sized
+-- quantities that must never enter the plan.
+CREATE TABLE IF NOT EXISTS public.oc_product_mapping (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  odoo_product_id INTEGER NOT NULL UNIQUE,
+  odoo_product_name TEXT,
+  finished_good_id UUID NOT NULL REFERENCES public.finished_goods(id) ON DELETE CASCADE,
+  mapped_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  mapped_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_oc_product_mapping_fg
+  ON public.oc_product_mapping (finished_good_id);
+
+-- Backfill from the links the existing planner has already resolved, so the
+-- mapping screen starts with the known-good pairs rather than an empty table.
+INSERT INTO public.oc_product_mapping (odoo_product_id, odoo_product_name, finished_good_id, notes)
+SELECT DISTINCT ON (fg.odoo_product_id)
+       fg.odoo_product_id, fg.name, fg.id,
+       'Backfilled from finished_goods.odoo_product_id'
+FROM public.finished_goods fg
+WHERE fg.odoo_product_id IS NOT NULL
+ORDER BY fg.odoo_product_id, fg.created_at
+ON CONFLICT (odoo_product_id) DO NOTHING;
+
+-- Manual escape hatch for classification ONLY. Kept separate so the mapping
+-- table above never becomes a dumping ground for non-physical products.
+CREATE TABLE IF NOT EXISTS public.oc_product_classification_overrides (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  odoo_product_id INTEGER NOT NULL UNIQUE,
+  odoo_product_name TEXT,
+  line_kind TEXT NOT NULL CHECK (line_kind IN ('product', 'service', 'note', 'unmapped')),
+  reason TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- --------------------------------------------------------------- audit -----
+-- Module-wide append-only audit (PRD §74), modelled on work_item_events.
+-- Written best-effort by the API layer; never blocks the operation it records.
+CREATE TABLE IF NOT EXISTS public.oc_audit_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity TEXT NOT NULL,               -- table/concept, e.g. 'oc_activity_rates'
+  entity_id TEXT,                     -- TEXT: singleton settings key is not a uuid
+  action TEXT NOT NULL,               -- created | updated | deleted | posted | …
+  before_value JSONB,
+  after_value JSONB,
+  reason TEXT,
+  performed_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_oc_audit_entity
+  ON public.oc_audit_events (entity, entity_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_oc_audit_created
+  ON public.oc_audit_events (created_at DESC);
+
+-- -------------------------------------------------------- RLS + triggers ----
+-- Authenticated read; NO write policies. Writes go through service-role API
+-- routes that enforce roles in-handler (requireProductionRole) — that is the
+-- real gate, matching ops_planning / expenses / factory_ledger.
+DO $$
+DECLARE t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'oc_settings', 'oc_activity_types', 'oc_activity_rates',
+    'oc_consumption_standards', 'oc_vehicles', 'oc_vehicle_capacities',
+    'oc_deviation_reasons', 'oc_product_mapping',
+    'oc_product_classification_overrides', 'oc_audit_events']
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('DROP POLICY IF EXISTS "auth read %s" ON public.%I', t, t);
+    EXECUTE format(
+      'CREATE POLICY "auth read %s" ON public.%I FOR SELECT TO authenticated USING (true)', t, t);
+  END LOOP;
+
+  -- oc_audit_events is append-only: no updated_at column, so no trigger.
+  FOREACH t IN ARRAY ARRAY[
+    'oc_settings', 'oc_activity_types', 'oc_activity_rates',
+    'oc_consumption_standards', 'oc_vehicles', 'oc_vehicle_capacities',
+    'oc_deviation_reasons', 'oc_product_mapping',
+    'oc_product_classification_overrides']
+  LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS trg_%s_updated_at ON public.%I', t, t);
+    EXECUTE format(
+      'CREATE TRIGGER trg_%s_updated_at BEFORE UPDATE ON public.%I
+       FOR EACH ROW EXECUTE FUNCTION public.set_updated_at()', t, t);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

Phase 1 of the **Production, Fulfilment & Dispatch Control** PRD. Adds the `oc_` ("operations control") namespace **alongside** the existing `factory_*` ledger and `ops_plan*` planner — neither is modified. Each module gets a dated cutover later, after which the matching `factory_*` entry screen becomes read-only.

Phase 1 ships **configuration only**: every operational value the system will use is now a configurable master, so no business rule is hard-coded in TypeScript. No demand, production or dispatch behaviour lands yet.

**Guiding principle:** Odoo remains the ERP and the authoritative physical inventory. Operations Control is the operational intelligence layer — not a competing ERP, and not a second stock ledger.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

**Schema** — `supabase/migrations/20260822090000_ops_control_masters.sql`

- `oc_settings` singleton: shifts/day, max trips/day, load bands, cement bag weight and entry step, ratio tolerances, wage basis
- `oc_activity_types`, `oc_activity_rates`, `oc_consumption_standards`, `oc_vehicles`, `oc_vehicle_capacities`, `oc_deviation_reasons`
- `oc_product_mapping` (purely Odoo product → finished good) plus a **separate** `oc_product_classification_overrides`, so mapping never doubles as classification
- `oc_audit_events` — append-only, modelled on `work_item_events`

Nothing configurable is a CHECK enum; each is a seeded master row, so a new vehicle, activity or reason is configuration rather than a migration. This is a deliberate departure from `factory_*`.

**Effective dating is enforced by the database**, not just by application code — `btree_gist` EXCLUDE constraints on rates, cement standards *and* vehicle capacities. Periods are inclusive at both ends, so a rate ending 31 Aug and one starting 1 Sep coexist while a genuine overlap is rejected. An August record keeps evaluating against the August rate after September's is entered.

**No labour rate and no cement ratio is seeded.** Both must come from the business through configuration, so the PRD's illustrative figures never reach the database. Seeded instead: shifts/day 2, max trips/day 2, 50 kg bags in 0.5 steps, and vehicle capacity 6" = 1,000 / 8" = 900 — the last derived from the Odoo product name rather than pasted UUIDs, so it stays correct across environments.

**Application**

- `packages/shared/src/ops-control.ts` — zod schemas + types validating both the API body and the form
- `apps/web/src/lib/ops-control/rates.ts` — pure effective-dated resolution plus the rate snapshot that keeps approved history reproducible
- `apps/web/src/lib/ops-control/settings.ts` — settings accessor and bag-step validation using integer arithmetic, so 4.5 at a 0.1 step is not falsely rejected
- `apps/web/src/lib/ops-control/audit.ts` — best-effort audit that never blocks the operation it records
- `apps/web/app/api/ops-control/masters/*` — reads open to authenticated users, writes gated to founder/owner. Overlapping periods surface as a 409 with a usable message.
- `/ops/masters` UI, registered in `navigation`, `roleModuleAccess` **and** `middleware.ts` `protectedRoutes`

## Testing

- [x] Unit tests pass (`bun test`) — **505 pass across 33 files, 48 of them new**
- [ ] TypeScript types check (`bun typecheck`) — see note below
- [x] Linting passes (`bun lint`) — **0 errors** (356 pre-existing warnings, none from this change)
- [x] Manual testing performed — migration exercised against a real database

**On the typecheck box:** `@maiyuri/web` and `@maiyuri/shared` both pass. `@maiyuri/api` fails on a **pre-existing, unrelated** problem — it imports `uuid` without declaring it in its `package.json`, resolving only by npm hoisting from `apps/web`. That is fixed in a separate small PR, not here. Note this does **not** affect the required CI check, which installs with `npm install --legacy-peer-deps` and therefore hoists `uuid` successfully.

**Migration verification.** Rather than eyeballing the SQL, the migration was applied **and re-applied** against a throwaway local Postgres 16:

- applies clean; re-running is idempotent and does not duplicate seeds
- seeds verified: 8" = 900, 6" = 1000, Solid Blocks correctly excluded (no size in the name), 22 deviation reasons, 3 activity types, and **0 rates / 0 consumption standards**
- EXCLUDE constraints verified: adjacent periods accepted, overlapping rejected, inactive overlapping rows permitted so a rate can be superseded without deletion
- PRD §60 proven at the database level — 31 Aug resolves to ₹7, 1 Sep to ₹7.50

Test coverage focuses on the rules that are expensive to get wrong: effective-dated rate/ratio/capacity resolution across boundary dates, 0.5-bag validation, the role gates on every write route, and the overlap 409.

## Screenshots (if applicable)

n/a — `/ops/masters` is a configuration screen; its tables render from the seeded masters, with deliberate empty states for rates and cement standards explaining that those values must come from the business.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Deployment note — read before merging

**The migration must be applied to production BEFORE this PR merges.** Phase 1 ships `/ops/masters`, eight API routes and a nav entry that all query `oc_*` tables, and `main` auto-deploys. Merging code ahead of the schema would mean live routes querying tables that do not exist.

The migration is purely additive — it creates new `oc_*` objects and one extension, and makes no destructive or semantic change to `factory_*`, `finished_goods`, `ops_plan*` or any existing table.

Merge order: lockfile fix → `uuid` fix → apply migration → this PR.

## Related Issues

Follow-up PRs, both pre-existing problems unrelated to this feature:
- regenerate `bun.lock` (missing `@sparticuz/chromium` / `puppeteer-core` since #131)
- declare `uuid` in `@maiyuri/api`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYXekmvVgN6NLbc3xEw7UE)_