### PR TITLE
fix(api): declare the uuid dependency @maiyuri/api actually uses

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "langfuse": "^3.38.6",
     "makerjs": "^0.18.2",
     "openai": "^6.15.0",
+    "uuid": "^13.0.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "langfuse": "^3.38.6",
         "makerjs": "^0.18.2",
         "openai": "^6.15.0",
+        "uuid": "^13.0.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary

`apps/api` imports `uuid` but never declares it:

```
src/agents/lead-manager/index.ts:2   import { v4 as uuidv4 } from "uuid";
src/services/llm-wrapper.ts:27       import { v4 as uuidv4 } from "uuid";
```

It resolves today only because npm workspaces hoist `apps/web`'s `uuid@^13` into the root `node_modules` — a **phantom dependency**. Under bun, which resolves per-workspace, `bun typecheck` fails with `TS2307` on both files. It would also break under `bun install --filter=@maiyuri/api`, or the moment `apps/web` drops `uuid`.

> **Stacked on #151.** Based on `chore/bun-lock-chromium-puppeteer` so this PR's lockfile diff is exactly one line rather than duplicating that fix. GitHub will retarget this to `main` automatically once #151 merges.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added `"uuid": "^13.0.0"` to `apps/api` `dependencies` — the same version `apps/web` already uses, so the monorepo continues to resolve a single copy
- Regenerated `bun.lock` (one line)

**`@types/uuid` deliberately not added.** `uuid` ships its own TypeScript declarations from v9 onward, and I verified `tsc --noEmit` in `apps/api` exits **0 with zero errors** without it. Adding it would be dead weight. (`apps/web` still carries `@types/uuid@^11`, likely redundant too, but out of scope here.)

No source code changes — the imports were always correct; only the manifest was wrong.

## Testing

- [x] Unit tests pass (`bun test`) — unaffected, no source changes
- [x] TypeScript types check — `@maiyuri/api` now exits **0**; see the caveat below
- [x] Linting passes (`bun lint`) — 0 errors across all 4 workspaces
- [x] Manual testing performed

```
# before
apps/api: error TS2307: Cannot find module 'uuid' (x2)

# after
@maiyuri/api tsc exit code: 0
0 TypeScript errors
```

## Caveat reviewers should know

**Repo-wide `bun typecheck` is still red after this PR**, on a *separate* pre-existing problem of exactly the same class, which this PR deliberately does not touch:

```
apps/web/tests/test-smart-quote-redesign.ts:10  error TS2307: Cannot find module 'playwright'
apps/web/tests/test-sq-redesign.ts:6            error TS2307: Cannot find module 'playwright'
```

Both import bare `playwright`, but only `@playwright/test` is declared (root `package.json`). npm hoists the transitive `playwright` so it resolves; bun does not. Fixing it means either declaring `playwright`, or excluding these two one-off scripts from the `tsconfig` include — a judgement call that belongs in its own PR rather than being smuggled into a dependency fix.

So the honest state after this merges: **two of the three phantom-dependency problems are fixed**, and `@maiyuri/api` is green.

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works — n/a; `tsc` exiting 0 is the proof, and the follow-up CI change below is what would keep it that way
- [x] New and existing unit tests pass locally

## Root cause worth addressing

All three of these problems share one cause: **CLAUDE.md tells developers to use Bun while CI validates with npm**, so npm's hoisting masks undeclared dependencies that bun correctly refuses to resolve. Until CI runs `bun install --frozen-lockfile` and `bun typecheck`, this class of drift keeps recurring invisibly. Happy to raise that as a separate PR.

## Related Issues

Split out of #150 (Operations Control Phase 1). Stacked on #151.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYXekmvVgN6NLbc3xEw7UE)_