### PR TITLE
fix(web): import chromium from @playwright/test, not bare playwright

### DIFF
--- a/apps/web/tests/test-smart-quote-redesign.ts
+++ b/apps/web/tests/test-smart-quote-redesign.ts
@@ -7,7 +7,7 @@
  * - 7-section layout
  */
 
-import { chromium } from "playwright";
+import { chromium } from "@playwright/test";
 
 async function testSmartQuoteRedesign() {
   console.log("Launching browser...");

--- a/apps/web/tests/test-sq-redesign.ts
+++ b/apps/web/tests/test-sq-redesign.ts
@@ -3,7 +3,7 @@
  * Uses "robin avadi" lead for testing
  */
 
-import { chromium } from "playwright";
+import { chromium } from "@playwright/test";
 
 // Use environment variables for test credentials
 // NEVER commit actual credentials - see .env.example for setup


### PR DESCRIPTION
## Summary

`apps/web/tests/test-smart-quote-redesign.ts` and `test-sq-redesign.ts` imported `chromium` from bare `"playwright"`, which is **not declared anywhere**. `@playwright/test` *is* declared (`apps/web/package.json`) and re-exports the browser APIs, so the fix is one line per file.

This is the last of three phantom dependencies of the same class — npm hoists the transitive `playwright` from `@playwright/test` so it resolves, while bun resolves per-workspace and correctly refuses:

| PR | Package | Masked by |
|---|---|---|
| #151 | `@sparticuz/chromium`, `puppeteer-core` | npm never reads `bun.lock` |
| #152 | `uuid` in `apps/api` | npm hoists from `apps/web` |
| **this** | `playwright` in `apps/web/tests` | npm hoists from `@playwright/test` |

**`bun typecheck` is now green across all four workspaces for the first time.**

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

```diff
-import { chromium } from "playwright";
+import { chromium } from "@playwright/test";
```

Two files, two lines. No dependency added, no config changed, no code deleted.

## Why not exclude the files from tsconfig

That was the first idea, and it was worse on inspection:

1. It makes a special case for a problem a **correct import** solves.
2. The exclusion would have had to be **path-specific**. Excluding the whole `tests` directory looks tidy but `playwright.config.ts` sets `testDir: "./tests/e2e"` — that directory holds the **live** production smoke suite that runs in CI after every deploy, plus `tests/helpers/error-tracker.ts`, which three specs import. All of it typechecks cleanly today, and dropping it would have quietly removed the safety net that guards the recurring `protectedRoutes` bug.

So the import fix keeps strictly more coverage than any exclusion would have.

## Testing

- [x] Unit tests pass (`bun test`) — unaffected; no runtime behaviour changed
- [x] TypeScript types check (`bun typecheck`) — **4 successful, 4 total**, first fully green run
- [x] Linting passes (`bun lint`) — 0 errors
- [x] Manual testing performed

Verified no coverage was traded away — after the change, everything is still in the typecheck program:

```
e2e specs typechecked:          6
error-tracker in program:       1
orphan scripts still typechecked: 1
```

```
# before
tests/test-smart-quote-redesign.ts(10,26): error TS2307: Cannot find module 'playwright'
tests/test-sq-redesign.ts(6,26):           error TS2307: Cannot find module 'playwright'

# after
exit: 0
```

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works — n/a; `tsc` exiting 0 is the proof. #153 adds the CI step that keeps it that way.
- [x] New and existing unit tests pass locally

## Note on the two scripts themselves

They are orphans — referenced by no script, config or workflow — and they drive a **visible** browser (`headless: false`) against production with a hardcoded lead name. This PR deliberately only fixes the import; whether they should exist at all is a separate cleanup, and I did not want to bundle a deletion into a typecheck fix.

## Related Issues

Completes the phantom-dependency series (#151, #152) and unblocks the `bun run typecheck` step in #153.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYXekmvVgN6NLbc3xEw7UE)_