### PR TITLE
ci: verify the bun workflow, and run checks on PR retarget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # `opened, synchronize, reopened` is the default set. `edited` is added
+    # because retargeting a PR's base onto main fires ONLY `edited` — without
+    # it the required Code Quality check silently never runs and the PR shows
+    # the gate as absent rather than failing. Hit on #152.
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
 
@@ -20,6 +25,14 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
+    # `edited` also fires on title/body edits, which do not change what is
+    # built. Only proceed when the edit was a BASE change (the retarget case
+    # this trigger exists for); `github.event.changes.base` is present only
+    # then. Non-`edited` events are unaffected.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'edited' ||
+      github.event.changes.base != null
 
     steps:
       - name: Checkout code
@@ -70,6 +83,46 @@ jobs:
         run: npx turbo run build --filter=@maiyuri/web
         env:
           CI: true
+
+  # CLAUDE.md makes bun.lock authoritative and tells contributors to run bun,
+  # but the job above installs with npm, which ignores bun.lock entirely. That
+  # gap is not theoretical: apps/web declared @sparticuz/chromium and
+  # puppeteer-core in #131 without the lockfile ever being regenerated, and
+  # `bun install --frozen-lockfile` was broken for two weeks while CI stayed
+  # green the whole time.
+  #
+  # This job closes that hole. It is intentionally minimal — it proves the
+  # lockfile matches the manifests, nothing more.
+  #
+  # This job is NOT a required status check. Make it required in
+  # Settings → Branches → main once it has proven stable.
+  bun-lockfile:
+    name: Bun Lockfile
+    runs-on: ubuntu-latest
+    # `edited` also fires on title/body edits, which do not change what is
+    # built. Only proceed when the edit was a BASE change (the retarget case
+    # this trigger exists for); `github.event.changes.base` is present only
+    # then. Non-`edited` events are unaffected.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'edited' ||
+      github.event.changes.base != null
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      # Fails if bun.lock disagrees with any package.json in the workspace.
+      - name: Verify bun.lock is current
+        run: bun install --frozen-lockfile
+
+      # The gate CLAUDE.md actually tells contributors to run. Green across all
+      # four workspaces as of #154, which fixed the last phantom dependency.
+      - name: Verify the contributor typecheck
+        run: bun run typecheck
 
   # Telegram notifications temporarily disabled
   # notify-success:


### PR DESCRIPTION
## Summary

Two CI gaps, both found the hard way while shipping #150–#154.

**1. CI never validated the development workflow.** CLAUDE.md makes `bun.lock` authoritative and tells contributors to run bun, but the Code Quality job installs with `npm install --legacy-peer-deps`, which ignores `bun.lock` entirely and hoists undeclared transitive dependencies. Three phantom dependencies landed and survived that way — every one invisible to CI while breaking the gate contributors are told to run:

| PR | Package | Masked by |
|---|---|---|
| #151 | `@sparticuz/chromium`, `puppeteer-core` | npm never reads `bun.lock` (broken ~2 weeks) |
| #152 | `uuid` in `apps/api` | hoisted from `apps/web` |
| #154 | `playwright` in `apps/web/tests` | hoisted from `@playwright/test` |

**2. Retargeting a PR's base left the required check absent.** The workflow ran on the default `pull_request` activity set (`opened, synchronize, reopened`). Changing a PR's base onto `main` fires **only** `edited`, so Code Quality never ran — and an absent required check reads as "nothing to do" rather than as a failure. #152 hit exactly this and needed a close/reopen to clear.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

A new `Bun Lockfile` job running the two commands that would have caught all three:

```yaml
- run: bun install --frozen-lockfile   # fails if bun.lock disagrees with any manifest
- run: bun run typecheck               # the gate CLAUDE.md tells contributors to run
```

And the trigger fix, keeping the `branches: [main]` filter:

```yaml
types: [opened, synchronize, reopened, edited]
```

The existing npm pipeline is **untouched** — replacing it is a larger decision that deserves its own discussion.

The `bun run typecheck` step is included now that #154 fixed the last phantom dependency. It could not have been added before then without landing a permanently-red job.

## Testing

- [x] Unit tests pass (`bun test`) — unaffected; workflow-only change
- [x] TypeScript types check (`bun typecheck`) — **4 successful, 4 total**
- [x] Linting passes (`bun lint`) — 0 errors
- [x] Manual testing performed

Both commands verified locally on this branch, rebased onto current `main`:

```
$ bun install --frozen-lockfile
Checked 1125 installs across 1226 packages (no changes)

$ bun run typecheck
Tasks: 4 successful, 4 total
```

The job itself already ran green on an earlier push of this branch (11s). YAML validated: `types: ['opened','synchronize','reopened','edited']`, job steps `['Checkout code','Setup bun','Verify bun.lock is current','Verify the contributor typecheck']`.

Each check would have failed before its corresponding fix — that is the point of adding them.

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works — n/a; this PR *is* the test
- [x] New and existing unit tests pass locally

## Note for the repo admin

`Bun Lockfile` is **not** a required status check, so it cannot block anyone while it settles. Once it has proven stable, promote it in **Settings → Branches → main** — until then it is advisory and the same drift can still merge.

## Related Issues

Follows #151, #152 and #154, the three instances this job would have caught.