### PR TITLE
feat(unit-economics): standard cost module with reference-cost reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ bun typecheck && bun lint && bun test
 | [TESTING.md](docs/TESTING.md) | Testing and debugging protocol |
 | [DATABASE_PATTERNS.md](docs/DATABASE_PATTERNS.md) | SQL safety and patterns |
 | [OBSERVABILITY.md](docs/OBSERVABILITY.md) | Logging and monitoring |
+| [UNIT_ECONOMICS.md](docs/UNIT_ECONOMICS.md) | Standard cost module + frozen Intelligence Layer contract |
 | [ISSUE_WORKFLOW.md](docs/ISSUE_WORKFLOW.md) | Issue fixing workflow |
 | [GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md) | Git and release process |
 

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -62,6 +62,12 @@ const navigation: NavItem[] = [
   { name: "Reimbursements", href: "/expenses", icon: KPIIcon, key: "expenses" },
   { name: "Rate Card", href: "/rate-card", icon: KPIIcon, key: "rate-card" },
   {
+    name: "Unit Economics",
+    href: "/unit-economics",
+    icon: KPIIcon,
+    key: "unit-economics",
+  },
+  {
     name: "Approvals",
     href: "/approvals",
     icon: ApprovalsIcon,
@@ -95,6 +101,7 @@ const roleModuleAccess: Record<UserRole, string[]> = {
     "projects",
     "expenses",
     "rate-card",
+    "unit-economics",
   ],
   engineer: [
     "dashboard",

--- a/apps/web/app/(dashboard)/unit-economics/page.tsx
+++ b/apps/web/app/(dashboard)/unit-economics/page.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  computeAllReferenceVariances,
   computeBundle,
   diffBundles,
   publishBlockers,
@@ -23,11 +24,14 @@ import {
   type PublishWarning,
   type StdCostBundle,
   type StdCostDiffRow,
+  type StdCostReference,
+  type StdCostReferenceVariance,
   type StdCostVersionSummary,
 } from "@maiyuri/shared";
 import { DraftEditor } from "@/components/unit-economics/DraftEditor";
 import { HistoryPanel } from "@/components/unit-economics/HistoryPanel";
 import { PublishPanel } from "@/components/unit-economics/PublishPanel";
+import { ReconciliationPanel } from "@/components/unit-economics/ReconciliationPanel";
 import { toBundle, toForm, toPayload, validateForm, type DraftForm } from "@/components/unit-economics/form";
 
 interface OverviewResponse {
@@ -39,6 +43,8 @@ interface OverviewResponse {
   blockers: PublishBlocker[];
   warnings: PublishWarning[];
   history: StdCostVersionSummary[];
+  references: StdCostReference[];
+  reference_variances: StdCostReferenceVariance[];
   can_publish: boolean;
 }
 
@@ -50,7 +56,7 @@ async function getJson<T>(url: string): Promise<T> {
   return body.data as T;
 }
 
-async function sendJson(url: string, method: "PUT" | "POST", payload?: unknown) {
+async function sendJson(url: string, method: "PUT" | "POST" | "DELETE", payload?: unknown) {
   const res = await fetch(url, {
     method,
     headers: { "Content-Type": "application/json" },
@@ -61,7 +67,7 @@ async function sendJson(url: string, method: "PUT" | "POST", payload?: unknown) 
   return body.data;
 }
 
-type Tab = "draft" | "publish" | "history";
+type Tab = "draft" | "reconcile" | "publish" | "history";
 
 export default function UnitEconomicsPage() {
   const queryClient = useQueryClient();
@@ -114,6 +120,17 @@ export default function UnitEconomicsPage() {
     [liveBundle, data?.published],
   );
 
+  // Reconciliation follows what you are looking at: the live draft while
+  // editing, the published standard once the draft matches it. Benchmarks
+  // never enter computeBundle() — they are only ever subtracted from it.
+  const liveVariances = useMemo(
+    () =>
+      liveBundle && data?.references
+        ? computeAllReferenceVariances(liveBundle, data.references)
+        : (data?.reference_variances ?? []),
+    [liveBundle, data?.references, data?.reference_variances],
+  );
+
   const save = useMutation({
     mutationFn: () => {
       if (!form || !draftVersion) throw new Error("Nothing to save");
@@ -154,6 +171,20 @@ export default function UnitEconomicsPage() {
     },
   });
 
+  const saveReference = useMutation({
+    mutationFn: (reference: StdCostReference) =>
+      sendJson("/api/unit-economics/references", "POST", reference),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["unit-economics"] }),
+  });
+
+  const deactivateReference = useMutation({
+    mutationFn: (referenceId: string) =>
+      sendJson(`/api/unit-economics/references/${referenceId}`, "DELETE"),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["unit-economics"] }),
+  });
+
+  const significantVariances = liveVariances.filter((variance) => variance.is_significant).length;
+
   const onFormChange = (updater: (previous: DraftForm) => DraftForm) => {
     setForm((previous) => (previous ? updater(previous) : previous));
     setDirty(true);
@@ -184,6 +215,7 @@ export default function UnitEconomicsPage() {
         {(
           [
             ["draft", "Standard costs (draft)"],
+            ["reconcile", "Reconciliation"],
             ["publish", "Publish"],
             ["history", "History"],
           ] as const
@@ -202,6 +234,11 @@ export default function UnitEconomicsPage() {
             {key === "publish" && liveDiff.length > 0 ? (
               <span className="ml-1.5 rounded-full bg-orange-100 px-1.5 text-xs text-orange-700">
                 {liveDiff.length}
+              </span>
+            ) : null}
+            {key === "reconcile" && significantVariances > 0 ? (
+              <span className="ml-1.5 rounded-full bg-amber-100 px-1.5 text-xs text-amber-800">
+                ⚠ {significantVariances}
               </span>
             ) : null}
           </button>
@@ -260,6 +297,20 @@ export default function UnitEconomicsPage() {
 
           <DraftEditor form={form} computed={computed} issues={issues} onChange={onFormChange} />
         </>
+      ) : tab === "reconcile" ? (
+        <ReconciliationPanel
+          variances={liveVariances}
+          brickTypes={form.brick_types.map((bt) => bt.brick_type)}
+          publishedValidFrom={data.published?.version.valid_from ?? null}
+          isDraftPreview={dirty || liveDiff.length > 0}
+          onSaveReference={(reference) => saveReference.mutate(reference)}
+          onDeactivateReference={(referenceId) => deactivateReference.mutate(referenceId)}
+          saving={saveReference.isPending}
+          deactivating={deactivateReference.isPending}
+          errorMessage={
+            saveReference.isError ? message(saveReference.error, "Could not save") : null
+          }
+        />
       ) : tab === "publish" ? (
         <PublishPanel
           diff={liveDiff}

--- a/apps/web/app/(dashboard)/unit-economics/page.tsx
+++ b/apps/web/app/(dashboard)/unit-economics/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+/**
+ * 🧱 Unit Economics — the standard cost of every brick type.
+ *
+ * Replaces the "Mb Unit Economics" Google Sheet. Staff maintain ONE draft;
+ * management publishes it as an immutable, dated version; the Maiyuri
+ * Intelligence Layer reads the published version straight out of Postgres
+ * (v_standard_costs_current). Nothing downstream moves until a publish.
+ *
+ * Every number on this page that could be computed IS computed, live, from the
+ * inputs — using the same formulas as the published SQL views.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  computeBundle,
+  diffBundles,
+  publishBlockers,
+  publishWarnings,
+  type ComputedBundle,
+  type PublishBlocker,
+  type PublishWarning,
+  type StdCostBundle,
+  type StdCostDiffRow,
+  type StdCostVersionSummary,
+} from "@maiyuri/shared";
+import { DraftEditor } from "@/components/unit-economics/DraftEditor";
+import { HistoryPanel } from "@/components/unit-economics/HistoryPanel";
+import { PublishPanel } from "@/components/unit-economics/PublishPanel";
+import { toBundle, toForm, toPayload, validateForm, type DraftForm } from "@/components/unit-economics/form";
+
+interface OverviewResponse {
+  draft: StdCostBundle | null;
+  draft_computed: ComputedBundle | null;
+  published: StdCostBundle | null;
+  published_computed: ComputedBundle | null;
+  diff: StdCostDiffRow[];
+  blockers: PublishBlocker[];
+  warnings: PublishWarning[];
+  history: StdCostVersionSummary[];
+  can_publish: boolean;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  // no-store: a cached standard cost is a wrong standard cost.
+  const res = await fetch(url, { cache: "no-store" });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data as T;
+}
+
+async function sendJson(url: string, method: "PUT" | "POST", payload?: unknown) {
+  const res = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: payload === undefined ? undefined : JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data;
+}
+
+type Tab = "draft" | "publish" | "history";
+
+export default function UnitEconomicsPage() {
+  const queryClient = useQueryClient();
+  const [tab, setTab] = useState<Tab>("draft");
+  const [form, setForm] = useState<DraftForm | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["unit-economics"],
+    queryFn: () => getJson<OverviewResponse>("/api/unit-economics"),
+  });
+
+  // Load the server draft into the form, but never clobber edits in progress.
+  const serverDraftKey = data?.draft ? JSON.stringify(data.draft) : "";
+  const lastLoadedKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!data?.draft) return;
+    if (serverDraftKey === lastLoadedKey.current) return;
+    if (dirty) return;
+    lastLoadedKey.current = serverDraftKey;
+    setForm(toForm(data.draft));
+  }, [serverDraftKey, data?.draft, dirty]);
+
+  const draftVersion = data?.draft?.version ?? null;
+
+  // Live recompute on every keystroke — this is what makes a stale derived
+  // number impossible: there is nowhere for one to be stored.
+  const liveBundle = useMemo(
+    () => (form && draftVersion ? toBundle(form, draftVersion) : null),
+    [form, draftVersion],
+  );
+  const computed = useMemo(
+    () => (liveBundle ? computeBundle(liveBundle) : null),
+    [liveBundle],
+  );
+  const issues = useMemo(() => (form ? validateForm(form) : []), [form]);
+
+  // The publish tab compares SAVED state, since publishing freezes what is
+  // stored — but blockers use the live draft so problems surface while typing.
+  const liveBlockers = useMemo(
+    () => (liveBundle ? publishBlockers(liveBundle) : []),
+    [liveBundle],
+  );
+  const liveWarnings = useMemo(
+    () => (liveBundle ? publishWarnings(liveBundle, data?.published ?? null) : []),
+    [liveBundle, data?.published],
+  );
+  const liveDiff = useMemo(
+    () => (liveBundle ? diffBundles(data?.published ?? null, liveBundle) : []),
+    [liveBundle, data?.published],
+  );
+
+  const save = useMutation({
+    mutationFn: () => {
+      if (!form || !draftVersion) throw new Error("Nothing to save");
+      return sendJson("/api/unit-economics/draft", "PUT", toPayload(form, draftVersion));
+    },
+    onSuccess: () => {
+      setDirty(false);
+      lastLoadedKey.current = null;
+      void queryClient.invalidateQueries({ queryKey: ["unit-economics"] });
+    },
+  });
+
+  const publish = useMutation({
+    mutationFn: (validFrom: string) => {
+      if (!draftVersion) throw new Error("No draft to publish");
+      return sendJson("/api/unit-economics/publish", "POST", {
+        version_id: draftVersion.id,
+        valid_from: validFrom,
+        notes: form?.notes || null,
+      });
+    },
+    onSuccess: () => {
+      setDirty(false);
+      lastLoadedKey.current = null;
+      setTab("history");
+      void queryClient.invalidateQueries({ queryKey: ["unit-economics"] });
+    },
+  });
+
+  const revert = useMutation({
+    mutationFn: (versionId: string) =>
+      sendJson(`/api/unit-economics/versions/${versionId}/use-as-draft`, "POST"),
+    onSuccess: () => {
+      setDirty(false);
+      lastLoadedKey.current = null;
+      setTab("draft");
+      void queryClient.invalidateQueries({ queryKey: ["unit-economics"] });
+    },
+  });
+
+  const onFormChange = (updater: (previous: DraftForm) => DraftForm) => {
+    setForm((previous) => (previous ? updater(previous) : previous));
+    setDirty(true);
+  };
+
+  const message = (err: unknown, fallback: string) =>
+    err instanceof Error ? err.message : fallback;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 sm:p-6">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">🧱 Unit Economics</h1>
+        <p className="text-sm text-slate-500">
+          The standard cost of each brick type. Edit the draft freely — nothing changes downstream
+          until management publishes it as a dated version.
+        </p>
+        {data?.published?.version.valid_from ? (
+          <p className="mt-1 text-xs text-slate-400">
+            Standard in force since {data.published.version.valid_from}
+            {data.published_computed
+              ? ` · ${data.published_computed.brick_types.length} brick types`
+              : ""}
+          </p>
+        ) : null}
+      </header>
+
+      <nav className="flex gap-1 border-b border-slate-200">
+        {(
+          [
+            ["draft", "Standard costs (draft)"],
+            ["publish", "Publish"],
+            ["history", "History"],
+          ] as const
+        ).map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setTab(key)}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium ${
+              tab === key
+                ? "border-orange-500 text-orange-600"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {label}
+            {key === "publish" && liveDiff.length > 0 ? (
+              <span className="ml-1.5 rounded-full bg-orange-100 px-1.5 text-xs text-orange-700">
+                {liveDiff.length}
+              </span>
+            ) : null}
+          </button>
+        ))}
+      </nav>
+
+      {isLoading ? (
+        <p className="text-sm text-slate-400">Loading…</p>
+      ) : isError ? (
+        <p className="text-sm text-red-600">{message(error, "Failed to load standard costs")}</p>
+      ) : !data?.draft || !form || !computed ? (
+        <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          No draft exists yet. Run the standard-cost seed migration, then reload.
+        </p>
+      ) : tab === "draft" ? (
+        <>
+          <div className="sticky top-0 z-10 -mx-1 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/95 px-3 py-2 backdrop-blur">
+            <p className="text-sm text-slate-500">
+              {issues.length > 0 ? (
+                <span className="text-red-600">
+                  {issues.length} field{issues.length === 1 ? "" : "s"} need fixing
+                </span>
+              ) : dirty ? (
+                "Unsaved changes"
+              ) : (
+                "All changes saved"
+              )}
+            </p>
+            <div className="flex items-center gap-2">
+              {dirty ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (data.draft) setForm(toForm(data.draft));
+                    setDirty(false);
+                  }}
+                  className="text-sm text-slate-500 hover:underline"
+                >
+                  Discard
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => save.mutate()}
+                disabled={!dirty || issues.length > 0 || save.isPending}
+                className="rounded-lg bg-slate-900 px-4 py-1.5 text-sm font-semibold text-white disabled:opacity-40"
+              >
+                {save.isPending ? "Saving…" : dirty ? "Save draft" : "Saved ✓"}
+              </button>
+            </div>
+          </div>
+
+          {save.isError ? (
+            <p className="text-sm text-red-600">{message(save.error, "Save failed")}</p>
+          ) : null}
+
+          <DraftEditor form={form} computed={computed} issues={issues} onChange={onFormChange} />
+        </>
+      ) : tab === "publish" ? (
+        <PublishPanel
+          diff={liveDiff}
+          blockers={liveBlockers}
+          warnings={liveWarnings}
+          publishedValidFrom={data.published?.version.valid_from ?? null}
+          canPublish={data.can_publish}
+          dirty={dirty}
+          isPublishing={publish.isPending}
+          errorMessage={publish.isError ? message(publish.error, "Publish failed") : null}
+          onPublish={(validFrom) => publish.mutate(validFrom)}
+        />
+      ) : (
+        <HistoryPanel
+          history={data.history}
+          canRevert={data.can_publish}
+          onUseAsDraft={(versionId) => revert.mutate(versionId)}
+          revertPending={revert.isPending}
+          revertError={revert.isError ? message(revert.error, "Could not create a draft") : null}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/api/unit-economics/draft/route.ts
+++ b/apps/web/app/api/unit-economics/draft/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { saveDraft, StdCostError } from "@/lib/unit-economics";
+import {
+  computeBundle,
+  publishBlockers,
+  stdCostDraftSchema,
+} from "@maiyuri/shared";
+
+/**
+ * PUT /api/unit-economics/draft — save the working draft (any staff member).
+ *
+ * Replace-all: the body is the complete draft. Nothing here goes live; the
+ * Intelligence Layer only ever reads published versions.
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+
+    const parsed = await parseBody(request, stdCostDraftSchema);
+    if (parsed.error) return parsed.error;
+    const payload = parsed.data;
+
+    // Duplicate keys would silently drop rows on the unique constraints, and
+    // the error Postgres returns names a constraint rather than the field.
+    const duplicate =
+      firstDuplicate(payload.rm_prices.map((rm) => rm.rm_key)) ??
+      firstDuplicate(payload.fixed_items.map((item) => item.item_key)) ??
+      firstDuplicate(payload.brick_types.map((bt) => bt.brick_type));
+    if (duplicate) return error(`Duplicate entry: ${duplicate}`, 422);
+
+    for (const bt of payload.brick_types) {
+      const dupeRm = firstDuplicate(bt.recipe.map((line) => line.rm_key));
+      if (dupeRm) return error(`${bt.brick_type}: duplicate recipe line for ${dupeRm}`, 422);
+    }
+
+    const bundle = await saveDraft(payload, user.id);
+
+    return success({
+      draft: bundle,
+      draft_computed: computeBundle(bundle),
+      blockers: publishBlockers(bundle),
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof StdCostError) return error(err.message, err.status);
+    console.error("[UnitEconomics] PUT draft failed:", err);
+    return error("Failed to save the draft", 500);
+  }
+}
+
+function firstDuplicate(keys: string[]): string | null {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) return key;
+    seen.add(key);
+  }
+  return null;
+}

--- a/apps/web/app/api/unit-economics/publish/route.ts
+++ b/apps/web/app/api/unit-economics/publish/route.ts
@@ -1,0 +1,71 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import {
+  canPublishStandardCost,
+  loadBundle,
+  loadCurrentPublishedBundle,
+  publishDraft,
+  StdCostError,
+} from "@/lib/unit-economics";
+import { publishBlockers, stdCostPublishSchema } from "@maiyuri/shared";
+
+/**
+ * POST /api/unit-economics/publish — freeze the draft as the new standard.
+ *
+ * Admin only. Blocked (PRD §7) when any brick type has no cement recipe line
+ * or a total cost per unit of zero or less: a published version cannot be
+ * edited afterwards, so bad inputs must not get in.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+    if (!canPublishStandardCost(user.role)) {
+      return error("Only management can publish a standard cost version", 403);
+    }
+
+    const parsed = await parseBody(request, stdCostPublishSchema);
+    if (parsed.error) return parsed.error;
+    const { version_id, valid_from, notes } = parsed.data;
+
+    const draft = await loadBundle(version_id);
+    if (!draft) return error("Draft not found", 404);
+    if (draft.version.status !== "draft") {
+      return error("That version is already published", 409);
+    }
+
+    const blockers = publishBlockers(draft);
+    if (blockers.length > 0) {
+      return error(
+        `Cannot publish: ${blockers
+          .map((b) => (b.brick_type ? `${b.brick_type} — ${b.message}` : b.message))
+          .join("; ")}`,
+        422,
+      );
+    }
+
+    const currentPublished = await loadCurrentPublishedBundle();
+    if (currentPublished?.version.valid_from && valid_from <= currentPublished.version.valid_from) {
+      return error(
+        `Valid from must be after ${currentPublished.version.valid_from} (the current standard)`,
+        422,
+      );
+    }
+
+    const result = await publishDraft({
+      versionId: version_id,
+      validFrom: valid_from,
+      publishedBy: user.id,
+      notes: notes ?? null,
+    });
+
+    return success(result);
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof StdCostError) return error(err.message, err.status);
+    console.error("[UnitEconomics] publish failed:", err);
+    return error("Failed to publish", 500);
+  }
+}

--- a/apps/web/app/api/unit-economics/references/[id]/route.ts
+++ b/apps/web/app/api/unit-economics/references/[id]/route.ts
@@ -1,0 +1,26 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { deactivateReference } from "@/lib/unit-economics";
+
+/**
+ * DELETE /api/unit-economics/references/:id — stop comparing against this
+ * benchmark. Deactivates rather than deletes: a legacy number that has been
+ * argued over is part of the audit trail.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const user = await requireAuth(request);
+    await deactivateReference(params.id, user.id);
+    return success({ id: params.id, is_active: false });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[UnitEconomics] DELETE reference failed:", err);
+    return error("Failed to deactivate the reference cost", 500);
+  }
+}

--- a/apps/web/app/api/unit-economics/references/route.ts
+++ b/apps/web/app/api/unit-economics/references/route.ts
@@ -1,0 +1,60 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error, parseBody } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import {
+  listReferences,
+  loadCurrentPublishedBundle,
+  saveReference,
+  StdCostError,
+} from "@/lib/unit-economics";
+import { computeAllReferenceVariances, stdCostReferenceSchema } from "@maiyuri/shared";
+
+/**
+ * Reference (benchmark) costs — legacy sheet totals, manual benchmarks, past
+ * actuals. Stored beside the standard, never inside it.
+ *
+ *   GET  — every benchmark, plus the variance of each against the PUBLISHED
+ *          standard (what the Intelligence Layer sees)
+ *   POST — create or update one benchmark and its optional breakdown
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await requireAuth(request);
+
+    const [references, published] = await Promise.all([
+      listReferences(),
+      loadCurrentPublishedBundle(),
+    ]);
+
+    return success({
+      references,
+      // Variance against the published standard. The screen recomputes this
+      // live for the draft; this is the number downstream actually reads.
+      variances: published ? computeAllReferenceVariances(published, references) : [],
+      published_valid_from: published?.version.valid_from ?? null,
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[UnitEconomics] GET references failed:", err);
+    return error("Failed to load reference costs", 500);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+
+    const parsed = await parseBody(request, stdCostReferenceSchema);
+    if (parsed.error) return parsed.error;
+
+    const reference = await saveReference(parsed.data, user.id);
+    return success({ reference });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof StdCostError) return error(err.message, err.status);
+    console.error("[UnitEconomics] POST reference failed:", err);
+    return error("Failed to save the reference cost", 500);
+  }
+}

--- a/apps/web/app/api/unit-economics/route.ts
+++ b/apps/web/app/api/unit-economics/route.ts
@@ -1,0 +1,47 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import {
+  canPublishStandardCost,
+  listPublishedVersions,
+  loadCurrentPublishedBundle,
+  loadDraftBundle,
+} from "@/lib/unit-economics";
+import { computeBundle, diffBundles, publishBlockers, publishWarnings } from "@maiyuri/shared";
+
+/**
+ * GET /api/unit-economics — everything the Standard Costs screen needs:
+ * the working draft, the currently published standard, the diff between them,
+ * publish gating, and the published history.
+ *
+ * Every derived number here is computed, never read from storage.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireAuth(request);
+
+    const [draft, published, history] = await Promise.all([
+      loadDraftBundle(),
+      loadCurrentPublishedBundle(),
+      listPublishedVersions(),
+    ]);
+
+    return success({
+      draft,
+      draft_computed: draft ? computeBundle(draft) : null,
+      published,
+      published_computed: published ? computeBundle(published) : null,
+      diff: draft ? diffBundles(published, draft) : [],
+      blockers: draft ? publishBlockers(draft) : [],
+      warnings: draft ? publishWarnings(draft, published) : [],
+      history,
+      can_publish: canPublishStandardCost(user.role),
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[UnitEconomics] GET failed:", err);
+    return error("Failed to load standard costs", 500);
+  }
+}

--- a/apps/web/app/api/unit-economics/route.ts
+++ b/apps/web/app/api/unit-economics/route.ts
@@ -6,10 +6,17 @@ import { requireAuth, AuthError } from "@/lib/api-helpers";
 import {
   canPublishStandardCost,
   listPublishedVersions,
+  listReferences,
   loadCurrentPublishedBundle,
   loadDraftBundle,
 } from "@/lib/unit-economics";
-import { computeBundle, diffBundles, publishBlockers, publishWarnings } from "@maiyuri/shared";
+import {
+  computeAllReferenceVariances,
+  computeBundle,
+  diffBundles,
+  publishBlockers,
+  publishWarnings,
+} from "@maiyuri/shared";
 
 /**
  * GET /api/unit-economics — everything the Standard Costs screen needs:
@@ -22,10 +29,11 @@ export async function GET(request: NextRequest) {
   try {
     const user = await requireAuth(request);
 
-    const [draft, published, history] = await Promise.all([
+    const [draft, published, history, references] = await Promise.all([
       loadDraftBundle(),
       loadCurrentPublishedBundle(),
       listPublishedVersions(),
+      listReferences(),
     ]);
 
     return success({
@@ -37,6 +45,12 @@ export async function GET(request: NextRequest) {
       blockers: draft ? publishBlockers(draft) : [],
       warnings: draft ? publishWarnings(draft, published) : [],
       history,
+      references,
+      // Reconciliation against the PUBLISHED standard — the screen recomputes
+      // it live for the draft as you type.
+      reference_variances: published
+        ? computeAllReferenceVariances(published, references)
+        : [],
       can_publish: canPublishStandardCost(user.role),
     });
   } catch (err) {

--- a/apps/web/app/api/unit-economics/versions/[id]/route.ts
+++ b/apps/web/app/api/unit-economics/versions/[id]/route.ts
@@ -1,0 +1,41 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import { loadBundle } from "@/lib/unit-economics";
+import { computeBundle, diffBundles } from "@maiyuri/shared";
+
+/**
+ * GET /api/unit-economics/versions/:id — one version, read-only, with its
+ * computed numbers. `?compare=<other version id>` returns the number-by-number
+ * diff between the two ("what changed between v3 and v4").
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireAuth(request);
+
+    const bundle = await loadBundle(params.id);
+    if (!bundle) return error("Version not found", 404);
+
+    const compareId = request.nextUrl.searchParams.get("compare");
+    const compareBundle = compareId ? await loadBundle(compareId) : null;
+    if (compareId && !compareBundle) return error("Comparison version not found", 404);
+
+    return success({
+      version: bundle,
+      computed: computeBundle(bundle),
+      compare: compareBundle,
+      compare_computed: compareBundle ? computeBundle(compareBundle) : null,
+      // Older version on the left, the one being viewed on the right.
+      diff: compareBundle ? diffBundles(compareBundle, bundle) : [],
+    });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    console.error("[UnitEconomics] GET version failed:", err);
+    return error("Failed to load version", 500);
+  }
+}

--- a/apps/web/app/api/unit-economics/versions/[id]/use-as-draft/route.ts
+++ b/apps/web/app/api/unit-economics/versions/[id]/use-as-draft/route.ts
@@ -1,0 +1,37 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-utils";
+import { requireAuth, AuthError } from "@/lib/api-helpers";
+import {
+  canPublishStandardCost,
+  StdCostError,
+  useVersionAsDraft,
+} from "@/lib/unit-economics";
+import { computeBundle } from "@maiyuri/shared";
+
+/**
+ * POST /api/unit-economics/versions/:id/use-as-draft — revert.
+ *
+ * Admin only. Refills the open draft from an older published version; history
+ * is never rewritten, and nothing changes downstream until it is published.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const user = await requireAuth(request);
+    if (!canPublishStandardCost(user.role)) {
+      return error("Only management can revert to an earlier standard", 403);
+    }
+
+    const draft = await useVersionAsDraft(params.id, user.id);
+    return success({ draft, draft_computed: computeBundle(draft) });
+  } catch (err) {
+    if (err instanceof AuthError) return error(err.message, err.status);
+    if (err instanceof StdCostError) return error(err.message, err.status);
+    console.error("[UnitEconomics] use-as-draft failed:", err);
+    return error("Failed to create a draft from that version", 500);
+  }
+}

--- a/apps/web/src/components/unit-economics/DiffTable.tsx
+++ b/apps/web/src/components/unit-economics/DiffTable.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Number-by-number diff, old → new (PRD §7.2 and §10.4). Used both by the
+ * publish flow (draft vs currently published) and by History (any two
+ * published versions).
+ */
+import type { StdCostDiffRow } from "@maiyuri/shared";
+import { inr } from "./form";
+
+const SECTION_LABELS: Record<StdCostDiffRow["section"], string> = {
+  version: "Version settings",
+  raw_material: "Raw materials",
+  brick_type: "Brick type inputs",
+  recipe: "Recipes",
+  fixed_cost: "Fixed costs",
+  computed: "Computed totals",
+};
+
+const SECTION_ORDER: StdCostDiffRow["section"][] = [
+  "computed",
+  "raw_material",
+  "recipe",
+  "brick_type",
+  "fixed_cost",
+  "version",
+];
+
+function renderValue(value: number | string | null, isMoney: boolean): string {
+  if (value === null) return "—";
+  if (typeof value === "string") return value;
+  return isMoney ? inr(value) : String(value);
+}
+
+export function DiffTable({
+  rows,
+  beforeLabel,
+  afterLabel,
+  emptyMessage = "No changes.",
+}: {
+  rows: StdCostDiffRow[];
+  beforeLabel: string;
+  afterLabel: string;
+  emptyMessage?: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="text-sm text-slate-400">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {SECTION_ORDER.filter((section) => rows.some((row) => row.section === section)).map(
+        (section) => (
+          <div key={section}>
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {SECTION_LABELS[section]}
+            </h4>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] text-sm">
+                <thead>
+                  <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                    <th className="py-1">Item</th>
+                    <th className="py-1">Field</th>
+                    <th className="py-1 text-right">{beforeLabel}</th>
+                    <th className="py-1 text-right">{afterLabel}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows
+                    .filter((row) => row.section === section)
+                    .map((row, i) => {
+                      const isMoney =
+                        !row.label.toLowerCase().includes("kg") &&
+                        !row.label.toLowerCase().includes("batch") &&
+                        !row.label.toLowerCase().includes("basis") &&
+                        !row.label.toLowerCase().includes("match") &&
+                        !row.label.toLowerCase().includes("label");
+                      const rose =
+                        typeof row.before === "number" &&
+                        typeof row.after === "number" &&
+                        row.after > row.before;
+                      return (
+                        <tr key={`${row.group}-${row.label}-${i}`} className="border-t border-slate-100">
+                          <td className="py-1.5 pr-3 text-slate-600">{row.group}</td>
+                          <td className="py-1.5 pr-3 text-slate-500">{row.label}</td>
+                          <td className="py-1.5 pr-3 text-right tabular-nums text-slate-400 line-through">
+                            {renderValue(row.before, isMoney)}
+                          </td>
+                          <td
+                            className={`py-1.5 text-right font-semibold tabular-nums ${
+                              rose ? "text-red-600" : "text-emerald-700"
+                            }`}
+                          >
+                            {renderValue(row.after, isMoney)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ),
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/unit-economics/DraftEditor.tsx
+++ b/apps/web/src/components/unit-economics/DraftEditor.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+/**
+ * The working screen (PRD §7.1). Sections mirror the retiring sheet:
+ * raw-material prices · per-brick-type cards · monthly fixed costs · basis.
+ *
+ * Everything derived re-renders as you type, because it is recomputed from the
+ * form on every keystroke by computeBundle() — the same formulas the published
+ * SQL views use. There is no code path that stores a derived number.
+ */
+import type { ComputedBundle } from "@maiyuri/shared";
+import { Derived, DerivedCount, NumberField, SectionCard, TextField } from "./primitives";
+import {
+  inr,
+  issueFor,
+  type BrickTypeForm,
+  type DraftForm,
+  type FieldIssue,
+} from "./form";
+
+interface Props {
+  form: DraftForm;
+  computed: ComputedBundle;
+  issues: FieldIssue[];
+  onChange: (updater: (previous: DraftForm) => DraftForm) => void;
+  readOnly?: boolean;
+}
+
+export function DraftEditor({ form, computed, issues, onChange, readOnly = false }: Props) {
+  const costPerKg = new Map(computed.rm_prices.map((rm) => [rm.rm_key, rm.cost_per_kg]));
+  const computedByType = new Map(computed.brick_types.map((bt) => [bt.brick_type, bt]));
+
+  const setRm = (index: number, key: keyof DraftForm["rm_prices"][number], value: string) =>
+    onChange((prev) => ({
+      ...prev,
+      rm_prices: prev.rm_prices.map((rm, i) => (i === index ? { ...rm, [key]: value } : rm)),
+    }));
+
+  const setFixed = (index: number, key: keyof DraftForm["fixed_items"][number], value: string) =>
+    onChange((prev) => ({
+      ...prev,
+      fixed_items: prev.fixed_items.map((item, i) =>
+        i === index ? { ...item, [key]: value } : item,
+      ),
+    }));
+
+  const setBrick = (index: number, key: keyof BrickTypeForm, value: string) =>
+    onChange((prev) => ({
+      ...prev,
+      brick_types: prev.brick_types.map((bt, i) => (i === index ? { ...bt, [key]: value } : bt)),
+    }));
+
+  const setRecipe = (btIndex: number, lineIndex: number, value: string) =>
+    onChange((prev) => ({
+      ...prev,
+      brick_types: prev.brick_types.map((bt, i) =>
+        i === btIndex
+          ? {
+              ...bt,
+              recipe: bt.recipe.map((line, j) =>
+                j === lineIndex ? { ...line, kg_per_batch: value } : line,
+              ),
+            }
+          : bt,
+      ),
+    }));
+
+  const addRecipeLine = (btIndex: number, rmKey: string) =>
+    onChange((prev) => ({
+      ...prev,
+      brick_types: prev.brick_types.map((bt, i) =>
+        i === btIndex ? { ...bt, recipe: [...bt.recipe, { rm_key: rmKey, kg_per_batch: "0" }] } : bt,
+      ),
+    }));
+
+  const removeRecipeLine = (btIndex: number, lineIndex: number) =>
+    onChange((prev) => ({
+      ...prev,
+      brick_types: prev.brick_types.map((bt, i) =>
+        i === btIndex ? { ...bt, recipe: bt.recipe.filter((_, j) => j !== lineIndex) } : bt,
+      ),
+    }));
+
+  return (
+    <div className="space-y-4">
+      {/* ------------------------------------------------ raw materials --- */}
+      <SectionCard
+        title="Raw material prices"
+        subtitle="Type what you pay and what you get for it. Cost per kg is computed — it can never disagree with these two numbers."
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="py-1">Material</th>
+                <th className="py-1">Purchase amount</th>
+                <th className="py-1">Unit</th>
+                <th className="py-1">Unit weight (kg)</th>
+                <th className="py-1 text-right">Cost / kg</th>
+              </tr>
+            </thead>
+            <tbody>
+              {form.rm_prices.map((rm, i) => (
+                <tr key={rm.rm_key} className="border-t border-slate-100 align-top">
+                  <td className="py-2 pr-3">
+                    <TextField
+                      value={rm.display_name}
+                      onChange={(v) => setRm(i, "display_name", v)}
+                      issue={issueFor(issues, `rm.${i}.display_name`)}
+                    />
+                    <span className="mt-0.5 block font-mono text-[11px] text-slate-400">{rm.rm_key}</span>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <NumberField
+                      value={rm.purchase_amount}
+                      onChange={(v) => setRm(i, "purchase_amount", v)}
+                      issue={issueFor(issues, `rm.${i}.purchase_amount`)}
+                      disabled={readOnly}
+                      suffix="₹"
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <TextField
+                      value={rm.purchase_unit_label}
+                      onChange={(v) => setRm(i, "purchase_unit_label", v)}
+                      issue={issueFor(issues, `rm.${i}.purchase_unit_label`)}
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <NumberField
+                      value={rm.purchase_unit_kg}
+                      onChange={(v) => setRm(i, "purchase_unit_kg", v)}
+                      issue={issueFor(issues, `rm.${i}.purchase_unit_kg`)}
+                      disabled={readOnly}
+                      suffix="kg"
+                    />
+                  </td>
+                  <td className="py-2 text-right">
+                    <span className="inline-block rounded-lg bg-slate-100 px-3 py-1.5 font-semibold tabular-nums text-slate-700">
+                      {inr(costPerKg.get(rm.rm_key) ?? 0, 4)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      {/* --------------------------------------------------- brick types -- */}
+      {form.brick_types.map((bt, i) => {
+        const c = computedByType.get(bt.brick_type);
+        const unusedMaterials = form.rm_prices
+          .map((rm) => rm.rm_key)
+          .filter((key) => !bt.recipe.some((line) => line.rm_key === key));
+
+        return (
+          <SectionCard
+            key={`${bt.brick_type}-${i}`}
+            title={bt.brick_type || "Untitled brick type"}
+            subtitle={`Odoo match: ${bt.odoo_product_match || "—"}`}
+          >
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <TextField
+                    label="Brick type"
+                    value={bt.brick_type}
+                    onChange={(v) => setBrick(i, "brick_type", v)}
+                    issue={issueFor(issues, `bt.${i}.brick_type`)}
+                  />
+                  <TextField
+                    label="Odoo product match"
+                    value={bt.odoo_product_match}
+                    onChange={(v) => setBrick(i, "odoo_product_match", v)}
+                    issue={issueFor(issues, `bt.${i}.odoo_product_match`)}
+                  />
+                  <NumberField
+                    label="Bricks per batch"
+                    value={bt.bricks_per_batch}
+                    onChange={(v) => setBrick(i, "bricks_per_batch", v)}
+                    issue={issueFor(issues, `bt.${i}.bricks_per_batch`)}
+                    disabled={readOnly}
+                    step="0.5"
+                  />
+                  <NumberField
+                    label="Labour ₹ / batch"
+                    value={bt.labor_cost_per_batch}
+                    onChange={(v) => setBrick(i, "labor_cost_per_batch", v)}
+                    issue={issueFor(issues, `bt.${i}.labor_cost_per_batch`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Electricity ₹ / unit"
+                    value={bt.electricity_per_unit}
+                    onChange={(v) => setBrick(i, "electricity_per_unit", v)}
+                    issue={issueFor(issues, `bt.${i}.electricity_per_unit`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Depreciation ₹ / unit"
+                    value={bt.depreciation_per_unit}
+                    onChange={(v) => setBrick(i, "depreciation_per_unit", v)}
+                    issue={issueFor(issues, `bt.${i}.depreciation_per_unit`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Sales price ₹ / unit"
+                    value={bt.sales_price}
+                    onChange={(v) => setBrick(i, "sales_price", v)}
+                    issue={issueFor(issues, `bt.${i}.sales_price`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Loading / unloading ₹"
+                    value={bt.loading_unloading_per_unit}
+                    onChange={(v) => setBrick(i, "loading_unloading_per_unit", v)}
+                    issue={issueFor(issues, `bt.${i}.loading_unloading_per_unit`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Transport ₹ / unit"
+                    value={bt.transport_per_unit}
+                    onChange={(v) => setBrick(i, "transport_per_unit", v)}
+                    issue={issueFor(issues, `bt.${i}.transport_per_unit`)}
+                    disabled={readOnly}
+                  />
+                  <NumberField
+                    label="Commission ₹ / unit"
+                    value={bt.commission_per_unit}
+                    onChange={(v) => setBrick(i, "commission_per_unit", v)}
+                    issue={issueFor(issues, `bt.${i}.commission_per_unit`)}
+                    disabled={readOnly}
+                  />
+                </div>
+
+                <div>
+                  <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Recipe — kg per batch
+                  </h4>
+                  <div className="space-y-1.5">
+                    {bt.recipe.map((line, j) => (
+                      <div key={line.rm_key} className="flex items-center gap-2">
+                        <span className="w-32 shrink-0 text-sm text-slate-600">
+                          {form.rm_prices.find((rm) => rm.rm_key === line.rm_key)?.display_name ??
+                            line.rm_key}
+                        </span>
+                        <div className="w-32">
+                          <NumberField
+                            value={line.kg_per_batch}
+                            onChange={(v) => setRecipe(i, j, v)}
+                            issue={
+                              issueFor(issues, `bt.${i}.recipe.${j}.kg_per_batch`) ??
+                              issueFor(issues, `bt.${i}.recipe.${j}.rm_key`)
+                            }
+                            disabled={readOnly}
+                            step="0.001"
+                            suffix="kg"
+                          />
+                        </div>
+                        <span className="text-xs text-slate-400 tabular-nums">
+                          = {inr((Number(line.kg_per_batch) || 0) * (costPerKg.get(line.rm_key) ?? 0))}{" "}
+                          / batch
+                        </span>
+                        {readOnly ? null : (
+                          <button
+                            type="button"
+                            onClick={() => removeRecipeLine(i, j)}
+                            className="ml-auto text-xs text-red-500 hover:underline"
+                          >
+                            remove
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  {readOnly || unusedMaterials.length === 0 ? null : (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {unusedMaterials.map((key) => (
+                        <button
+                          key={key}
+                          type="button"
+                          onClick={() => addRecipeLine(i, key)}
+                          className="rounded-full border border-slate-200 px-2.5 py-1 text-xs text-slate-600 hover:border-orange-400 hover:text-orange-600"
+                        >
+                          + {form.rm_prices.find((rm) => rm.rm_key === key)?.display_name ?? key}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* ------------------------------------------ derived ------ */}
+              <div className="rounded-xl bg-slate-50 p-3">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Computed — not editable
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  <Derived label="Material / batch" value={c?.material_cost_per_batch ?? 0} />
+                  <Derived label="Material / unit" value={c?.material_cost_per_unit ?? 0} />
+                  <Derived label="Labour / unit" value={c?.labor_cost_per_unit ?? 0} />
+                  <Derived label="Overhead / unit" value={c?.overhead_per_unit ?? 0} />
+                  <Derived label="Variable / unit" value={c?.variable_cost_per_unit ?? 0} />
+                  <Derived label="Fixed / unit" value={c?.fixed_cost_per_unit ?? 0} />
+                  <Derived label="Total cost / unit" value={c?.total_cost_per_unit ?? 0} tone="strong" />
+                  <Derived
+                    label="Margin / unit"
+                    value={c?.margin_per_unit ?? null}
+                    tone={(c?.margin_per_unit ?? 0) < 0 ? "bad" : "good"}
+                    hint="Sales price − loading/unloading − transport − commission − total cost"
+                  />
+                  <DerivedCount label="Bricks / cement bag" value={c?.bricks_per_cement_bag ?? null} />
+                </div>
+                {c && c.missing_rm_keys.length > 0 ? (
+                  <p className="mt-2 text-xs text-red-600">
+                    Recipe uses materials with no price: {c.missing_rm_keys.join(", ")}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </SectionCard>
+        );
+      })}
+
+      {/* ---------------------------------------------------- fixed cost -- */}
+      <SectionCard
+        title="Monthly fixed costs"
+        subtitle="Spread evenly over the monthly production basis to give each brick its share."
+      >
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {form.fixed_items.map((item, i) => (
+            <div key={item.item_key} className="rounded-lg border border-slate-100 p-2">
+              <TextField
+                value={item.display_name}
+                onChange={(v) => setFixed(i, "display_name", v)}
+                issue={issueFor(issues, `fixed.${i}.display_name`)}
+              />
+              <div className="mt-1.5">
+                <NumberField
+                  value={item.monthly_amount}
+                  onChange={(v) => setFixed(i, "monthly_amount", v)}
+                  issue={issueFor(issues, `fixed.${i}.monthly_amount`)}
+                  disabled={readOnly}
+                  suffix="₹ / month"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          <NumberField
+            label="Monthly production basis (bricks)"
+            value={form.monthly_production_basis}
+            onChange={(v) => onChange((prev) => ({ ...prev, monthly_production_basis: v }))}
+            issue={issueFor(issues, "monthly_production_basis")}
+            disabled={readOnly}
+            step="100"
+          />
+          <Derived label="Total fixed / month" value={computed.monthly_fixed_total} />
+          <Derived label="Fixed cost / unit" value={computed.fixed_cost_per_unit} tone="strong" />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Notes" subtitle="Why this standard changed — shown alongside the version in history.">
+        <textarea
+          value={form.notes}
+          onChange={(e) => onChange((prev) => ({ ...prev, notes: e.target.value }))}
+          rows={3}
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900"
+          placeholder="e.g. Cement moved to ₹340 from the July purchase order."
+        />
+      </SectionCard>
+    </div>
+  );
+}

--- a/apps/web/src/components/unit-economics/DraftEditor.tsx
+++ b/apps/web/src/components/unit-economics/DraftEditor.tsx
@@ -109,6 +109,22 @@ export function DraftEditor({ form, computed, issues, onChange, readOnly = false
                       issue={issueFor(issues, `rm.${i}.display_name`)}
                     />
                     <span className="mt-0.5 block font-mono text-[11px] text-slate-400">{rm.rm_key}</span>
+                    <label className="mt-1 flex items-center gap-1.5 text-[11px] text-slate-500">
+                      <input
+                        type="checkbox"
+                        checked={rm.needs_verification}
+                        disabled={readOnly}
+                        onChange={(e) =>
+                          onChange((prev) => ({
+                            ...prev,
+                            rm_prices: prev.rm_prices.map((row, j) =>
+                              j === i ? { ...row, needs_verification: e.target.checked } : row,
+                            ),
+                          }))
+                        }
+                      />
+                      needs verification
+                    </label>
                   </td>
                   <td className="py-2 pr-3">
                     <NumberField
@@ -139,6 +155,13 @@ export function DraftEditor({ form, computed, issues, onChange, readOnly = false
                     <span className="inline-block rounded-lg bg-slate-100 px-3 py-1.5 font-semibold tabular-nums text-slate-700">
                       {inr(costPerKg.get(rm.rm_key) ?? 0, 4)}
                     </span>
+                    {rm.needs_verification ? (
+                      <span className="mt-1 block rounded-lg bg-amber-50 px-2 py-1 text-left text-[11px] text-amber-800">
+                        ⚠ Unconfirmed input.{" "}
+                        {rm.verification_note ||
+                          "Confirm the real figure, correct it here and publish — never adjust a formula to compensate."}
+                      </span>
+                    ) : null}
                   </td>
                 </tr>
               ))}

--- a/apps/web/src/components/unit-economics/HistoryPanel.tsx
+++ b/apps/web/src/components/unit-economics/HistoryPanel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+/**
+ * History (PRD §7.3): every published standard, read-only, with a diff between
+ * any two, and "use as new draft" for management.
+ */
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type {
+  ComputedBundle,
+  StdCostBundle,
+  StdCostDiffRow,
+  StdCostVersionSummary,
+} from "@maiyuri/shared";
+import { DiffTable } from "./DiffTable";
+import { SectionCard } from "./primitives";
+import { inr } from "./form";
+
+interface VersionResponse {
+  version: StdCostBundle;
+  computed: ComputedBundle;
+  diff: StdCostDiffRow[];
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: "no-store" });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Failed (${res.status})`);
+  return body.data as T;
+}
+
+export function HistoryPanel({
+  history,
+  canRevert,
+  onUseAsDraft,
+  revertPending,
+  revertError,
+}: {
+  history: StdCostVersionSummary[];
+  canRevert: boolean;
+  onUseAsDraft: (versionId: string) => void;
+  revertPending: boolean;
+  revertError: string | null;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(history[0]?.id ?? null);
+  const [compareId, setCompareId] = useState<string | null>(history[1]?.id ?? null);
+
+  const query = useQuery({
+    queryKey: ["unit-economics", "version", selectedId, compareId],
+    enabled: !!selectedId,
+    queryFn: () =>
+      getJson<VersionResponse>(
+        `/api/unit-economics/versions/${selectedId}${compareId ? `?compare=${compareId}` : ""}`,
+      ),
+  });
+
+  if (history.length === 0) {
+    return <p className="text-sm text-slate-400">No standard has been published yet.</p>;
+  }
+
+  const selected = history.find((version) => version.id === selectedId) ?? null;
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Published standards" subtitle="Newest first. Published versions are immutable.">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="py-1">Valid from</th>
+                <th className="py-1">Published</th>
+                <th className="py-1">By</th>
+                <th className="py-1">Notes</th>
+                <th className="py-1 text-right">View</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((version, index) => (
+                <tr
+                  key={version.id}
+                  className={`border-t border-slate-100 ${
+                    version.id === selectedId ? "bg-orange-50/60" : ""
+                  }`}
+                >
+                  <td className="py-1.5 pr-3 font-medium text-slate-800">
+                    {version.valid_from ?? "—"}
+                    {index === 0 ? (
+                      <span className="ml-2 rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                        in force
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1.5 pr-3 text-slate-500">
+                    {version.published_at ? version.published_at.slice(0, 10) : "—"}
+                  </td>
+                  <td className="py-1.5 pr-3 text-slate-500">{version.published_by_name ?? "—"}</td>
+                  <td className="py-1.5 pr-3 text-slate-500">{version.notes ?? "—"}</td>
+                  <td className="py-1.5 text-right">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedId(version.id)}
+                      className="text-xs font-medium text-orange-600 hover:underline"
+                    >
+                      open
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      {selected ? (
+        <SectionCard
+          title={`Standard from ${selected.valid_from ?? "—"}`}
+          subtitle="Read-only. Compare against any other published version."
+          actions={
+            canRevert ? (
+              <button
+                type="button"
+                onClick={() => onUseAsDraft(selected.id)}
+                disabled={revertPending}
+                className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-700 disabled:opacity-40"
+              >
+                {revertPending ? "Filling draft…" : "Use as new draft"}
+              </button>
+            ) : null
+          }
+        >
+          {revertError ? <p className="mb-2 text-sm text-red-600">{revertError}</p> : null}
+
+          <label className="mb-3 block text-sm">
+            <span className="mr-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              Compare with
+            </span>
+            <select
+              value={compareId ?? ""}
+              onChange={(e) => setCompareId(e.target.value || null)}
+              className="rounded-lg border border-slate-200 px-2 py-1 text-sm"
+            >
+              <option value="">— none —</option>
+              {history
+                .filter((version) => version.id !== selectedId)
+                .map((version) => (
+                  <option key={version.id} value={version.id}>
+                    {version.valid_from ?? version.id.slice(0, 8)}
+                  </option>
+                ))}
+            </select>
+          </label>
+
+          {query.isLoading ? (
+            <p className="text-sm text-slate-400">Loading…</p>
+          ) : query.isError ? (
+            <p className="text-sm text-red-600">
+              {query.error instanceof Error ? query.error.message : "Failed to load"}
+            </p>
+          ) : query.data ? (
+            <div className="space-y-4">
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[560px] text-sm">
+                  <thead>
+                    <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                      <th className="py-1">Brick type</th>
+                      <th className="py-1 text-right">Variable / unit</th>
+                      <th className="py-1 text-right">Fixed / unit</th>
+                      <th className="py-1 text-right">Total / unit</th>
+                      <th className="py-1 text-right">Margin / unit</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {query.data.computed.brick_types.map((bt) => (
+                      <tr key={bt.brick_type} className="border-t border-slate-100">
+                        <td className="py-1.5 pr-3 font-medium text-slate-800">{bt.brick_type}</td>
+                        <td className="py-1.5 text-right tabular-nums">{inr(bt.variable_cost_per_unit)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{inr(bt.fixed_cost_per_unit)}</td>
+                        <td className="py-1.5 text-right font-semibold tabular-nums">
+                          {inr(bt.total_cost_per_unit)}
+                        </td>
+                        <td className="py-1.5 text-right tabular-nums">{inr(bt.margin_per_unit)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {compareId ? (
+                <div>
+                  <h4 className="mb-2 text-sm font-semibold text-slate-800">What changed</h4>
+                  <DiffTable
+                    rows={query.data.diff}
+                    beforeLabel={
+                      history.find((version) => version.id === compareId)?.valid_from ?? "Other"
+                    }
+                    afterLabel={selected.valid_from ?? "This"}
+                    emptyMessage="These two versions are identical."
+                  />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </SectionCard>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/unit-economics/PublishPanel.tsx
+++ b/apps/web/src/components/unit-economics/PublishPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * Publish flow (PRD §7.2). Side-by-side diff against the currently published
+ * standard, a valid_from date, and a confirmation. Publishing freezes this
+ * draft and opens a fresh one copied from it.
+ *
+ * Blockers refuse the publish; warnings (>15% move) only ask for a second look.
+ */
+import { useState } from "react";
+import type { PublishBlocker, PublishWarning, StdCostDiffRow } from "@maiyuri/shared";
+import { DiffTable } from "./DiffTable";
+import { SectionCard } from "./primitives";
+
+export function PublishPanel({
+  diff,
+  blockers,
+  warnings,
+  publishedValidFrom,
+  canPublish,
+  dirty,
+  isPublishing,
+  errorMessage,
+  onPublish,
+}: {
+  diff: StdCostDiffRow[];
+  blockers: PublishBlocker[];
+  warnings: PublishWarning[];
+  publishedValidFrom: string | null;
+  canPublish: boolean;
+  dirty: boolean;
+  isPublishing: boolean;
+  errorMessage: string | null;
+  onPublish: (validFrom: string) => void;
+}) {
+  const today = new Date().toISOString().slice(0, 10);
+  const [validFrom, setValidFrom] = useState(today);
+  const [confirming, setConfirming] = useState(false);
+
+  // The standard must move forward in time, or the contract views would point
+  // at the wrong version.
+  const dateTooEarly = !!publishedValidFrom && validFrom <= publishedValidFrom;
+  const blocked = blockers.length > 0 || dateTooEarly || dirty || !canPublish;
+
+  return (
+    <div className="space-y-4">
+      {!canPublish ? (
+        <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          You can edit the draft, but only management publishes it as the standard.
+        </p>
+      ) : null}
+
+      {dirty ? (
+        <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          Save the draft before publishing — what gets published is what is stored.
+        </p>
+      ) : null}
+
+      {blockers.length > 0 ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-3">
+          <h3 className="text-sm font-semibold text-red-800">Cannot publish yet</h3>
+          <ul className="mt-1 list-disc pl-5 text-sm text-red-700">
+            {blockers.map((blocker, i) => (
+              <li key={i}>
+                {blocker.brick_type ? `${blocker.brick_type} — ` : ""}
+                {blocker.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {warnings.length > 0 ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+          <h3 className="text-sm font-semibold text-amber-900">Worth a second look</h3>
+          <ul className="mt-1 space-y-0.5 text-sm text-amber-800">
+            {warnings.map((warning, i) => (
+              <li key={i}>
+                {warning.label}: ₹{warning.previous} → ₹{warning.next} ({warning.change_pct > 0 ? "+" : ""}
+                {warning.change_pct}%)
+              </li>
+            ))}
+          </ul>
+          <p className="mt-1 text-xs text-amber-700">
+            A move this size is unusual but allowed — publish if the inputs are right.
+          </p>
+        </div>
+      ) : null}
+
+      <SectionCard
+        title="What changes when you publish"
+        subtitle={
+          publishedValidFrom
+            ? `Compared with the standard in force since ${publishedValidFrom}`
+            : "Nothing is published yet — this will be the first standard."
+        }
+      >
+        <DiffTable
+          rows={diff}
+          beforeLabel="Published"
+          afterLabel="Draft"
+          emptyMessage="The draft matches the published standard exactly — nothing to publish."
+        />
+      </SectionCard>
+
+      <SectionCard title="Publish" subtitle="The published version is immutable. A fresh draft opens automatically.">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="block">
+            <span className="mb-1 block text-xs font-medium text-slate-500">Takes effect from</span>
+            <input
+              type="date"
+              value={validFrom}
+              onChange={(e) => {
+                setValidFrom(e.target.value);
+                setConfirming(false);
+              }}
+              className={`rounded-lg border px-2 py-1.5 text-sm ${
+                dateTooEarly ? "border-red-400 bg-red-50" : "border-slate-200 bg-white"
+              }`}
+            />
+            {dateTooEarly ? (
+              <span className="mt-0.5 block text-xs text-red-600">
+                Must be after {publishedValidFrom}
+              </span>
+            ) : null}
+          </label>
+
+          {confirming ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => onPublish(validFrom)}
+                disabled={blocked || isPublishing}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+              >
+                {isPublishing ? "Publishing…" : "Yes, publish as the standard"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                className="text-sm text-slate-500 hover:underline"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirming(true)}
+              disabled={blocked || diff.length === 0}
+              className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40"
+            >
+              Publish…
+            </button>
+          )}
+        </div>
+
+        {confirming ? (
+          <p className="mt-2 text-sm text-slate-600">
+            This freezes the draft as the standard from {validFrom}. The Intelligence Layer picks it
+            up on its next read, and the numbers can never be edited afterwards.
+          </p>
+        ) : null}
+
+        {errorMessage ? <p className="mt-2 text-sm text-red-600">{errorMessage}</p> : null}
+      </SectionCard>
+    </div>
+  );
+}

--- a/apps/web/src/components/unit-economics/ReconciliationPanel.tsx
+++ b/apps/web/src/components/unit-economics/ReconciliationPanel.tsx
@@ -10,9 +10,11 @@
  */
 import { useState } from "react";
 import {
+  STD_COST_BREAKDOWN_TOLERANCE,
   STD_COST_ELEMENT_KEYS,
   STD_COST_ELEMENT_LABELS,
   STD_COST_REFERENCE_SOURCES,
+  type StdCostBreakdownStatus,
   type StdCostComponentVariance,
   type StdCostReference,
   type StdCostReferenceVariance,
@@ -173,6 +175,43 @@ function ReferenceCard({
         <div className="mt-2 space-y-3 border-t border-slate-100 pt-2">
           {variance.has_component_breakdown ? (
             <>
+              <div className="rounded-lg bg-slate-50 px-3 py-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-slate-600">
+                    Breakdown coverage
+                    <span
+                      className={`ml-2 rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                        variance.breakdown_status === "complete"
+                          ? "bg-emerald-100 text-emerald-800"
+                          : "bg-slate-200 text-slate-600"
+                      }`}
+                    >
+                      {variance.breakdown_status}
+                    </span>
+                  </span>
+                  <span className="font-semibold tabular-nums text-slate-800">
+                    {inr(variance.breakdown_coverage)} / {inr(variance.reference_cost)}
+                    {variance.breakdown_coverage_pct === null
+                      ? ""
+                      : ` (${variance.breakdown_coverage_pct}%)`}
+                  </span>
+                </div>
+                <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
+                  <div
+                    className="h-full rounded-full bg-slate-500"
+                    style={{
+                      width: `${Math.min(100, Math.max(0, variance.breakdown_coverage_pct ?? 0))}%`,
+                    }}
+                  />
+                </div>
+                {variance.breakdown_status === "partial" ? (
+                  <p className="mt-1 text-xs text-slate-500">
+                    Partial breakdown — the rest of the benchmark is still unaccounted for, so the
+                    unexplained figure below stays live.
+                  </p>
+                ) : null}
+              </div>
+
               <ComponentRows title="By cost element" rows={variance.cost_elements} />
               <ComponentRows
                 title="Raw materials"
@@ -189,14 +228,23 @@ function ReferenceCard({
           ) : (
             <p className="text-sm text-slate-500">
               No component breakdown has been recorded for this benchmark, so none of the
-              difference is attributed yet. Add one when the underlying figures are known — the
-              gap stays fully unexplained until then, on purpose.
+              difference is attributed yet. Add components as you discover them — each one shrinks
+              the unexplained figure below, and the rest stays unexplained until it is genuinely
+              accounted for.
             </p>
           )}
 
-          <div className="flex items-center justify-between rounded-lg bg-amber-50 px-3 py-2 text-sm">
-            <span className="text-amber-900">Unexplained</span>
-            <span className="font-semibold tabular-nums text-amber-900">
+          <div
+            className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm ${
+              variance.unexplained_difference === 0
+                ? "bg-emerald-50 text-emerald-800"
+                : "bg-amber-50 text-amber-900"
+            }`}
+          >
+            <span>
+              {variance.unexplained_difference === 0 ? "Fully explained" : "Still unexplained"}
+            </span>
+            <span className="font-semibold tabular-nums">
               {inr(variance.unexplained_difference)}
             </span>
           </div>
@@ -226,6 +274,8 @@ function AddReferenceForm({
   const [date, setDate] = useState(today);
   const [notes, setNotes] = useState("");
   const [components, setComponents] = useState<Record<string, string>>({});
+  const [breakdownStatus, setBreakdownStatus] =
+    useState<StdCostBreakdownStatus>("partial");
 
   if (!open) {
     return (
@@ -248,9 +298,19 @@ function AddReferenceForm({
   );
   const componentSum = componentRows.reduce((sum, row) => sum + row.amount, 0);
   const costNumber = Number(cost);
-  const breakdownMismatch =
-    componentRows.length > 0 && Math.abs(componentSum - costNumber) > 0.01;
-  const invalid = !brickType || cost.trim() === "" || !Number.isFinite(costNumber) || breakdownMismatch;
+  // Over the total is always wrong; short of it is only wrong when the
+  // breakdown claims to be complete.
+  const overTotal =
+    componentRows.length > 0 && componentSum > costNumber + STD_COST_BREAKDOWN_TOLERANCE;
+  const incompleteButClaimed =
+    breakdownStatus === "complete" &&
+    Math.abs(componentSum - costNumber) > STD_COST_BREAKDOWN_TOLERANCE;
+  const invalid =
+    !brickType ||
+    cost.trim() === "" ||
+    !Number.isFinite(costNumber) ||
+    overTotal ||
+    incompleteButClaimed;
 
   return (
     <div className="space-y-3 rounded-xl border border-slate-200 p-3">
@@ -352,12 +412,34 @@ function AddReferenceForm({
           ))}
         </div>
         {componentRows.length > 0 ? (
-          <p
-            className={`mt-1 text-xs ${breakdownMismatch ? "text-red-600" : "text-slate-500"}`}
-          >
-            Breakdown adds up to {inr(componentSum)}
-            {breakdownMismatch ? ` — but the reference cost is ${inr(costNumber)}` : " ✓"}
-          </p>
+          <div className="mt-2 space-y-1">
+            <p
+              className={`text-xs ${
+                overTotal || incompleteButClaimed ? "text-red-600" : "text-slate-500"
+              }`}
+            >
+              Covers {inr(componentSum)} of {inr(Number.isFinite(costNumber) ? costNumber : 0)}
+              {overTotal
+                ? " — a breakdown cannot exceed the total it splits"
+                : incompleteButClaimed
+                  ? ` — marked complete, but ${inr(costNumber - componentSum)} is unaccounted for`
+                  : ""}
+            </p>
+            <label className="flex items-center gap-1.5 text-xs text-slate-600">
+              <input
+                type="checkbox"
+                checked={breakdownStatus === "complete"}
+                onChange={(e) => setBreakdownStatus(e.target.checked ? "complete" : "partial")}
+              />
+              This breakdown is complete — it accounts for the whole benchmark
+            </label>
+            {breakdownStatus === "partial" ? (
+              <p className="text-xs text-slate-400">
+                Leaving it partial is normal. Whatever the components don&apos;t cover stays
+                visible as unexplained variance rather than being quietly absorbed.
+              </p>
+            ) : null}
+          </div>
         ) : null}
       </div>
 
@@ -376,6 +458,7 @@ function AddReferenceForm({
               reference_date: date,
               notes: notes || null,
               is_active: true,
+              breakdown_status: breakdownStatus,
               components: componentRows,
             })
           }

--- a/apps/web/src/components/unit-economics/ReconciliationPanel.tsx
+++ b/apps/web/src/components/unit-economics/ReconciliationPanel.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+/**
+ * Cost Reconciliation — computed standard vs stored benchmarks.
+ *
+ * This screen only ever SHOWS a difference. There is no control here that
+ * changes a computed cost, because the way to move a computed cost is to
+ * correct a business input in the draft and publish it. A variance is a
+ * question to answer, not a number to close.
+ */
+import { useState } from "react";
+import {
+  STD_COST_ELEMENT_KEYS,
+  STD_COST_ELEMENT_LABELS,
+  STD_COST_REFERENCE_SOURCES,
+  type StdCostComponentVariance,
+  type StdCostReference,
+  type StdCostReferenceVariance,
+} from "@maiyuri/shared";
+import { SectionCard } from "./primitives";
+import { inr } from "./form";
+
+const sourceLabel = (source: string) =>
+  STD_COST_REFERENCE_SOURCES.find((entry) => entry.value === source)?.label ?? source;
+
+function VarianceHeadline({ variance }: { variance: StdCostReferenceVariance }) {
+  const below = variance.variance_amount < 0;
+  return (
+    <div className="grid gap-2 sm:grid-cols-3">
+      <div className="rounded-lg bg-slate-900 px-3 py-2 text-white">
+        <div className="text-[11px] font-medium uppercase tracking-wide opacity-70">
+          Computed cost
+        </div>
+        <div className="text-base font-semibold tabular-nums">
+          {inr(variance.computed_cost_per_unit)}
+        </div>
+      </div>
+      <div className="rounded-lg bg-slate-100 px-3 py-2 text-slate-700">
+        <div className="text-[11px] font-medium uppercase tracking-wide opacity-70">
+          {sourceLabel(variance.source)}
+        </div>
+        <div className="text-base font-semibold tabular-nums">{inr(variance.reference_cost)}</div>
+      </div>
+      <div
+        className={`rounded-lg px-3 py-2 ${
+          variance.is_significant
+            ? "bg-amber-100 text-amber-900"
+            : below
+              ? "bg-emerald-50 text-emerald-800"
+              : "bg-slate-100 text-slate-700"
+        }`}
+      >
+        <div className="text-[11px] font-medium uppercase tracking-wide opacity-70">Variance</div>
+        <div className="text-base font-semibold tabular-nums">
+          {variance.variance_amount < 0 ? "−" : "+"}
+          {inr(Math.abs(variance.variance_amount))}
+          {variance.variance_pct === null
+            ? ""
+            : ` (${variance.variance_pct > 0 ? "+" : ""}${variance.variance_pct}%)`}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ComponentRows({
+  title,
+  rows,
+  note,
+}: {
+  title: string;
+  rows: StdCostComponentVariance[];
+  note?: string;
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">{title}</h4>
+      {note ? <p className="mb-1 text-xs text-slate-400">{note}</p> : null}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+            <th className="py-1">Component</th>
+            <th className="py-1 text-right">Benchmark</th>
+            <th className="py-1 text-right">Computed</th>
+            <th className="py-1 text-right">Difference</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`${row.component_kind}-${row.component_key}`} className="border-t border-slate-100">
+              <td className="py-1.5 text-slate-600">{row.label}</td>
+              <td className="py-1.5 text-right tabular-nums text-slate-500">
+                {inr(row.reference_amount)}
+              </td>
+              <td className="py-1.5 text-right tabular-nums text-slate-500">
+                {row.computed_amount === null ? "—" : inr(row.computed_amount)}
+              </td>
+              <td
+                className={`py-1.5 text-right font-semibold tabular-nums ${
+                  row.difference === null
+                    ? "text-slate-400"
+                    : row.difference < 0
+                      ? "text-emerald-700"
+                      : "text-red-600"
+                }`}
+              >
+                {row.difference === null
+                  ? "not matched"
+                  : `${row.difference < 0 ? "−" : "+"}${inr(Math.abs(row.difference))}`}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReferenceCard({
+  variance,
+  onDeactivate,
+  deactivating,
+}: {
+  variance: StdCostReferenceVariance;
+  onDeactivate: (referenceId: string) => void;
+  deactivating: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-xl border border-slate-200 p-3">
+      <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 className="font-semibold text-slate-900">{variance.brick_type}</h3>
+          <p className="text-xs text-slate-500">
+            {sourceLabel(variance.source)}
+            {variance.source_label ? ` · ${variance.source_label}` : ""} ·{" "}
+            {variance.reference_date}
+          </p>
+        </div>
+        {variance.reference_id ? (
+          <button
+            type="button"
+            onClick={() => onDeactivate(variance.reference_id as string)}
+            disabled={deactivating}
+            className="text-xs text-slate-400 hover:text-red-600 hover:underline disabled:opacity-40"
+          >
+            stop comparing
+          </button>
+        ) : null}
+      </div>
+
+      <VarianceHeadline variance={variance} />
+
+      {variance.is_significant ? (
+        <p className="mt-2 rounded-lg bg-amber-50 px-3 py-1.5 text-sm text-amber-800">
+          ⚠ Significant variance — worth explaining before anyone quotes from either number.
+        </p>
+      ) : null}
+
+      {variance.notes ? <p className="mt-2 text-xs text-slate-500">{variance.notes}</p> : null}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((previous) => !previous)}
+        className="mt-2 text-sm font-medium text-orange-600 hover:underline"
+      >
+        {expanded ? "Hide breakdown" : "Where does the difference come from?"}
+      </button>
+
+      {expanded ? (
+        <div className="mt-2 space-y-3 border-t border-slate-100 pt-2">
+          {variance.has_component_breakdown ? (
+            <>
+              <ComponentRows title="By cost element" rows={variance.cost_elements} />
+              <ComponentRows
+                title="Raw materials"
+                rows={variance.raw_materials}
+                note="Inside the raw-material element above — shown for detail, not added again."
+              />
+              <div className="flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-sm">
+                <span className="text-slate-600">Explained by the breakdown</span>
+                <span className="font-semibold tabular-nums text-slate-800">
+                  {inr(variance.explained_difference)}
+                </span>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-slate-500">
+              No component breakdown has been recorded for this benchmark, so none of the
+              difference is attributed yet. Add one when the underlying figures are known — the
+              gap stays fully unexplained until then, on purpose.
+            </p>
+          )}
+
+          <div className="flex items-center justify-between rounded-lg bg-amber-50 px-3 py-2 text-sm">
+            <span className="text-amber-900">Unexplained</span>
+            <span className="font-semibold tabular-nums text-amber-900">
+              {inr(variance.unexplained_difference)}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AddReferenceForm({
+  brickTypes,
+  onSave,
+  saving,
+  errorMessage,
+}: {
+  brickTypes: string[];
+  onSave: (reference: StdCostReference) => void;
+  saving: boolean;
+  errorMessage: string | null;
+}) {
+  const today = new Date().toISOString().slice(0, 10);
+  const [open, setOpen] = useState(false);
+  const [brickType, setBrickType] = useState(brickTypes[0] ?? "");
+  const [cost, setCost] = useState("");
+  const [source, setSource] = useState<StdCostReference["source"]>("manual_benchmark");
+  const [sourceLabelText, setSourceLabelText] = useState("");
+  const [date, setDate] = useState(today);
+  const [notes, setNotes] = useState("");
+  const [components, setComponents] = useState<Record<string, string>>({});
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-700"
+      >
+        + Add a benchmark
+      </button>
+    );
+  }
+
+  const componentRows = STD_COST_ELEMENT_KEYS.filter((key) => (components[key] ?? "") !== "").map(
+    (key) => ({
+      component_kind: "cost_element" as const,
+      component_key: key,
+      amount: Number(components[key]),
+    }),
+  );
+  const componentSum = componentRows.reduce((sum, row) => sum + row.amount, 0);
+  const costNumber = Number(cost);
+  const breakdownMismatch =
+    componentRows.length > 0 && Math.abs(componentSum - costNumber) > 0.01;
+  const invalid = !brickType || cost.trim() === "" || !Number.isFinite(costNumber) || breakdownMismatch;
+
+  return (
+    <div className="space-y-3 rounded-xl border border-slate-200 p-3">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Brick type</span>
+          <select
+            value={brickType}
+            onChange={(e) => setBrickType(e.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          >
+            {brickTypes.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Reference cost ₹/unit</span>
+          <input
+            type="number"
+            step="0.01"
+            value={cost}
+            onChange={(e) => setCost(e.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Source</span>
+          <select
+            value={source}
+            onChange={(e) => setSource(e.target.value as StdCostReference["source"])}
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          >
+            {STD_COST_REFERENCE_SOURCES.map((entry) => (
+              <option key={entry.value} value={entry.value}>
+                {entry.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Source name</span>
+          <input
+            type="text"
+            value={sourceLabelText}
+            onChange={(e) => setSourceLabelText(e.target.value)}
+            placeholder="e.g. Mb Unit Economics sheet"
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Reference date</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block sm:col-span-2 lg:col-span-3">
+          <span className="mb-1 block text-xs font-medium text-slate-500">Notes</span>
+          <input
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Where this number came from, and what it is meant to represent"
+            className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+          />
+        </label>
+      </div>
+
+      <div>
+        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Component breakdown (optional)
+        </h4>
+        <p className="mb-2 text-xs text-slate-400">
+          Fill these in only if you know the benchmark&apos;s own split. They must add up to the
+          reference cost — a breakdown that does not is worse than none, because the residual it
+          leaves would be meaningless.
+        </p>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {STD_COST_ELEMENT_KEYS.map((key) => (
+            <label key={key} className="block">
+              <span className="mb-1 block text-xs font-medium text-slate-500">
+                {STD_COST_ELEMENT_LABELS[key]}
+              </span>
+              <input
+                type="number"
+                step="0.01"
+                value={components[key] ?? ""}
+                onChange={(e) =>
+                  setComponents((previous) => ({ ...previous, [key]: e.target.value }))
+                }
+                className="w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm"
+              />
+            </label>
+          ))}
+        </div>
+        {componentRows.length > 0 ? (
+          <p
+            className={`mt-1 text-xs ${breakdownMismatch ? "text-red-600" : "text-slate-500"}`}
+          >
+            Breakdown adds up to {inr(componentSum)}
+            {breakdownMismatch ? ` — but the reference cost is ${inr(costNumber)}` : " ✓"}
+          </p>
+        ) : null}
+      </div>
+
+      {errorMessage ? <p className="text-sm text-red-600">{errorMessage}</p> : null}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={invalid || saving}
+          onClick={() =>
+            onSave({
+              brick_type: brickType,
+              reference_cost: costNumber,
+              source,
+              source_label: sourceLabelText || null,
+              reference_date: date,
+              notes: notes || null,
+              is_active: true,
+              components: componentRows,
+            })
+          }
+          className="rounded-lg bg-slate-900 px-4 py-1.5 text-sm font-semibold text-white disabled:opacity-40"
+        >
+          {saving ? "Saving…" : "Save benchmark"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-sm text-slate-500 hover:underline"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ReconciliationPanel({
+  variances,
+  brickTypes,
+  publishedValidFrom,
+  isDraftPreview,
+  onSaveReference,
+  onDeactivateReference,
+  saving,
+  deactivating,
+  errorMessage,
+}: {
+  variances: StdCostReferenceVariance[];
+  brickTypes: string[];
+  publishedValidFrom: string | null;
+  isDraftPreview: boolean;
+  onSaveReference: (reference: StdCostReference) => void;
+  onDeactivateReference: (referenceId: string) => void;
+  saving: boolean;
+  deactivating: boolean;
+  errorMessage: string | null;
+}) {
+  const significant = variances.filter((variance) => variance.is_significant);
+
+  return (
+    <div className="space-y-4">
+      <SectionCard
+        title="Cost reconciliation"
+        subtitle={
+          isDraftPreview
+            ? "Your unsaved draft against the stored benchmarks."
+            : publishedValidFrom
+              ? `The standard in force since ${publishedValidFrom}, against the stored benchmarks.`
+              : "Nothing is published yet."
+        }
+        actions={
+          <AddReferenceForm
+            brickTypes={brickTypes}
+            onSave={onSaveReference}
+            saving={saving}
+            errorMessage={errorMessage}
+          />
+        }
+      >
+        <p className="mb-3 text-sm text-slate-500">
+          Benchmarks are stored separately from the standard and never feed into it. A difference
+          here is a question to answer — the only way to move a computed cost is to correct a
+          business input in the draft and publish it.
+        </p>
+
+        {significant.length > 0 ? (
+          <p className="mb-3 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            ⚠ {significant.length} of {variances.length} benchmarks differ by more than 10%:{" "}
+            {significant.map((variance) => variance.brick_type).join(", ")}.
+          </p>
+        ) : null}
+
+        {variances.length === 0 ? (
+          <p className="text-sm text-slate-400">
+            No benchmarks recorded yet. Add one to reconcile the computed standard against a legacy
+            or external number.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {variances.map((variance) => (
+              <ReferenceCard
+                key={`${variance.brick_type}-${variance.reference_id ?? variance.reference_date}`}
+                variance={variance}
+                onDeactivate={onDeactivateReference}
+                deactivating={deactivating}
+              />
+            ))}
+          </div>
+        )}
+      </SectionCard>
+    </div>
+  );
+}

--- a/apps/web/src/components/unit-economics/form.test.ts
+++ b/apps/web/src/components/unit-economics/form.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { computeBundle, type StdCostBundle, type StdCostVersion } from "@maiyuri/shared";
+import { inr, issueFor, toBundle, toForm, toNumber, toPayload, validateForm } from "./form";
+
+const version: StdCostVersion = {
+  id: "11111111-1111-1111-1111-111111111111",
+  status: "draft",
+  valid_from: null,
+  monthly_production_basis: 15000,
+  notes: null,
+  created_by: null,
+  created_at: "2026-08-22T00:00:00Z",
+  updated_by: null,
+  updated_at: "2026-08-22T00:00:00Z",
+  published_by: null,
+  published_at: null,
+};
+
+const bundle: StdCostBundle = {
+  version,
+  rm_prices: [
+    { rm_key: "cement", display_name: "Cement", purchase_amount: 320, purchase_unit_label: "50 Kg Bag", purchase_unit_kg: 50 },
+  ],
+  fixed_items: [{ item_key: "rent", display_name: "Rent", monthly_amount: 2500 }],
+  brick_types: [
+    {
+      brick_type: "8 CIB",
+      odoo_product_match: "CIB-10*8*5%",
+      bricks_per_batch: 9,
+      labor_cost_per_batch: 63,
+      electricity_per_unit: 1,
+      depreciation_per_unit: 1,
+      sales_price: 54,
+      loading_unloading_per_unit: 3,
+      transport_per_unit: 3,
+      commission_per_unit: 1,
+      recipe: [{ rm_key: "cement", kg_per_batch: 8.5 }],
+    },
+  ],
+};
+
+describe("toForm / toBundle round trip", () => {
+  it("survives the trip unchanged", () => {
+    const round = toBundle(toForm(bundle), version);
+    expect(round.rm_prices).toEqual(bundle.rm_prices);
+    expect(round.fixed_items).toEqual(bundle.fixed_items);
+    expect(round.brick_types[0]).toMatchObject({
+      brick_type: "8 CIB",
+      bricks_per_batch: 9,
+      sales_price: 54,
+      recipe: [{ rm_key: "cement", kg_per_batch: 8.5 }],
+    });
+  });
+
+  it("keeps an empty sales price as null rather than 0", () => {
+    const form = toForm(bundle);
+    form.brick_types[0].sales_price = "";
+    expect(toBundle(form, version).brick_types[0].sales_price).toBeNull();
+  });
+
+  it("computes live from a half-typed field without producing NaN", () => {
+    const form = toForm(bundle);
+    form.rm_prices[0].purchase_amount = ""; // mid-keystroke
+    const computed = computeBundle(toBundle(form, version));
+    expect(computed.rm_prices[0].cost_per_kg).toBe(0);
+    expect(Number.isFinite(computed.brick_types[0].total_cost_per_unit)).toBe(true);
+  });
+
+  it("builds a payload the API schema accepts", () => {
+    const payload = toPayload(toForm(bundle), version);
+    expect(payload.version_id).toBe(version.id);
+    expect(payload.monthly_production_basis).toBe(15000);
+    expect(payload.brick_types[0].sort_order).toBe(0);
+  });
+});
+
+describe("toNumber", () => {
+  it("treats empty and unparseable input as 0", () => {
+    expect(toNumber("")).toBe(0);
+    expect(toNumber("  ")).toBe(0);
+    expect(toNumber("abc")).toBe(0);
+  });
+  it("parses real numbers", () => {
+    expect(toNumber("8.5")).toBe(8.5);
+    expect(toNumber("-2")).toBe(-2);
+  });
+});
+
+describe("validateForm", () => {
+  it("passes a complete form", () => {
+    expect(validateForm(toForm(bundle))).toEqual([]);
+  });
+
+  it("requires a positive production basis — it is a divisor", () => {
+    const form = toForm(bundle);
+    form.monthly_production_basis = "0";
+    expect(issueFor(validateForm(form), "monthly_production_basis")).toContain("greater than 0");
+  });
+
+  it("requires a positive unit weight", () => {
+    const form = toForm(bundle);
+    form.rm_prices[0].purchase_unit_kg = "0";
+    expect(issueFor(validateForm(form), "rm.0.purchase_unit_kg")).toContain("greater than 0");
+  });
+
+  it("rejects a negative cost", () => {
+    const form = toForm(bundle);
+    form.fixed_items[0].monthly_amount = "-1";
+    expect(issueFor(validateForm(form), "fixed.0.monthly_amount")).toContain("negative");
+  });
+
+  it("flags an empty required field instead of silently saving 0", () => {
+    const form = toForm(bundle);
+    form.brick_types[0].bricks_per_batch = "";
+    expect(issueFor(validateForm(form), "bt.0.bricks_per_batch")).toContain("required");
+  });
+
+  it("flags a recipe line whose material has no price row", () => {
+    const form = toForm(bundle);
+    form.brick_types[0].recipe.push({ rm_key: "ghost_sand", kg_per_batch: "5" });
+    expect(issueFor(validateForm(form), "bt.0.recipe.1.rm_key")).toContain("ghost_sand");
+  });
+
+  it("accepts an empty sales price (not every type is priced)", () => {
+    const form = toForm(bundle);
+    form.brick_types[0].sales_price = "";
+    expect(validateForm(form)).toEqual([]);
+  });
+});
+
+describe("inr", () => {
+  it("formats to 2 dp by default", () => {
+    expect(inr(27.0564)).toBe("₹27.06");
+  });
+  it("renders a dash rather than NaN for a missing value", () => {
+    expect(inr(null)).toBe("—");
+    expect(inr(Number.NaN)).toBe("—");
+  });
+});

--- a/apps/web/src/components/unit-economics/form.test.ts
+++ b/apps/web/src/components/unit-economics/form.test.ts
@@ -42,7 +42,15 @@ const bundle: StdCostBundle = {
 describe("toForm / toBundle round trip", () => {
   it("survives the trip unchanged", () => {
     const round = toBundle(toForm(bundle), version);
-    expect(round.rm_prices).toEqual(bundle.rm_prices);
+    // The round trip normalises the optional verification fields to explicit
+    // defaults; every typed value must come back identical.
+    expect(round.rm_prices).toEqual(
+      bundle.rm_prices.map((rm) => ({
+        ...rm,
+        needs_verification: false,
+        verification_note: null,
+      })),
+    );
     expect(round.fixed_items).toEqual(bundle.fixed_items);
     expect(round.brick_types[0]).toMatchObject({
       brick_type: "8 CIB",
@@ -71,6 +79,42 @@ describe("toForm / toBundle round trip", () => {
     expect(payload.version_id).toBe(version.id);
     expect(payload.monthly_production_basis).toBe(15000);
     expect(payload.brick_types[0].sort_order).toBe(0);
+  });
+});
+
+describe("verification flags", () => {
+  it("carries an unconfirmed-input flag through the form round trip", () => {
+    const flagged: StdCostBundle = {
+      ...bundle,
+      rm_prices: [
+        {
+          ...bundle.rm_prices[0],
+          needs_verification: true,
+          verification_note: "Load weight unconfirmed",
+        },
+      ],
+    };
+    const round = toBundle(toForm(flagged), version);
+    expect(round.rm_prices[0].needs_verification).toBe(true);
+    expect(round.rm_prices[0].verification_note).toBe("Load weight unconfirmed");
+  });
+
+  it("defaults to unflagged when the field is absent", () => {
+    const round = toBundle(toForm(bundle), version);
+    expect(round.rm_prices[0].needs_verification).toBe(false);
+    expect(round.rm_prices[0].verification_note).toBeNull();
+  });
+
+  it("does not change any computed number", () => {
+    // A flag records doubt about an input; it must never alter how that input
+    // is used, or the flag itself would become a balancing adjustment.
+    const flagged: StdCostBundle = {
+      ...bundle,
+      rm_prices: [{ ...bundle.rm_prices[0], needs_verification: true }],
+    };
+    expect(computeBundle(flagged).brick_types[0].total_cost_per_unit).toBe(
+      computeBundle(bundle).brick_types[0].total_cost_per_unit,
+    );
   });
 });
 

--- a/apps/web/src/components/unit-economics/form.ts
+++ b/apps/web/src/components/unit-economics/form.ts
@@ -18,6 +18,9 @@ export interface RmPriceForm {
   purchase_amount: string;
   purchase_unit_label: string;
   purchase_unit_kg: string;
+  /** In use but unconfirmed — carried through saves and publishes untouched. */
+  needs_verification: boolean;
+  verification_note: string;
 }
 
 export interface RecipeLineForm {
@@ -68,6 +71,8 @@ export function toForm(bundle: StdCostBundle): DraftForm {
       purchase_amount: str(rm.purchase_amount),
       purchase_unit_label: rm.purchase_unit_label,
       purchase_unit_kg: str(rm.purchase_unit_kg),
+      needs_verification: rm.needs_verification === true,
+      verification_note: rm.verification_note ?? "",
     })),
     brick_types: (bundle.brick_types ?? []).map((bt) => ({
       brick_type: bt.brick_type,
@@ -118,6 +123,8 @@ export function toBundle(form: DraftForm, version: StdCostVersion): StdCostBundl
       purchase_amount: toNumber(rm.purchase_amount),
       purchase_unit_label: rm.purchase_unit_label,
       purchase_unit_kg: toNumber(rm.purchase_unit_kg),
+      needs_verification: rm.needs_verification,
+      verification_note: rm.verification_note || null,
     })),
     brick_types: form.brick_types.map((bt, index) => ({
       brick_type: bt.brick_type,

--- a/apps/web/src/components/unit-economics/form.ts
+++ b/apps/web/src/components/unit-economics/form.ts
@@ -1,0 +1,244 @@
+/**
+ * Draft form model for the Standard Costs editor.
+ *
+ * Inputs are held as STRINGS while editing (so a field can be empty
+ * mid-keystroke without becoming 0 or NaN) and converted to numbers only when
+ * computing or saving. Only the fields a person types live here — every
+ * derived number comes from computeBundle() in @maiyuri/shared.
+ */
+import type {
+  StdCostBundle,
+  StdCostDraftPayload,
+  StdCostVersion,
+} from "@maiyuri/shared";
+
+export interface RmPriceForm {
+  rm_key: string;
+  display_name: string;
+  purchase_amount: string;
+  purchase_unit_label: string;
+  purchase_unit_kg: string;
+}
+
+export interface RecipeLineForm {
+  rm_key: string;
+  kg_per_batch: string;
+}
+
+export interface BrickTypeForm {
+  brick_type: string;
+  odoo_product_match: string;
+  bricks_per_batch: string;
+  labor_cost_per_batch: string;
+  electricity_per_unit: string;
+  depreciation_per_unit: string;
+  sales_price: string;
+  loading_unloading_per_unit: string;
+  transport_per_unit: string;
+  commission_per_unit: string;
+  recipe: RecipeLineForm[];
+}
+
+export interface FixedItemForm {
+  item_key: string;
+  display_name: string;
+  monthly_amount: string;
+}
+
+export interface DraftForm {
+  version_id: string;
+  monthly_production_basis: string;
+  notes: string;
+  rm_prices: RmPriceForm[];
+  brick_types: BrickTypeForm[];
+  fixed_items: FixedItemForm[];
+}
+
+const str = (value: number | null | undefined): string =>
+  value === null || value === undefined ? "" : String(value);
+
+export function toForm(bundle: StdCostBundle): DraftForm {
+  return {
+    version_id: bundle.version.id,
+    monthly_production_basis: str(bundle.version.monthly_production_basis),
+    notes: bundle.version.notes ?? "",
+    rm_prices: (bundle.rm_prices ?? []).map((rm) => ({
+      rm_key: rm.rm_key,
+      display_name: rm.display_name,
+      purchase_amount: str(rm.purchase_amount),
+      purchase_unit_label: rm.purchase_unit_label,
+      purchase_unit_kg: str(rm.purchase_unit_kg),
+    })),
+    brick_types: (bundle.brick_types ?? []).map((bt) => ({
+      brick_type: bt.brick_type,
+      odoo_product_match: bt.odoo_product_match,
+      bricks_per_batch: str(bt.bricks_per_batch),
+      labor_cost_per_batch: str(bt.labor_cost_per_batch),
+      electricity_per_unit: str(bt.electricity_per_unit),
+      depreciation_per_unit: str(bt.depreciation_per_unit),
+      sales_price: str(bt.sales_price),
+      loading_unloading_per_unit: str(bt.loading_unloading_per_unit),
+      transport_per_unit: str(bt.transport_per_unit),
+      commission_per_unit: str(bt.commission_per_unit),
+      recipe: (bt.recipe ?? []).map((line) => ({
+        rm_key: line.rm_key,
+        kg_per_batch: str(line.kg_per_batch),
+      })),
+    })),
+    fixed_items: (bundle.fixed_items ?? []).map((item) => ({
+      item_key: item.item_key,
+      display_name: item.display_name,
+      monthly_amount: str(item.monthly_amount),
+    })),
+  };
+}
+
+/** Empty or unparseable reads as 0 for computing — never NaN on screen. */
+export function toNumber(value: string): number {
+  if (value.trim() === "") return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toNullableNumber(value: string): number | null {
+  return value.trim() === "" ? null : toNumber(value);
+}
+
+/** Form → the shape computeBundle() and the diff understand. */
+export function toBundle(form: DraftForm, version: StdCostVersion): StdCostBundle {
+  return {
+    version: {
+      ...version,
+      monthly_production_basis: toNumber(form.monthly_production_basis),
+      notes: form.notes || null,
+    },
+    rm_prices: form.rm_prices.map((rm) => ({
+      rm_key: rm.rm_key,
+      display_name: rm.display_name,
+      purchase_amount: toNumber(rm.purchase_amount),
+      purchase_unit_label: rm.purchase_unit_label,
+      purchase_unit_kg: toNumber(rm.purchase_unit_kg),
+    })),
+    brick_types: form.brick_types.map((bt, index) => ({
+      brick_type: bt.brick_type,
+      odoo_product_match: bt.odoo_product_match,
+      bricks_per_batch: toNumber(bt.bricks_per_batch),
+      labor_cost_per_batch: toNumber(bt.labor_cost_per_batch),
+      electricity_per_unit: toNumber(bt.electricity_per_unit),
+      depreciation_per_unit: toNumber(bt.depreciation_per_unit),
+      sales_price: toNullableNumber(bt.sales_price),
+      loading_unloading_per_unit: toNumber(bt.loading_unloading_per_unit),
+      transport_per_unit: toNumber(bt.transport_per_unit),
+      commission_per_unit: toNumber(bt.commission_per_unit),
+      sort_order: index,
+      recipe: bt.recipe.map((line) => ({
+        rm_key: line.rm_key,
+        kg_per_batch: toNumber(line.kg_per_batch),
+      })),
+    })),
+    fixed_items: form.fixed_items.map((item) => ({
+      item_key: item.item_key,
+      display_name: item.display_name,
+      monthly_amount: toNumber(item.monthly_amount),
+    })),
+  };
+}
+
+/** Form → the PUT body. */
+export function toPayload(form: DraftForm, version: StdCostVersion): StdCostDraftPayload {
+  const bundle = toBundle(form, version);
+  return {
+    version_id: form.version_id,
+    monthly_production_basis: Math.round(toNumber(form.monthly_production_basis)),
+    notes: form.notes || null,
+    rm_prices: bundle.rm_prices,
+    brick_types: bundle.brick_types,
+    fixed_items: bundle.fixed_items,
+  };
+}
+
+export interface FieldIssue {
+  path: string;
+  message: string;
+}
+
+/**
+ * Inline validation — the same rules the CHECK constraints enforce, said in
+ * words at the field instead of as a Postgres error after saving.
+ */
+export function validateForm(form: DraftForm): FieldIssue[] {
+  const issues: FieldIssue[] = [];
+  const require = (path: string, value: string, label: string, rule: "positive" | "non_negative") => {
+    if (value.trim() === "") {
+      issues.push({ path, message: `${label} is required` });
+      return;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      issues.push({ path, message: `${label} must be a number` });
+    } else if (rule === "positive" && parsed <= 0) {
+      issues.push({ path, message: `${label} must be greater than 0` });
+    } else if (rule === "non_negative" && parsed < 0) {
+      issues.push({ path, message: `${label} cannot be negative` });
+    }
+  };
+
+  require("monthly_production_basis", form.monthly_production_basis, "Monthly production basis", "positive");
+
+  form.rm_prices.forEach((rm, i) => {
+    if (!rm.display_name.trim()) issues.push({ path: `rm.${i}.display_name`, message: "Name is required" });
+    require(`rm.${i}.purchase_amount`, rm.purchase_amount, "Purchase amount", "non_negative");
+    require(`rm.${i}.purchase_unit_kg`, rm.purchase_unit_kg, "Unit weight (kg)", "positive");
+    if (!rm.purchase_unit_label.trim()) {
+      issues.push({ path: `rm.${i}.purchase_unit_label`, message: "Unit label is required" });
+    }
+  });
+
+  form.fixed_items.forEach((item, i) => {
+    if (!item.display_name.trim()) issues.push({ path: `fixed.${i}.display_name`, message: "Name is required" });
+    require(`fixed.${i}.monthly_amount`, item.monthly_amount, "Monthly amount", "non_negative");
+  });
+
+  const knownRmKeys = new Set(form.rm_prices.map((rm) => rm.rm_key));
+  form.brick_types.forEach((bt, i) => {
+    if (!bt.brick_type.trim()) issues.push({ path: `bt.${i}.brick_type`, message: "Brick type is required" });
+    if (!bt.odoo_product_match.trim()) {
+      issues.push({ path: `bt.${i}.odoo_product_match`, message: "Odoo product match is required" });
+    }
+    require(`bt.${i}.bricks_per_batch`, bt.bricks_per_batch, "Bricks per batch", "positive");
+    require(`bt.${i}.labor_cost_per_batch`, bt.labor_cost_per_batch, "Labour per batch", "non_negative");
+    require(`bt.${i}.electricity_per_unit`, bt.electricity_per_unit, "Electricity per unit", "non_negative");
+    require(`bt.${i}.depreciation_per_unit`, bt.depreciation_per_unit, "Depreciation per unit", "non_negative");
+    require(`bt.${i}.loading_unloading_per_unit`, bt.loading_unloading_per_unit, "Loading / unloading", "non_negative");
+    require(`bt.${i}.transport_per_unit`, bt.transport_per_unit, "Transport", "non_negative");
+    require(`bt.${i}.commission_per_unit`, bt.commission_per_unit, "Commission", "non_negative");
+    if (bt.sales_price.trim() !== "") {
+      require(`bt.${i}.sales_price`, bt.sales_price, "Sales price", "non_negative");
+    }
+    bt.recipe.forEach((line, j) => {
+      require(`bt.${i}.recipe.${j}.kg_per_batch`, line.kg_per_batch, "Kg per batch", "non_negative");
+      if (!knownRmKeys.has(line.rm_key)) {
+        issues.push({
+          path: `bt.${i}.recipe.${j}.rm_key`,
+          message: `No price row for "${line.rm_key}"`,
+        });
+      }
+    });
+  });
+
+  return issues;
+}
+
+/** Look up the message for one field so it can render under the input. */
+export function issueFor(issues: FieldIssue[], path: string): string | null {
+  return issues.find((issue) => issue.path === path)?.message ?? null;
+}
+
+/** ₹ formatting for display only — the underlying value keeps full precision. */
+export function inr(value: number | null | undefined, dp = 2): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "—";
+  return `₹${value.toLocaleString("en-IN", {
+    minimumFractionDigits: dp,
+    maximumFractionDigits: dp,
+  })}`;
+}

--- a/apps/web/src/components/unit-economics/primitives.tsx
+++ b/apps/web/src/components/unit-economics/primitives.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * Shared bits of the Standard Costs screen.
+ *
+ * The visual contract of the whole module: an INPUT is white with a border and
+ * you can type in it; a DERIVED number is on a tinted, borderless surface and
+ * you cannot. If it can be computed, it is never an input.
+ */
+import { inr } from "./form";
+
+export function NumberField({
+  label,
+  value,
+  onChange,
+  issue,
+  suffix,
+  step = "0.01",
+  disabled = false,
+}: {
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  issue?: string | null;
+  suffix?: string;
+  step?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="block">
+      {label ? (
+        <span className="mb-1 block text-xs font-medium text-slate-500">{label}</span>
+      ) : null}
+      <span className="flex items-center gap-1">
+        <input
+          type="number"
+          inputMode="decimal"
+          step={step}
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={issue ? true : undefined}
+          className={`w-full rounded-lg border px-2 py-1.5 text-sm text-slate-900 disabled:bg-slate-50 ${
+            issue ? "border-red-400 bg-red-50" : "border-slate-200 bg-white"
+          }`}
+        />
+        {suffix ? <span className="shrink-0 text-xs text-slate-400">{suffix}</span> : null}
+      </span>
+      {issue ? <span className="mt-0.5 block text-xs text-red-600">{issue}</span> : null}
+    </label>
+  );
+}
+
+export function TextField({
+  label,
+  value,
+  onChange,
+  issue,
+  placeholder,
+}: {
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  issue?: string | null;
+  placeholder?: string;
+}) {
+  return (
+    <label className="block">
+      {label ? (
+        <span className="mb-1 block text-xs font-medium text-slate-500">{label}</span>
+      ) : null}
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        aria-invalid={issue ? true : undefined}
+        className={`w-full rounded-lg border px-2 py-1.5 text-sm text-slate-900 ${
+          issue ? "border-red-400 bg-red-50" : "border-slate-200 bg-white"
+        }`}
+      />
+      {issue ? <span className="mt-0.5 block text-xs text-red-600">{issue}</span> : null}
+    </label>
+  );
+}
+
+/** A computed value. Read-only by construction — there is no input here. */
+export function Derived({
+  label,
+  value,
+  dp = 2,
+  tone = "neutral",
+  hint,
+}: {
+  label: string;
+  value: number | null;
+  dp?: number;
+  tone?: "neutral" | "strong" | "good" | "bad";
+  hint?: string;
+}) {
+  const toneClass =
+    tone === "strong"
+      ? "bg-slate-900 text-white"
+      : tone === "good"
+        ? "bg-emerald-50 text-emerald-800"
+        : tone === "bad"
+          ? "bg-red-50 text-red-700"
+          : "bg-slate-100 text-slate-700";
+
+  return (
+    <div className={`rounded-lg px-3 py-2 ${toneClass}`} title={hint}>
+      <div className="text-[11px] font-medium uppercase tracking-wide opacity-70">{label}</div>
+      <div className="text-base font-semibold tabular-nums">{inr(value, dp)}</div>
+    </div>
+  );
+}
+
+/** A computed value that is a count, not money. */
+export function DerivedCount({ label, value, dp = 2 }: { label: string; value: number | null; dp?: number }) {
+  return (
+    <div className="rounded-lg bg-slate-100 px-3 py-2 text-slate-700">
+      <div className="text-[11px] font-medium uppercase tracking-wide opacity-70">{label}</div>
+      <div className="text-base font-semibold tabular-nums">
+        {value === null || !Number.isFinite(value)
+          ? "—"
+          : value.toLocaleString("en-IN", { minimumFractionDigits: dp, maximumFractionDigits: dp })}
+      </div>
+    </div>
+  );
+}
+
+export function SectionCard({
+  title,
+  subtitle,
+  actions,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="font-semibold text-slate-900">{title}</h2>
+          {subtitle ? <p className="text-xs text-slate-500">{subtitle}</p> : null}
+        </div>
+        {actions}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/lib/unit-economics.ts
+++ b/apps/web/src/lib/unit-economics.ts
@@ -1,0 +1,374 @@
+/**
+ * Unit Economics (standard cost) — server-side data access.
+ *
+ * Staff edit ONE mutable draft; an admin publishes it as an immutable version
+ * with a valid_from date, and the Intelligence Layer reads the published
+ * standard through v_standard_costs_current. Nothing derived is stored: every
+ * per-unit number comes from computeBundle() in @maiyuri/shared, which mirrors
+ * the SQL view v_std_cost_brick_type_computed.
+ *
+ * All writes use the service-role client, so the role gate lives in the API
+ * routes (see STD_COST_PUBLISH_ROLES).
+ */
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import type {
+  StdCostBrickType,
+  StdCostBundle,
+  StdCostDraftPayload,
+  StdCostFixedItem,
+  StdCostRmPrice,
+  StdCostVersion,
+  StdCostVersionSummary,
+} from "@maiyuri/shared";
+
+/** Only these roles may publish a draft as the new standard (PRD §4). */
+export const STD_COST_PUBLISH_ROLES = ["founder", "owner"] as const;
+
+export function canPublishStandardCost(role: string | null | undefined): boolean {
+  return !!role && (STD_COST_PUBLISH_ROLES as readonly string[]).includes(role);
+}
+
+const VERSION_COLUMNS =
+  "id, status, valid_from, monthly_production_basis, notes, created_by, created_at, updated_by, updated_at, published_by, published_at";
+
+/** Postgres numerics arrive as strings over PostgREST — coerce every one. */
+function num(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? Number.NaN);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function nullableNum(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toVersion(row: Record<string, unknown>): StdCostVersion {
+  return {
+    id: String(row.id),
+    status: row.status as StdCostVersion["status"],
+    valid_from: (row.valid_from as string | null) ?? null,
+    monthly_production_basis: num(row.monthly_production_basis),
+    notes: (row.notes as string | null) ?? null,
+    created_by: (row.created_by as string | null) ?? null,
+    created_at: String(row.created_at ?? ""),
+    updated_by: (row.updated_by as string | null) ?? null,
+    updated_at: String(row.updated_at ?? ""),
+    published_by: (row.published_by as string | null) ?? null,
+    published_at: (row.published_at as string | null) ?? null,
+  };
+}
+
+/** Load one version with every child row, shaped for computeBundle(). */
+export async function loadBundle(versionId: string): Promise<StdCostBundle | null> {
+  const db = supabaseAdmin;
+
+  const { data: versionRow, error: versionError } = await db
+    .from("std_cost_versions")
+    .select(VERSION_COLUMNS)
+    .eq("id", versionId)
+    .maybeSingle();
+  if (versionError) throw new Error(`Failed to load version: ${versionError.message}`);
+  if (!versionRow) return null;
+
+  const [rmResult, btResult, fixedResult] = await Promise.all([
+    db
+      .from("std_cost_rm_prices")
+      .select("id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg")
+      .eq("version_id", versionId)
+      .order("rm_key"),
+    db
+      .from("std_cost_brick_types")
+      .select(
+        "id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch, electricity_per_unit, depreciation_per_unit, sales_price, loading_unloading_per_unit, transport_per_unit, commission_per_unit, sort_order",
+      )
+      .eq("version_id", versionId)
+      .order("sort_order")
+      .order("brick_type"),
+    db
+      .from("std_cost_fixed_items")
+      .select("id, item_key, display_name, monthly_amount")
+      .eq("version_id", versionId)
+      .order("item_key"),
+  ]);
+
+  if (rmResult.error) throw new Error(`Failed to load raw materials: ${rmResult.error.message}`);
+  if (btResult.error) throw new Error(`Failed to load brick types: ${btResult.error.message}`);
+  if (fixedResult.error) throw new Error(`Failed to load fixed costs: ${fixedResult.error.message}`);
+
+  const brickTypeIds = (btResult.data ?? []).map((row) => String(row.id));
+  const recipeByBrickType = new Map<string, { rm_key: string; kg_per_batch: number }[]>();
+  if (brickTypeIds.length > 0) {
+    const { data: recipeRows, error: recipeError } = await db
+      .from("std_cost_recipe_lines")
+      .select("brick_type_id, rm_key, kg_per_batch")
+      .in("brick_type_id", brickTypeIds)
+      .order("rm_key");
+    if (recipeError) throw new Error(`Failed to load recipes: ${recipeError.message}`);
+    for (const row of recipeRows ?? []) {
+      const key = String(row.brick_type_id);
+      const lines = recipeByBrickType.get(key) ?? [];
+      lines.push({ rm_key: String(row.rm_key), kg_per_batch: num(row.kg_per_batch) });
+      recipeByBrickType.set(key, lines);
+    }
+  }
+
+  const rm_prices: StdCostRmPrice[] = (rmResult.data ?? []).map((row) => ({
+    id: String(row.id),
+    rm_key: String(row.rm_key),
+    display_name: String(row.display_name),
+    purchase_amount: num(row.purchase_amount),
+    purchase_unit_label: String(row.purchase_unit_label),
+    purchase_unit_kg: num(row.purchase_unit_kg),
+  }));
+
+  const brick_types: StdCostBrickType[] = (btResult.data ?? []).map((row) => ({
+    id: String(row.id),
+    brick_type: String(row.brick_type),
+    odoo_product_match: String(row.odoo_product_match),
+    bricks_per_batch: num(row.bricks_per_batch),
+    labor_cost_per_batch: num(row.labor_cost_per_batch),
+    electricity_per_unit: num(row.electricity_per_unit),
+    depreciation_per_unit: num(row.depreciation_per_unit),
+    sales_price: nullableNum(row.sales_price),
+    loading_unloading_per_unit: num(row.loading_unloading_per_unit),
+    transport_per_unit: num(row.transport_per_unit),
+    commission_per_unit: num(row.commission_per_unit),
+    sort_order: num(row.sort_order),
+    recipe: recipeByBrickType.get(String(row.id)) ?? [],
+  }));
+
+  const fixed_items: StdCostFixedItem[] = (fixedResult.data ?? []).map((row) => ({
+    id: String(row.id),
+    item_key: String(row.item_key),
+    display_name: String(row.display_name),
+    monthly_amount: num(row.monthly_amount),
+  }));
+
+  return { version: toVersion(versionRow), rm_prices, brick_types, fixed_items };
+}
+
+/** The single open draft, or null when the module has never been seeded. */
+export async function loadDraftBundle(): Promise<StdCostBundle | null> {
+  const { data, error } = await supabaseAdmin
+    .from("std_cost_versions")
+    .select("id")
+    .eq("status", "draft")
+    .maybeSingle();
+  if (error) throw new Error(`Failed to find the draft: ${error.message}`);
+  if (!data) return null;
+  return loadBundle(String(data.id));
+}
+
+/** The version the Intelligence Layer is currently reading (latest valid_from). */
+export async function loadCurrentPublishedBundle(): Promise<StdCostBundle | null> {
+  const { data, error } = await supabaseAdmin
+    .from("std_cost_versions")
+    .select("id")
+    .eq("status", "published")
+    .order("valid_from", { ascending: false })
+    .order("published_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(`Failed to find the published version: ${error.message}`);
+  if (!data) return null;
+  return loadBundle(String(data.id));
+}
+
+/** Published history, newest standard first. */
+export async function listPublishedVersions(limit = 50): Promise<StdCostVersionSummary[]> {
+  const db = supabaseAdmin;
+  const { data, error } = await db
+    .from("std_cost_versions")
+    .select(VERSION_COLUMNS)
+    .eq("status", "published")
+    .order("valid_from", { ascending: false })
+    .order("published_at", { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(`Failed to load history: ${error.message}`);
+
+  const rows = (data ?? []).map(toVersion);
+  const publisherIds = Array.from(
+    new Set(rows.map((row) => row.published_by).filter((id): id is string => !!id)),
+  );
+
+  const nameById = new Map<string, string>();
+  if (publisherIds.length > 0) {
+    const { data: users } = await db.from("users").select("id, name").in("id", publisherIds);
+    for (const user of users ?? []) nameById.set(String(user.id), String(user.name ?? ""));
+  }
+
+  return rows.map((row) => ({
+    ...row,
+    published_by_name: row.published_by ? (nameById.get(row.published_by) ?? null) : null,
+  }));
+}
+
+/**
+ * Replace the draft's contents wholesale.
+ *
+ * Replace-all rather than per-field patching: the editor always holds the
+ * complete picture, and it keeps "what the user sees" and "what is stored"
+ * impossible to drift apart. The database triggers refuse the write outright
+ * if the target version is not a draft.
+ */
+export async function saveDraft(
+  payload: StdCostDraftPayload,
+  userId: string,
+): Promise<StdCostBundle> {
+  const db = supabaseAdmin;
+
+  const { data: versionRow, error: versionError } = await db
+    .from("std_cost_versions")
+    .select("id, status")
+    .eq("id", payload.version_id)
+    .maybeSingle();
+  if (versionError) throw new Error(`Failed to load the draft: ${versionError.message}`);
+  if (!versionRow) throw new StdCostError("Draft not found", 404);
+  if (versionRow.status !== "draft") {
+    throw new StdCostError("That version is published and cannot be edited", 409);
+  }
+
+  const versionId = payload.version_id;
+
+  const { error: updateError } = await db
+    .from("std_cost_versions")
+    .update({
+      monthly_production_basis: payload.monthly_production_basis,
+      notes: payload.notes ?? null,
+      updated_by: userId,
+    })
+    .eq("id", versionId);
+  if (updateError) throw new Error(`Failed to save the draft: ${updateError.message}`);
+
+  // Children are replaced as a set. ON DELETE CASCADE removes recipe lines
+  // with their brick types, so the recipe is re-inserted with fresh ids.
+  await deleteChildren(versionId);
+
+  if (payload.rm_prices.length > 0) {
+    const { error } = await db.from("std_cost_rm_prices").insert(
+      payload.rm_prices.map((rm) => ({ version_id: versionId, ...rm })),
+    );
+    if (error) throw new Error(`Failed to save raw materials: ${error.message}`);
+  }
+
+  if (payload.fixed_items.length > 0) {
+    const { error } = await db.from("std_cost_fixed_items").insert(
+      payload.fixed_items.map((item) => ({ version_id: versionId, ...item })),
+    );
+    if (error) throw new Error(`Failed to save fixed costs: ${error.message}`);
+  }
+
+  if (payload.brick_types.length > 0) {
+    const { data: inserted, error } = await db
+      .from("std_cost_brick_types")
+      .insert(
+        payload.brick_types.map((bt, index) => ({
+          version_id: versionId,
+          brick_type: bt.brick_type,
+          odoo_product_match: bt.odoo_product_match,
+          bricks_per_batch: bt.bricks_per_batch,
+          labor_cost_per_batch: bt.labor_cost_per_batch,
+          electricity_per_unit: bt.electricity_per_unit,
+          depreciation_per_unit: bt.depreciation_per_unit,
+          sales_price: bt.sales_price,
+          loading_unloading_per_unit: bt.loading_unloading_per_unit,
+          transport_per_unit: bt.transport_per_unit,
+          commission_per_unit: bt.commission_per_unit,
+          sort_order: bt.sort_order ?? index,
+        })),
+      )
+      .select("id, brick_type");
+    if (error) throw new Error(`Failed to save brick types: ${error.message}`);
+
+    const idByType = new Map((inserted ?? []).map((row) => [String(row.brick_type), String(row.id)]));
+    const recipeRows = payload.brick_types.flatMap((bt) => {
+      const brickTypeId = idByType.get(bt.brick_type);
+      if (!brickTypeId) return [];
+      return bt.recipe.map((line) => ({
+        brick_type_id: brickTypeId,
+        rm_key: line.rm_key,
+        kg_per_batch: line.kg_per_batch,
+      }));
+    });
+    if (recipeRows.length > 0) {
+      const { error: recipeError } = await db.from("std_cost_recipe_lines").insert(recipeRows);
+      if (recipeError) throw new Error(`Failed to save recipes: ${recipeError.message}`);
+    }
+  }
+
+  const bundle = await loadBundle(versionId);
+  if (!bundle) throw new Error("Draft disappeared while saving");
+  return bundle;
+}
+
+async function deleteChildren(versionId: string): Promise<void> {
+  const db = supabaseAdmin;
+  const results = await Promise.all([
+    db.from("std_cost_rm_prices").delete().eq("version_id", versionId),
+    db.from("std_cost_fixed_items").delete().eq("version_id", versionId),
+    db.from("std_cost_brick_types").delete().eq("version_id", versionId),
+  ]);
+  for (const result of results) {
+    if (result.error) throw new Error(`Failed to clear the draft: ${result.error.message}`);
+  }
+}
+
+/**
+ * Publish the draft. The whole transition (freeze this version, open the next
+ * draft as a copy) happens inside publish_std_cost_draft() so there is never a
+ * moment with two drafts or none.
+ */
+export async function publishDraft(args: {
+  versionId: string;
+  validFrom: string;
+  publishedBy: string;
+  notes?: string | null;
+}): Promise<{ published_version_id: string; new_draft_id: string }> {
+  const { data, error } = await supabaseAdmin.rpc("publish_std_cost_draft", {
+    p_draft_id: args.versionId,
+    p_valid_from: args.validFrom,
+    p_published_by: args.publishedBy,
+    p_notes: args.notes ?? null,
+  });
+  if (error) throw new StdCostError(error.message, 409);
+  return { published_version_id: args.versionId, new_draft_id: String(data) };
+}
+
+/**
+ * Revert: refill the open draft from an older published version. The old
+ * version stays exactly where it is — reverting produces a new draft that Ram
+ * then publishes, so history is never rewritten.
+ */
+export async function useVersionAsDraft(
+  sourceVersionId: string,
+  userId: string,
+): Promise<StdCostBundle> {
+  const source = await loadBundle(sourceVersionId);
+  if (!source) throw new StdCostError("Version not found", 404);
+
+  const draft = await loadDraftBundle();
+  if (!draft) throw new StdCostError("No open draft to fill", 409);
+
+  return saveDraft(
+    {
+      version_id: draft.version.id,
+      monthly_production_basis: source.version.monthly_production_basis,
+      notes: `Reverted from the standard valid from ${source.version.valid_from ?? "?"}`,
+      rm_prices: source.rm_prices.map(({ id: _id, ...rest }) => rest),
+      fixed_items: source.fixed_items.map(({ id: _id, ...rest }) => rest),
+      brick_types: source.brick_types.map(({ id: _id, ...rest }) => rest),
+    },
+    userId,
+  );
+}
+
+/** An error with an HTTP status the route can pass straight through. */
+export class StdCostError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "StdCostError";
+    this.status = status;
+  }
+}

--- a/apps/web/src/lib/unit-economics.ts
+++ b/apps/web/src/lib/unit-economics.ts
@@ -16,6 +16,8 @@ import type {
   StdCostBundle,
   StdCostDraftPayload,
   StdCostFixedItem,
+  StdCostReference,
+  StdCostReferencePayload,
   StdCostRmPrice,
   StdCostVersion,
   StdCostVersionSummary,
@@ -74,7 +76,9 @@ export async function loadBundle(versionId: string): Promise<StdCostBundle | nul
   const [rmResult, btResult, fixedResult] = await Promise.all([
     db
       .from("std_cost_rm_prices")
-      .select("id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg")
+      .select(
+        "id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg, needs_verification, verification_note",
+      )
       .eq("version_id", versionId)
       .order("rm_key"),
     db
@@ -120,6 +124,8 @@ export async function loadBundle(versionId: string): Promise<StdCostBundle | nul
     purchase_amount: num(row.purchase_amount),
     purchase_unit_label: String(row.purchase_unit_label),
     purchase_unit_kg: num(row.purchase_unit_kg),
+    needs_verification: row.needs_verification === true,
+    verification_note: (row.verification_note as string | null) ?? null,
   }));
 
   const brick_types: StdCostBrickType[] = (btResult.data ?? []).map((row) => ({
@@ -371,4 +377,142 @@ export class StdCostError extends Error {
     this.name = "StdCostError";
     this.status = status;
   }
+}
+
+// ==========================================================================
+// Reference (benchmark) costs.
+//
+// Deliberately a separate read path from loadBundle(): nothing that computes a
+// standard cost may so much as see a reference. The only place the two meet is
+// computeAllReferenceVariances(), which subtracts and reports — it cannot feed
+// anything back.
+// ==========================================================================
+
+/** All benchmarks, newest first. Inactive ones included — history matters. */
+export async function listReferences(): Promise<StdCostReference[]> {
+  const db = supabaseAdmin;
+
+  const { data, error } = await db
+    .from("std_cost_reference_costs")
+    .select(
+      "id, brick_type, reference_cost, source, source_label, reference_date, notes, is_active",
+    )
+    .order("brick_type")
+    .order("reference_date", { ascending: false });
+  if (error) throw new Error(`Failed to load reference costs: ${error.message}`);
+
+  const rows = data ?? [];
+  if (rows.length === 0) return [];
+
+  const { data: componentRows, error: componentError } = await db
+    .from("std_cost_reference_components")
+    .select("id, reference_cost_id, component_kind, component_key, amount")
+    .in(
+      "reference_cost_id",
+      rows.map((row) => String(row.id)),
+    );
+  if (componentError) {
+    throw new Error(`Failed to load reference components: ${componentError.message}`);
+  }
+
+  const componentsByReference = new Map<string, StdCostReference["components"]>();
+  for (const row of componentRows ?? []) {
+    const key = String(row.reference_cost_id);
+    const list = componentsByReference.get(key) ?? [];
+    list.push({
+      id: String(row.id),
+      component_kind: row.component_kind as "cost_element" | "raw_material",
+      component_key: String(row.component_key),
+      amount: num(row.amount),
+    });
+    componentsByReference.set(key, list);
+  }
+
+  return rows.map((row) => ({
+    id: String(row.id),
+    brick_type: String(row.brick_type),
+    reference_cost: num(row.reference_cost),
+    source: row.source as StdCostReference["source"],
+    source_label: (row.source_label as string | null) ?? null,
+    reference_date: String(row.reference_date),
+    notes: (row.notes as string | null) ?? null,
+    is_active: row.is_active !== false,
+    components: componentsByReference.get(String(row.id)) ?? [],
+  }));
+}
+
+/** Create or update one benchmark, replacing its component breakdown. */
+export async function saveReference(
+  payload: StdCostReferencePayload,
+  userId: string,
+): Promise<StdCostReference> {
+  const db = supabaseAdmin;
+
+  const row = {
+    brick_type: payload.brick_type,
+    reference_cost: payload.reference_cost,
+    source: payload.source,
+    source_label: payload.source_label ?? null,
+    reference_date: payload.reference_date,
+    notes: payload.notes ?? null,
+    is_active: payload.is_active ?? true,
+    updated_by: userId,
+  };
+
+  let referenceId = payload.id ?? null;
+
+  if (referenceId) {
+    const { error } = await db.from("std_cost_reference_costs").update(row).eq("id", referenceId);
+    if (error) throw new StdCostError(`Failed to update the reference: ${error.message}`, 422);
+  } else {
+    const { data, error } = await db
+      .from("std_cost_reference_costs")
+      .insert({ ...row, created_by: userId })
+      .select("id")
+      .single();
+    if (error) {
+      // The unique key is (brick_type, source, reference_date) — say so plainly.
+      const duplicate = error.code === "23505";
+      throw new StdCostError(
+        duplicate
+          ? `A ${payload.source} reference for ${payload.brick_type} on ${payload.reference_date} already exists`
+          : `Failed to save the reference: ${error.message}`,
+        422,
+      );
+    }
+    referenceId = String(data.id);
+  }
+
+  const { error: deleteError } = await db
+    .from("std_cost_reference_components")
+    .delete()
+    .eq("reference_cost_id", referenceId);
+  if (deleteError) {
+    throw new Error(`Failed to clear the old breakdown: ${deleteError.message}`);
+  }
+
+  const components = payload.components ?? [];
+  if (components.length > 0) {
+    const { error } = await db
+      .from("std_cost_reference_components")
+      .insert(components.map((component) => ({ reference_cost_id: referenceId, ...component })));
+    if (error) throw new StdCostError(`Failed to save the breakdown: ${error.message}`, 422);
+  }
+
+  const saved = (await listReferences()).find((reference) => reference.id === referenceId);
+  if (!saved) throw new Error("Reference disappeared while saving");
+  return saved;
+}
+
+/**
+ * Deactivate a benchmark. Never a hard delete: a legacy number that has been
+ * argued over is part of the audit trail, and "we stopped comparing against it"
+ * is different from "it never existed".
+ */
+export async function deactivateReference(referenceId: string, userId: string): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("std_cost_reference_costs")
+    .update({ is_active: false, updated_by: userId })
+    .eq("id", referenceId);
+  if (error) throw new Error(`Failed to deactivate the reference: ${error.message}`);
 }

--- a/apps/web/src/lib/unit-economics.ts
+++ b/apps/web/src/lib/unit-economics.ts
@@ -395,7 +395,7 @@ export async function listReferences(): Promise<StdCostReference[]> {
   const { data, error } = await db
     .from("std_cost_reference_costs")
     .select(
-      "id, brick_type, reference_cost, source, source_label, reference_date, notes, is_active",
+      "id, brick_type, reference_cost, source, source_label, reference_date, notes, is_active, breakdown_status",
     )
     .order("brick_type")
     .order("reference_date", { ascending: false });
@@ -437,6 +437,7 @@ export async function listReferences(): Promise<StdCostReference[]> {
     reference_date: String(row.reference_date),
     notes: (row.notes as string | null) ?? null,
     is_active: row.is_active !== false,
+    breakdown_status: (row.breakdown_status as "partial" | "complete") ?? "partial",
     components: componentsByReference.get(String(row.id)) ?? [],
   }));
 }
@@ -456,6 +457,9 @@ export async function saveReference(
     reference_date: payload.reference_date,
     notes: payload.notes ?? null,
     is_active: payload.is_active ?? true,
+    // Default partial: a breakdown is incomplete until someone says otherwise,
+    // and only a complete one is required to balance.
+    breakdown_status: payload.breakdown_status ?? "partial",
     updated_by: userId,
   };
 

--- a/docs/UNIT_ECONOMICS.md
+++ b/docs/UNIT_ECONOMICS.md
@@ -1,0 +1,124 @@
+# Unit Economics (Standard Cost) module
+
+Replaces the "Mb Unit Economics" Google Sheet (sheet id
+`1h538LH--cr3yiqDVaiXvU85ZxsgVvqBZ010QuXpAdbM`), which is retired read-only at
+go-live with a banner pointing at the app.
+
+**Where it lives:** `/unit-economics` in the web app (nav: founder, owner,
+accountant).
+
+## The model
+
+| Concept | Rule |
+|---|---|
+| Draft | Exactly one, always. Any staff member edits it. Nothing downstream sees it. |
+| Published version | Immutable, dated (`valid_from`). Only founder/owner publishes. |
+| Revert | Refills the draft from an older version — history is never rewritten. |
+
+Publishing freezes the draft and opens a fresh draft copied from it, atomically,
+inside `publish_std_cost_draft()`.
+
+## The one invariant
+
+**No derived number is ever stored from user input.** `cost_per_kg` is a
+generated column; every per-unit cost is computed in the SQL view
+`v_std_cost_brick_type_computed` and mirrored, formula for formula, in
+`packages/shared/src/unit-economics.ts` (`computeBundle`) so the editor can show
+live numbers for an unsaved draft.
+
+Those two implementations are pinned to the same expected values by
+`packages/shared/src/unit-economics.test.ts`. If you change a formula, change it
+in **both** places and update that test — that is the whole defence against the
+"the sheet says chemical is ₹80/kg while its own inputs say ₹74" class of error.
+
+```
+material_cost_per_batch = Σ recipe: kg_per_batch × (purchase_amount / purchase_unit_kg)
+material_cost_per_unit  = material_cost_per_batch / bricks_per_batch
+labor_cost_per_unit     = labor_cost_per_batch / bricks_per_batch
+overhead_per_unit       = electricity_per_unit + depreciation_per_unit
+variable_cost_per_unit  = material + labor + overhead   (all per unit)
+fixed_cost_per_unit     = Σ fixed_items.monthly_amount / monthly_production_basis
+total_cost_per_unit     = variable_cost_per_unit + fixed_cost_per_unit
+margin_per_unit         = sales_price − loading_unloading − transport − commission − total_cost_per_unit
+bricks_per_cement_bag   = bricks_per_batch × 50 / recipe.cement.kg_per_batch
+```
+
+Full precision throughout; rounding happens at display and in the contract views
+only.
+
+## Frozen integration contract
+
+The Maiyuri Intelligence Layer reads these two views. **Never rename the views
+or their columns**, and never change `brick_type` values or `product_match`
+patterns without a downstream handshake — they join onto Odoo product names.
+
+- `public.v_standard_costs_current`
+- `public.v_standard_rm_prices_current`
+
+Both select the published version with the greatest `valid_from`. Both are
+`security_invoker` views: the reader needs `SELECT` on the five `std_cost_*`
+base tables. `service_role` and `authenticated` are granted in the migration; if
+the Intelligence Layer reads as some other role, grant it `SELECT` on those
+tables and add a `SELECT` policy — the views hand out no access of their own.
+
+Full history stays queryable in the base tables (`std_cost_versions` joined to
+its children).
+
+## Permissions
+
+| | Staff (any signed-in role) | Founder / owner |
+|---|---|---|
+| Read draft + history | ✅ | ✅ |
+| Edit the draft | ✅ | ✅ |
+| Publish / revert | ❌ | ✅ |
+| `anon` | reads nothing (revoked) | — |
+
+RLS is on with a SELECT-only policy for `authenticated`; every write goes
+through the service-role client in `apps/web/app/api/unit-economics/*`, which is
+where the role gate lives (`canPublishStandardCost`).
+
+## Publish gating
+
+- **Blocks** (`publishBlockers`): a brick type with no cement recipe line, a
+  `total_cost_per_unit ≤ 0`, a recipe line whose material has no price row, no
+  brick types, a non-positive production basis, a `valid_from` not after the
+  current standard.
+- **Warns, does not block** (`publishWarnings`): any total moving more than 15%
+  against the published version.
+
+## Files
+
+```
+supabase/migrations/20260822120000_std_cost_unit_economics.sql   tables, guards, views, RLS, publish()
+supabase/migrations/20260822120100_std_cost_seed_v1.sql          go-live seed (v1) + first draft
+packages/shared/src/unit-economics.ts                            types, formulas, diff, zod schemas
+apps/web/src/lib/unit-economics.ts                               server-side load/save/publish
+apps/web/app/api/unit-economics/…                                GET overview · PUT draft · POST publish · versions
+apps/web/app/(dashboard)/unit-economics/page.tsx                 the screen
+apps/web/src/components/unit-economics/…                         editor, diff, publish, history
+```
+
+## Go-live: two things to settle with Ram
+
+**1. Two seeded inputs are guesses.** The PRD contradicts itself on both, so
+each was seeded to match the per-kg cost the sheet actually costs with, and
+needs the real load weight confirmed (one edit in the app, then publish):
+
+| Material | PRD says | Seeded | Why |
+|---|---|---|---|
+| `red_soil` | `4712.50 / 37050 kg (≈1.27/kg)` | 4712.50 / **3705 kg** = 1.2719/kg | 4712.50/37050 is 0.127, off by 10× from the stated ≈1.27 |
+| `red_soil_gravel` | `3600 / 28900-for-8 (≈0.80/kg)` | 3600 / **4500 kg** = 0.80/kg | matches the stated ≈0.80; no recipe consumes it, so no total depends on it |
+
+**2. The computed totals do not match the sheet's.** The inputs below are the
+sheet's own inputs — where the totals differ, the sheet's totals were stale.
+Review before flipping the Intelligence Layer over:
+
+| Brick type | Computed | Sheet | Delta |
+|---|---|---|---|
+| 8 CIB | 27.06 | 32.83 | −5.77 |
+| 6 CIB | 26.24 | 31.80 | −5.56 |
+| 8 MIB | 34.77 | 36.12 | −1.35 |
+| 6 MIB | 27.94 | 29.04 | −1.10 |
+
+Then tell Ram, and the Intelligence Layer flips its standard-cost source from
+JSON snapshots to `v_standard_costs_current`.

--- a/docs/UNIT_ECONOMICS.md
+++ b/docs/UNIT_ECONOMICS.md
@@ -91,6 +91,8 @@ where the role gate lives (`canPublishStandardCost`).
 ```
 supabase/migrations/20260822120000_std_cost_unit_economics.sql   tables, guards, views, RLS, publish()
 supabase/migrations/20260822120100_std_cost_seed_v1.sql          go-live seed (v1) + first draft
+supabase/migrations/20260822120200_std_cost_reference_costs.sql  benchmarks + variance views
+supabase/migrations/20260822120300_std_cost_reference_seed.sql   legacy benchmarks + verification flags
 packages/shared/src/unit-economics.ts                            types, formulas, diff, zod schemas
 apps/web/src/lib/unit-economics.ts                               server-side load/save/publish
 apps/web/app/api/unit-economics/…                                GET overview · PUT draft · POST publish · versions
@@ -98,27 +100,103 @@ apps/web/app/(dashboard)/unit-economics/page.tsx                 the screen
 apps/web/src/components/unit-economics/…                         editor, diff, publish, history
 ```
 
-## Go-live: two things to settle with Ram
+## Reference (benchmark) costs — reconciliation
 
-**1. Two seeded inputs are guesses.** The PRD contradicts itself on both, so
-each was seeded to match the per-kg cost the sheet actually costs with, and
-needs the real load weight confirmed (one edit in the app, then publish):
+Legacy sheet totals, manual benchmarks and past actuals are stored in
+`std_cost_reference_costs`, **separately from the standard and never inside
+it**. The rule is structural, not a convention:
 
-| Material | PRD says | Seeded | Why |
+- `computeBundle()` takes no reference argument. There is no code path by which
+  a benchmark can influence a computed cost.
+- `v_std_cost_brick_type_computed` and the two frozen contract views do not
+  reference the benchmark tables at all.
+- The only operation defined between a computed cost and a reference is
+  subtraction, and the residual is reported as **unexplained** rather than
+  absorbed.
+
+A computed cost moves only one way: correct a business input in the draft and
+publish a new version. Never by adjusting a formula, and never by adding a
+balancing factor.
+
+### What the screen shows
+
+```
+Computed Cost:  ₹27.06
+Legacy Sheet:   ₹32.83
+Variance:      −₹5.77  (−17.6%)
+⚠ Significant variance
+```
+
+Expanded, once a breakdown exists:
+
+```
+Raw material   −₹3.20
+Labour         −₹1.45
+Fixed overhead −₹1.13
+  cement       −₹0.62   (inside raw material — detail, not added again)
+Unexplained     ₹0.00
+```
+
+With no breakdown recorded, the whole variance shows as unexplained. That is
+deliberate: a missing breakdown should look like a missing breakdown, not like a
+reconciled zero.
+
+### Two axes of breakdown
+
+| Kind | Keys | Role |
+|---|---|---|
+| `cost_element` | material · labour · electricity · depreciation · fixed · other | Mutually exclusive, must sum to the reference total (enforced in the zod schema). Each maps 1:1 onto a computed number. **The unexplained residual is measured on this axis only.** |
+| `raw_material` | any `rm_key` (cement, chemical, …) | A drill-down *inside* the material element. Never added to the cost-element sum — that would double-count material. |
+
+### Views for the Intelligence Layer
+
+- `v_std_cost_reference_variance` — one row per brick type per active
+  benchmark: computed, reference, `variance_amount`, `variance_pct`,
+  `explained_difference`, `unexplained_difference`, `has_component_breakdown`.
+- `v_std_cost_reference_component_variance` — per component: reference amount,
+  computed amount (NULL where there is no counterpart, e.g. `other`), and the
+  difference.
+
+Between them these answer "why is 8 CIB ₹5.77 below the old costing?" from
+stored data, and expose the pattern across products (both CIB around −17.5%,
+both MIB around −3.8%) for exception analysis. The narrative is the Intelligence
+Layer's job; the app's job is to make the numbers unambiguous.
+
+Note the percentages round to 1 dp in the UI and 2 dp in the views — same
+figure, different display precision.
+
+## Unconfirmed inputs
+
+`std_cost_rm_prices.needs_verification` + `verification_note` mark an input that
+is in use but not yet confirmed. The flag changes nothing about how the number
+is used — that is the point. It records doubt so it can be chased, and it
+travels forward on every publish so it cannot be lost.
+
+Two inputs are flagged at go-live, both because §9 of the PRD contradicts itself
+and both seeded to match the per-kg cost the standard has actually been costing
+with:
+
+| Material | Source says | In use | Why |
 |---|---|---|---|
-| `red_soil` | `4712.50 / 37050 kg (≈1.27/kg)` | 4712.50 / **3705 kg** = 1.2719/kg | 4712.50/37050 is 0.127, off by 10× from the stated ≈1.27 |
+| `red_soil` | `4712.50 / 37050 kg (≈1.27/kg)` | 4712.50 / **3705 kg** = 1.2719/kg | 4712.50/37050 is 0.127 — off by 10× from the stated ≈1.27 |
 | `red_soil_gravel` | `3600 / 28900-for-8 (≈0.80/kg)` | 3600 / **4500 kg** = 0.80/kg | matches the stated ≈0.80; no recipe consumes it, so no total depends on it |
 
-**2. The computed totals do not match the sheet's.** The inputs below are the
-sheet's own inputs — where the totals differ, the sheet's totals were stale.
-Review before flipping the Intelligence Layer over:
+When the real load weight is known: edit the draft, publish, and version history
+shows exactly what changed and what it did to every brick cost.
 
-| Brick type | Computed | Sheet | Delta |
+## Go-live
+
+The four legacy sheet totals are seeded as `legacy_excel` benchmarks, with no
+component breakdown (the sheet never published one), so every rupee shows as
+unexplained until someone supplies real figures:
+
+| Brick type | Computed | Legacy sheet | Variance |
 |---|---|---|---|
-| 8 CIB | 27.06 | 32.83 | −5.77 |
-| 6 CIB | 26.24 | 31.80 | −5.56 |
-| 8 MIB | 34.77 | 36.12 | −1.35 |
-| 6 MIB | 27.94 | 29.04 | −1.10 |
+| 8 CIB | 27.06 | 32.83 | −5.77 (−17.6%) |
+| 6 CIB | 26.24 | 31.80 | −5.56 (−17.5%) |
+| 8 MIB | 34.77 | 36.12 | −1.35 (−3.7%) |
+| 6 MIB | 27.94 | 29.04 | −1.10 (−3.8%) |
 
-Then tell Ram, and the Intelligence Layer flips its standard-cost source from
-JSON snapshots to `v_standard_costs_current`.
+These are test cases for the reconciliation feature, not blockers. Deploy, then
+the Intelligence Layer flips its standard-cost source from JSON snapshots to
+`v_standard_costs_current`.

--- a/docs/UNIT_ECONOMICS.md
+++ b/docs/UNIT_ECONOMICS.md
@@ -93,6 +93,7 @@ supabase/migrations/20260822120000_std_cost_unit_economics.sql   tables, guards,
 supabase/migrations/20260822120100_std_cost_seed_v1.sql          go-live seed (v1) + first draft
 supabase/migrations/20260822120200_std_cost_reference_costs.sql  benchmarks + variance views
 supabase/migrations/20260822120300_std_cost_reference_seed.sql   legacy benchmarks + verification flags
+supabase/migrations/20260822120400_std_cost_reference_partial_breakdown.sql  partial/complete breakdowns
 packages/shared/src/unit-economics.ts                            types, formulas, diff, zod schemas
 apps/web/src/lib/unit-economics.ts                               server-side load/save/publish
 apps/web/app/api/unit-economics/…                                GET overview · PUT draft · POST publish · versions
@@ -130,11 +131,11 @@ Variance:      −₹5.77  (−17.6%)
 Expanded, once a breakdown exists:
 
 ```
+Breakdown coverage: ₹24.47 / ₹32.83 (74.5%) · partial
 Raw material   −₹3.20
 Labour         −₹1.45
-Fixed overhead −₹1.13
   cement       −₹0.62   (inside raw material — detail, not added again)
-Unexplained     ₹0.00
+Still unexplained  −₹1.12
 ```
 
 With no breakdown recorded, the whole variance shows as unexplained. That is
@@ -145,8 +146,46 @@ reconciled zero.
 
 | Kind | Keys | Role |
 |---|---|---|
-| `cost_element` | material · labour · electricity · depreciation · fixed · other | Mutually exclusive, must sum to the reference total (enforced in the zod schema). Each maps 1:1 onto a computed number. **The unexplained residual is measured on this axis only.** |
+| `cost_element` | material · labour · electricity · depreciation · fixed · other | Mutually exclusive parts of the total. Each maps 1:1 onto a computed number. **The unexplained residual is measured on this axis only.** |
 | `raw_material` | any `rm_key` (cement, chemical, …) | A drill-down *inside* the material element. Never added to the cost-element sum — that would double-count material. |
+
+### Partial vs complete breakdowns
+
+`breakdown_status` decides what the components are claiming:
+
+| Status | Rule | Meaning |
+|---|---|---|
+| `partial` (default) | Components may cover *part* of the total; they may never exceed it | Reconciliation in progress. Coverage shows as `₹24.47 / ₹32.83 (74.5%)`, and the residual stays live |
+| `complete` | Components must equal the total, within ₹0.01 | An explicit claim that nothing is left out — only then does a zero residual mean anything |
+
+This distinction is load-bearing. Requiring every breakdown to balance would make
+
+```
+unexplained = total_variance − Σ(component variances)
+```
+
+**zero by construction**, because components that sum to the reference total
+produce variances that sum to the total variance. The number meant to say "we
+still don't know why" could only ever say zero.
+
+Progressive reconciliation, as it actually runs (verified end to end in SQL and
+TypeScript — see `progressive reconciliation` in the test file):
+
+| Stage | Explained | Still unexplained | Coverage |
+|---|---:|---:|---:|
+| Nothing known | ₹0.00 | −₹5.77 | 0% |
+| Material found | −₹3.20 | −₹2.57 | 48.8% |
+| + labour | −₹4.65 | −₹1.12 | 74.5% |
+| + fixed cost | −₹5.77 | ₹0.00 | 93.9% |
+
+Note the last row: the variance can be fully explained while coverage is under
+100%, when the components not yet entered happen to have no variance. Coverage
+and explanation answer different questions, so both are reported.
+
+Enforcement is a `DEFERRABLE INITIALLY DEFERRED` constraint trigger, because
+components are written as a set (delete-all then insert-all) — a row-by-row
+check would fire against a half-built breakdown. There is deliberately **no
+automatic balancing component**: the residual is reported, never absorbed.
 
 ### Views for the Intelligence Layer
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from "./schemas";
 export * from "./utils";
 export * from "./taxonomy";
 export * from "./work";
+export * from "./unit-economics";

--- a/packages/shared/src/unit-economics.test.ts
+++ b/packages/shared/src/unit-economics.test.ts
@@ -333,3 +333,250 @@ describe("stdCostDraftSchema", () => {
     expect(parsed.success).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Reference (benchmark) costs
+// ---------------------------------------------------------------------------
+
+import {
+  computeAllReferenceVariances,
+  computeReferenceVariance,
+  perUnitCostByRmKey,
+  stdCostReferenceSchema,
+  type StdCostReference,
+} from "./unit-economics";
+
+const legacy = (overrides: Partial<StdCostReference> = {}): StdCostReference => ({
+  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  brick_type: "8 CIB",
+  reference_cost: 32.83,
+  source: "legacy_excel",
+  source_label: "Mb Unit Economics sheet",
+  reference_date: "2026-08-22",
+  notes: null,
+  is_active: true,
+  components: [],
+  ...overrides,
+});
+
+describe("computeReferenceVariance", () => {
+  const computed = () => byType(seedBundle(), "8 CIB");
+
+  it("reports the headline reconciliation the screen shows", () => {
+    const variance = computeReferenceVariance(computed(), legacy());
+    expect(variance.computed_cost_per_unit).toBe(27.06);
+    expect(variance.reference_cost).toBe(32.83);
+    expect(variance.variance_amount).toBe(-5.77);
+    expect(variance.variance_pct).toBe(-17.6);
+    expect(variance.is_significant).toBe(true);
+  });
+
+  it("calls the whole gap unexplained when no breakdown is stored", () => {
+    // The honest answer, and the one that keeps a missing breakdown visible
+    // instead of looking like a reconciled zero.
+    const variance = computeReferenceVariance(computed(), legacy());
+    expect(variance.has_component_breakdown).toBe(false);
+    expect(variance.explained_difference).toBe(0);
+    expect(variance.unexplained_difference).toBe(-5.77);
+  });
+
+  it("attributes the gap once a cost element breakdown exists", () => {
+    const c = computed();
+    // A breakdown that accounts for part of the gap; the rest stays unexplained.
+    const reference = legacy({
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 16.02 },
+        { component_kind: "cost_element", component_key: "labour", amount: 8.45 },
+        { component_kind: "cost_element", component_key: "electricity", amount: 1 },
+        { component_kind: "cost_element", component_key: "depreciation", amount: 1 },
+        { component_kind: "cost_element", component_key: "fixed", amount: 6.36 },
+      ],
+    });
+    const variance = computeReferenceVariance(c, reference, {
+      electricityPerUnit: 1,
+      depreciationPerUnit: 1,
+    });
+
+    const material = variance.cost_elements.find((row) => row.component_key === "material");
+    const labour = variance.cost_elements.find((row) => row.component_key === "labour");
+    expect(material?.difference).toBeCloseTo(c.material_cost_per_unit - 16.02, 6);
+    expect(labour?.difference).toBeCloseTo(7 - 8.45, 6);
+
+    // explained + unexplained must always reconstruct the total variance
+    expect(variance.explained_difference + variance.unexplained_difference).toBeCloseTo(
+      variance.variance_amount,
+      2,
+    );
+  });
+
+  it("drills into raw materials without double-counting them as elements", () => {
+    const bundle = seedBundle();
+    const brickType = bundle.brick_types[0];
+    const perUnit = perUnitCostByRmKey(brickType, bundle.rm_prices);
+    const reference = legacy({
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 16.02 },
+        { component_kind: "cost_element", component_key: "labour", amount: 8.45 },
+        { component_kind: "cost_element", component_key: "electricity", amount: 1 },
+        { component_kind: "cost_element", component_key: "depreciation", amount: 1 },
+        { component_kind: "cost_element", component_key: "fixed", amount: 6.36 },
+        { component_kind: "raw_material", component_key: "cement", amount: 6.66 },
+      ],
+    });
+    const variance = computeReferenceVariance(byType(bundle, "8 CIB"), reference, {
+      electricityPerUnit: 1,
+      depreciationPerUnit: 1,
+      perUnitByRmKey: perUnit,
+    });
+
+    // 8.5 kg cement × 6.40 / 9 bricks = 6.044…
+    const cement = variance.raw_materials.find((row) => row.component_key === "cement");
+    expect(cement?.computed_amount).toBeCloseTo((8.5 * 6.4) / 9, 6);
+    expect(cement?.difference).toBeCloseTo((8.5 * 6.4) / 9 - 6.66, 6);
+
+    // The raw-material row lives INSIDE material, so it must not move the
+    // explained total — that would count material twice.
+    const elementSum = variance.cost_elements.reduce((sum, row) => sum + (row.difference ?? 0), 0);
+    expect(variance.explained_difference).toBeCloseTo(elementSum, 2);
+  });
+
+  it("leaves an 'other' component unmatched rather than scoring it as zero", () => {
+    const reference = legacy({
+      reference_cost: 32.83,
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 26.83 },
+        { component_kind: "cost_element", component_key: "other", amount: 6 },
+      ],
+    });
+    const variance = computeReferenceVariance(computed(), reference);
+    const other = variance.cost_elements.find((row) => row.component_key === "other");
+    expect(other?.computed_amount).toBeNull();
+    expect(other?.difference).toBeNull();
+  });
+
+  it("does not flag a small variance", () => {
+    const variance = computeReferenceVariance(computed(), legacy({ reference_cost: 27.5 }));
+    expect(variance.is_significant).toBe(false);
+  });
+
+  it("survives a zero reference cost without dividing by it", () => {
+    const variance = computeReferenceVariance(computed(), legacy({ reference_cost: 0 }));
+    expect(variance.variance_pct).toBeNull();
+    expect(variance.is_significant).toBe(false);
+  });
+});
+
+describe("references never touch the standard", () => {
+  it("computes identical totals with and without references present", () => {
+    // The structural guarantee: computeBundle() has no reference input at all,
+    // so a benchmark cannot leak into a published cost.
+    const bundle = seedBundle();
+    const before = computeBundle(bundle);
+    computeAllReferenceVariances(bundle, [
+      legacy(),
+      legacy({ brick_type: "6 CIB", reference_cost: 31.8 }),
+    ]);
+    expect(computeBundle(bundle)).toEqual(before);
+  });
+
+  it("reconciles every brick type that has a reference, ignoring the rest", () => {
+    const variances = computeAllReferenceVariances(seedBundle(), [
+      legacy(),
+      legacy({ brick_type: "6 CIB", reference_cost: 31.8 }),
+      legacy({ brick_type: "9 XYZ", reference_cost: 10 }), // no such brick type
+      legacy({ brick_type: "8 MIB", reference_cost: 36.12, is_active: false }),
+    ]);
+    expect(variances.map((v) => v.brick_type)).toEqual(["8 CIB", "6 CIB"]);
+  });
+
+  it("reproduces the seeded legacy gaps end to end", () => {
+    const variances = computeAllReferenceVariances(seedBundle(), [
+      legacy({ brick_type: "8 CIB", reference_cost: 32.83 }),
+      legacy({ brick_type: "6 CIB", reference_cost: 31.8 }),
+      legacy({ brick_type: "8 MIB", reference_cost: 36.12 }),
+      legacy({ brick_type: "6 MIB", reference_cost: 29.04 }),
+    ]);
+    expect(variances.map((v) => [v.brick_type, v.variance_amount, v.variance_pct])).toEqual([
+      ["8 CIB", -5.77, -17.6],
+      ["6 CIB", -5.56, -17.5],
+      ["8 MIB", -1.35, -3.7],
+      ["6 MIB", -1.1, -3.8],
+    ]);
+  });
+});
+
+describe("stdCostReferenceSchema", () => {
+  const base = {
+    brick_type: "8 CIB",
+    reference_cost: 32.83,
+    source: "legacy_excel" as const,
+    reference_date: "2026-08-22",
+  };
+
+  it("accepts a reference with no breakdown", () => {
+    expect(stdCostReferenceSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("accepts a cost element breakdown that adds up", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 26.83 },
+        { component_kind: "cost_element", component_key: "labour", amount: 6 },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a breakdown that does not add up to the reference cost", () => {
+    // Otherwise the residual it produces would be arithmetic noise.
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [{ component_kind: "cost_element", component_key: "material", amount: 10 }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("ignores raw material rows when checking that the breakdown adds up", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 26.83 },
+        { component_kind: "cost_element", component_key: "labour", amount: 6 },
+        { component_kind: "raw_material", component_key: "cement", amount: 6.66 },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a duplicate component", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 16.42 },
+        { component_kind: "cost_element", component_key: "material", amount: 16.41 },
+      ],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects an unknown cost element key", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [
+        { component_kind: "cost_element", component_key: "vibes", amount: 32.83 },
+      ],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("still allows any raw material key — those match rm_key, an open set", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      components: [
+        { component_kind: "raw_material", component_key: "some_new_sand", amount: 3 },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/shared/src/unit-economics.test.ts
+++ b/packages/shared/src/unit-economics.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeBundle,
+  computeRmCostPerKg,
+  diffBundles,
+  publishBlockers,
+  publishWarnings,
+  roundMoney,
+  stdCostDraftSchema,
+  type StdCostBundle,
+} from "./unit-economics";
+
+// The go-live seed (supabase/migrations/20260822120100_std_cost_seed_v1.sql).
+// These expectations are the contract between the TypeScript formulas used for
+// live editing and the SQL view v_std_cost_brick_type_computed: if either side
+// drifts, this file is where it gets caught.
+function seedBundle(): StdCostBundle {
+  return {
+    version: {
+      id: "00000000-0000-0000-0000-000000000001",
+      status: "draft",
+      valid_from: null,
+      monthly_production_basis: 15000,
+      notes: null,
+      created_by: null,
+      created_at: "2026-08-22T00:00:00Z",
+      updated_by: null,
+      updated_at: "2026-08-22T00:00:00Z",
+      published_by: null,
+      published_at: null,
+    },
+    rm_prices: [
+      { rm_key: "cement", display_name: "Cement", purchase_amount: 320, purchase_unit_label: "50 Kg Bag", purchase_unit_kg: 50 },
+      { rm_key: "chemical", display_name: "Chemical", purchase_amount: 1850, purchase_unit_label: "25 Kg Can", purchase_unit_kg: 25 },
+      { rm_key: "msand_dust", display_name: "M-Sand Dust", purchase_amount: 4512.5, purchase_unit_label: "Per Unit or 8000 Kgs", purchase_unit_kg: 8000 },
+      { rm_key: "msand_waste", display_name: "M-Sand Waste", purchase_amount: 1937.5, purchase_unit_label: "Per Unit or 8000 Kgs", purchase_unit_kg: 8000 },
+      { rm_key: "red_soil", display_name: "Red Soil", purchase_amount: 4712.5, purchase_unit_label: "Per Load", purchase_unit_kg: 3705 },
+      { rm_key: "red_soil_gravel", display_name: "Red Soil Gravel", purchase_amount: 3600, purchase_unit_label: "Per Load", purchase_unit_kg: 4500 },
+    ],
+    fixed_items: [
+      { item_key: "machine_repair", display_name: "Machine Repair", monthly_amount: 5000 },
+      { item_key: "rent", display_name: "Rent", monthly_amount: 2500 },
+      { item_key: "misc", display_name: "Miscellaneous", monthly_amount: 3000 },
+      { item_key: "stacking_curing", display_name: "Stacking & Curing", monthly_amount: 3000 },
+      { item_key: "manager_salary", display_name: "Manager Salary", monthly_amount: 60000 },
+      { item_key: "marketing", display_name: "Marketing", monthly_amount: 5000 },
+    ],
+    brick_types: [
+      {
+        brick_type: "8 CIB", odoo_product_match: "CIB-10*8*5%", bricks_per_batch: 9,
+        labor_cost_per_batch: 63, electricity_per_unit: 1, depreciation_per_unit: 1,
+        sales_price: 54, loading_unloading_per_unit: 3, transport_per_unit: 3, commission_per_unit: 1,
+        recipe: [
+          { rm_key: "cement", kg_per_batch: 8.5 }, { rm_key: "chemical", kg_per_batch: 0.1 },
+          { rm_key: "msand_dust", kg_per_batch: 74 }, { rm_key: "msand_waste", kg_per_batch: 49 },
+        ],
+      },
+      {
+        brick_type: "6 CIB", odoo_product_match: "CIB-11*6*5%", bricks_per_batch: 9,
+        labor_cost_per_batch: 54, electricity_per_unit: 1, depreciation_per_unit: 1,
+        sales_price: 45, loading_unloading_per_unit: 3, transport_per_unit: 3, commission_per_unit: 1,
+        recipe: [
+          { rm_key: "cement", kg_per_batch: 9.4 }, { rm_key: "chemical", kg_per_batch: 0.1 },
+          { rm_key: "msand_dust", kg_per_batch: 81.8 }, { rm_key: "msand_waste", kg_per_batch: 13.7 },
+        ],
+      },
+      {
+        brick_type: "8 MIB", odoo_product_match: "MIB-10*8*5%", bricks_per_batch: 8,
+        labor_cost_per_batch: 56, electricity_per_unit: 1, depreciation_per_unit: 1.5,
+        sales_price: 55, loading_unloading_per_unit: 3, transport_per_unit: 3, commission_per_unit: 1,
+        recipe: [
+          { rm_key: "cement", kg_per_batch: 9.165 }, { rm_key: "chemical", kg_per_batch: 0.1 },
+          { rm_key: "msand_dust", kg_per_batch: 18.28 }, { rm_key: "red_soil", kg_per_batch: 66 },
+        ],
+      },
+      {
+        brick_type: "6 MIB", odoo_product_match: "MIB-10*6*5%", bricks_per_batch: 11,
+        labor_cost_per_batch: 66, electricity_per_unit: 1, depreciation_per_unit: 1,
+        sales_price: 46, loading_unloading_per_unit: 3, transport_per_unit: 3, commission_per_unit: 1,
+        recipe: [
+          { rm_key: "cement", kg_per_batch: 9 }, { rm_key: "chemical", kg_per_batch: 0.1 },
+          { rm_key: "msand_dust", kg_per_batch: 25 }, { rm_key: "red_soil", kg_per_batch: 65 },
+        ],
+      },
+    ],
+  };
+}
+
+const byType = (bundle: StdCostBundle, type: string) => {
+  const found = computeBundle(bundle).brick_types.find((bt) => bt.brick_type === type);
+  if (!found) throw new Error(`No computed brick type ${type}`);
+  return found;
+};
+
+describe("computeRmCostPerKg", () => {
+  it("derives cost per kg from the purchase inputs", () => {
+    expect(computeRmCostPerKg({ purchase_amount: 320, purchase_unit_kg: 50 })).toBe(6.4);
+  });
+
+  it("computes chemical at 74/kg from 1850 per 25 kg — the sheet's 80 was stale", () => {
+    // The bug this module exists to make impossible: a derived number that
+    // disagrees with its own inputs. 1850/25 = 74, always.
+    expect(computeRmCostPerKg({ purchase_amount: 1850, purchase_unit_kg: 25 })).toBe(74);
+  });
+
+  it("returns 0 rather than Infinity when the unit weight is unusable", () => {
+    expect(computeRmCostPerKg({ purchase_amount: 320, purchase_unit_kg: 0 })).toBe(0);
+  });
+});
+
+describe("computeBundle — seed version", () => {
+  it("spreads the monthly fixed costs over the production basis", () => {
+    const computed = computeBundle(seedBundle());
+    expect(computed.monthly_fixed_total).toBe(78500);
+    expect(computed.fixed_cost_per_unit).toBeCloseTo(78500 / 15000, 10);
+  });
+
+  it("computes 8 CIB end to end", () => {
+    const bt = byType(seedBundle(), "8 CIB");
+    expect(bt.material_cost_per_batch).toBeCloseTo(115.4078125, 6);
+    expect(roundMoney(bt.material_cost_per_unit)).toBe(12.82);
+    expect(bt.labor_cost_per_unit).toBe(7);
+    expect(bt.overhead_per_unit).toBe(2);
+    expect(roundMoney(bt.variable_cost_per_unit)).toBe(21.82);
+    expect(roundMoney(bt.total_cost_per_unit)).toBe(27.06);
+    // 54 − 3 loading − 3 transport − 1 commission − total
+    expect(roundMoney(bt.margin_per_unit ?? 0)).toBe(19.94);
+    expect(roundMoney(bt.bricks_per_cement_bag ?? 0)).toBe(52.94);
+  });
+
+  it("computes every seeded brick type's total cost per unit", () => {
+    const bundle = seedBundle();
+    expect(roundMoney(byType(bundle, "8 CIB").total_cost_per_unit)).toBe(27.06);
+    expect(roundMoney(byType(bundle, "6 CIB").total_cost_per_unit)).toBe(26.24);
+    expect(roundMoney(byType(bundle, "8 MIB").total_cost_per_unit)).toBe(34.77);
+    expect(roundMoney(byType(bundle, "6 MIB").total_cost_per_unit)).toBe(27.94);
+  });
+
+  it("keeps total = variable + fixed for every brick type", () => {
+    for (const bt of computeBundle(seedBundle()).brick_types) {
+      expect(bt.total_cost_per_unit).toBeCloseTo(bt.variable_cost_per_unit + bt.fixed_cost_per_unit, 10);
+    }
+  });
+
+  it("re-derives every total when a raw material price changes", () => {
+    const bundle = seedBundle();
+    const before = byType(bundle, "8 CIB").total_cost_per_unit;
+    const cement = bundle.rm_prices.find((rm) => rm.rm_key === "cement");
+    if (!cement) throw new Error("no cement");
+    cement.purchase_amount = 400; // 8.00/kg
+    const after = byType(bundle, "8 CIB");
+    // 8.5 kg × (8.00 − 6.40) = 13.60 per batch over 9 bricks
+    expect(after.total_cost_per_unit - before).toBeCloseTo((8.5 * 1.6) / 9, 10);
+  });
+});
+
+describe("computeBundle — edge cases", () => {
+  it("does not divide by zero when a batch makes no bricks", () => {
+    const bundle = seedBundle();
+    bundle.brick_types[0].bricks_per_batch = 0;
+    const bt = byType(bundle, "8 CIB");
+    expect(bt.material_cost_per_unit).toBe(0);
+    expect(bt.labor_cost_per_unit).toBe(0);
+    expect(Number.isFinite(bt.total_cost_per_unit)).toBe(true);
+  });
+
+  it("flags recipe lines whose raw material has no price", () => {
+    const bundle = seedBundle();
+    bundle.rm_prices = bundle.rm_prices.filter((rm) => rm.rm_key !== "msand_dust");
+    expect(byType(bundle, "8 CIB").missing_rm_keys).toEqual(["msand_dust"]);
+  });
+
+  it("returns a null margin when there is no sales price", () => {
+    const bundle = seedBundle();
+    bundle.brick_types[0].sales_price = null;
+    expect(byType(bundle, "8 CIB").margin_per_unit).toBeNull();
+  });
+
+  it("returns null bricks-per-cement-bag when the recipe has no cement", () => {
+    const bundle = seedBundle();
+    bundle.brick_types[0].recipe = bundle.brick_types[0].recipe.filter((l) => l.rm_key !== "cement");
+    expect(byType(bundle, "8 CIB").bricks_per_cement_bag).toBeNull();
+  });
+});
+
+describe("publishBlockers", () => {
+  it("passes the seed version", () => {
+    expect(publishBlockers(seedBundle())).toEqual([]);
+  });
+
+  it("blocks a brick type with no cement recipe line", () => {
+    const bundle = seedBundle();
+    bundle.brick_types[1].recipe = bundle.brick_types[1].recipe.filter((l) => l.rm_key !== "cement");
+    const blockers = publishBlockers(bundle);
+    expect(blockers.some((b) => b.brick_type === "6 CIB" && b.message.includes("cement"))).toBe(true);
+  });
+
+  it("blocks a zero total cost per unit", () => {
+    const bundle = seedBundle();
+    bundle.brick_types = [
+      {
+        ...bundle.brick_types[0],
+        labor_cost_per_batch: 0,
+        electricity_per_unit: 0,
+        depreciation_per_unit: 0,
+        recipe: [{ rm_key: "cement", kg_per_batch: 0.001 }],
+      },
+    ];
+    bundle.fixed_items = [];
+    bundle.brick_types[0].recipe = [{ rm_key: "cement", kg_per_batch: 0 }];
+    expect(publishBlockers(bundle).some((b) => b.message.includes("Total cost per unit"))).toBe(true);
+  });
+
+  it("blocks a version with no brick types", () => {
+    const bundle = seedBundle();
+    bundle.brick_types = [];
+    expect(publishBlockers(bundle).some((b) => b.message === "No brick types defined")).toBe(true);
+  });
+});
+
+describe("publishWarnings", () => {
+  it("is quiet when nothing moved", () => {
+    expect(publishWarnings(seedBundle(), seedBundle())).toEqual([]);
+  });
+
+  it("is quiet for a small move", () => {
+    const draft = seedBundle();
+    const cement = draft.rm_prices.find((rm) => rm.rm_key === "cement");
+    if (!cement) throw new Error("no cement");
+    cement.purchase_amount = 330;
+    expect(publishWarnings(draft, seedBundle())).toEqual([]);
+  });
+
+  it("warns when a total moves more than 15%", () => {
+    const draft = seedBundle();
+    for (const rm of draft.rm_prices) rm.purchase_amount *= 2;
+    const warnings = publishWarnings(draft, seedBundle());
+    expect(warnings.length).toBe(4);
+    expect(warnings[0].change_pct).toBeGreaterThan(15);
+  });
+
+  it("has nothing to compare against when nothing is published yet", () => {
+    expect(publishWarnings(seedBundle(), null)).toEqual([]);
+  });
+});
+
+describe("diffBundles", () => {
+  it("finds nothing between identical versions", () => {
+    expect(diffBundles(seedBundle(), seedBundle())).toEqual([]);
+  });
+
+  it("reports the changed input and every total it moved", () => {
+    const after = seedBundle();
+    const cement = after.rm_prices.find((rm) => rm.rm_key === "cement");
+    if (!cement) throw new Error("no cement");
+    cement.purchase_amount = 400;
+
+    const rows = diffBundles(seedBundle(), after);
+    const purchase = rows.find((r) => r.section === "raw_material" && r.label === "Purchase amount");
+    expect(purchase).toMatchObject({ group: "Cement", before: 320, after: 400 });
+
+    const costPerKg = rows.find((r) => r.section === "raw_material" && r.label === "Cost / kg");
+    expect(costPerKg).toMatchObject({ before: 6.4, after: 8 });
+
+    // all four brick types' totals moved
+    const totals = rows.filter((r) => r.section === "computed" && r.label === "Total cost / unit");
+    expect(totals.length).toBe(4);
+  });
+
+  it("reports recipe changes per brick type", () => {
+    const after = seedBundle();
+    after.brick_types[0].recipe[0].kg_per_batch = 9;
+    const rows = diffBundles(seedBundle(), after);
+    expect(rows.some((r) => r.section === "recipe" && r.group === "8 CIB" && r.before === 8.5 && r.after === 9)).toBe(true);
+  });
+
+  it("shows an added and a removed brick type as null on one side", () => {
+    const after = seedBundle();
+    after.brick_types = after.brick_types.filter((bt) => bt.brick_type !== "6 MIB");
+    const rows = diffBundles(seedBundle(), after);
+    expect(rows.some((r) => r.group === "6 MIB" && r.after === null)).toBe(true);
+  });
+
+  it("returns nothing when there is no version to compare against", () => {
+    expect(diffBundles(null, seedBundle())).toEqual([]);
+  });
+});
+
+describe("roundMoney", () => {
+  it("rounds to 2 dp by default", () => {
+    expect(roundMoney(27.0564)).toBe(27.06);
+  });
+  it("never returns -0", () => {
+    expect(Object.is(roundMoney(-0.0001), 0)).toBe(true);
+  });
+  it("is null-safe", () => {
+    expect(roundMoney(null)).toBe(0);
+    expect(roundMoney(undefined)).toBe(0);
+    expect(roundMoney(Number.NaN)).toBe(0);
+  });
+});
+
+describe("stdCostDraftSchema", () => {
+  const base = {
+    version_id: "00000000-0000-0000-0000-000000000001",
+    monthly_production_basis: 15000,
+    rm_prices: [],
+    brick_types: [],
+    fixed_items: [],
+  };
+
+  it("accepts a well-formed draft", () => {
+    expect(stdCostDraftSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("rejects a zero production basis (it is a divisor)", () => {
+    expect(stdCostDraftSchema.safeParse({ ...base, monthly_production_basis: 0 }).success).toBe(false);
+  });
+
+  it("rejects a raw material with a zero purchase unit weight", () => {
+    const parsed = stdCostDraftSchema.safeParse({
+      ...base,
+      rm_prices: [{ rm_key: "cement", display_name: "Cement", purchase_amount: 320, purchase_unit_label: "Bag", purchase_unit_kg: 0 }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a negative cost", () => {
+    const parsed = stdCostDraftSchema.safeParse({
+      ...base,
+      fixed_items: [{ item_key: "rent", display_name: "Rent", monthly_amount: -1 }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/shared/src/unit-economics.test.ts
+++ b/packages/shared/src/unit-economics.test.ts
@@ -355,6 +355,7 @@ const legacy = (overrides: Partial<StdCostReference> = {}): StdCostReference => 
   reference_date: "2026-08-22",
   notes: null,
   is_active: true,
+  breakdown_status: "partial",
   components: [],
   ...overrides,
 });
@@ -528,13 +529,60 @@ describe("stdCostReferenceSchema", () => {
     expect(parsed.success).toBe(true);
   });
 
-  it("rejects a breakdown that does not add up to the reference cost", () => {
-    // Otherwise the residual it produces would be arithmetic noise.
+  it("accepts a PARTIAL breakdown that covers only part of the total", () => {
+    // The normal working state: one component discovered so far.
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      breakdown_status: "partial",
+      components: [{ component_kind: "cost_element", component_key: "material", amount: 10 }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("defaults to partial when no status is given", () => {
     const parsed = stdCostReferenceSchema.safeParse({
       ...base,
       components: [{ component_kind: "cost_element", component_key: "material", amount: 10 }],
     });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a COMPLETE breakdown that does not add up", () => {
+    // Completeness is a claim. If it is false, the zero residual it produces
+    // would be a lie.
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      breakdown_status: "complete",
+      components: [{ component_kind: "cost_element", component_key: "material", amount: 10 }],
+    });
     expect(parsed.success).toBe(false);
+  });
+
+  it("rejects any breakdown that sums beyond the total, in either state", () => {
+    // Cost elements are exclusive parts of the total — arithmetic, not policy.
+    for (const status of ["partial", "complete"] as const) {
+      const parsed = stdCostReferenceSchema.safeParse({
+        ...base,
+        breakdown_status: status,
+        components: [
+          { component_kind: "cost_element", component_key: "material", amount: 30 },
+          { component_kind: "cost_element", component_key: "labour", amount: 10 },
+        ],
+      });
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it("accepts a complete breakdown within the rounding tolerance", () => {
+    const parsed = stdCostReferenceSchema.safeParse({
+      ...base,
+      breakdown_status: "complete",
+      components: [
+        { component_kind: "cost_element", component_key: "material", amount: 26.83 },
+        { component_kind: "cost_element", component_key: "labour", amount: 6.005 },
+      ],
+    });
+    expect(parsed.success).toBe(true);
   });
 
   it("ignores raw material rows when checking that the breakdown adds up", () => {
@@ -578,5 +626,97 @@ describe("stdCostReferenceSchema", () => {
       ],
     });
     expect(parsed.success).toBe(true);
+  });
+});
+
+describe("progressive reconciliation", () => {
+  // The workflow this design exists for: discover components one at a time and
+  // watch the unexplained amount shrink. If a breakdown were forced to balance,
+  // unexplained would be zero from the first entry and none of this would work.
+  const computed = () => byType(seedBundle(), "8 CIB");
+  const options = { electricityPerUnit: 1, depreciationPerUnit: 1 };
+
+  // Reference components chosen so each difference is a round number:
+  //   material  16.0231 → −3.20   labour 8.45 → −1.45   fixed 6.3633 → −1.12
+  const MATERIAL = { component_kind: "cost_element" as const, component_key: "material", amount: 16.0231 };
+  const LABOUR = { component_kind: "cost_element" as const, component_key: "labour", amount: 8.45 };
+  const FIXED = { component_kind: "cost_element" as const, component_key: "fixed", amount: 6.3533 };
+
+  it("stage 0 — nothing known: the whole variance is unexplained", () => {
+    const variance = computeReferenceVariance(computed(), legacy(), options);
+    expect(variance.variance_amount).toBe(-5.77);
+    expect(variance.explained_difference).toBe(0);
+    expect(variance.unexplained_difference).toBe(-5.77);
+    expect(variance.breakdown_coverage).toBe(0);
+    expect(variance.breakdown_coverage_pct).toBe(0);
+  });
+
+  it("stage 1 — material found: part explained, the rest still open", () => {
+    const variance = computeReferenceVariance(
+      computed(),
+      legacy({ components: [MATERIAL] }),
+      options,
+    );
+    expect(variance.explained_difference).toBe(-3.2);
+    expect(variance.unexplained_difference).toBe(-2.57);
+    expect(variance.breakdown_status).toBe("partial");
+    expect(variance.breakdown_coverage).toBe(16.02);
+  });
+
+  it("stage 2 — material + labour: matches the worked example", () => {
+    const variance = computeReferenceVariance(
+      computed(),
+      legacy({ components: [MATERIAL, LABOUR] }),
+      options,
+    );
+    expect(variance.variance_amount).toBe(-5.77);
+    expect(variance.explained_difference).toBe(-4.65);
+    expect(variance.unexplained_difference).toBe(-1.12);
+    // Coverage is honest about how much of the benchmark is described.
+    expect(variance.breakdown_coverage).toBe(24.47);
+    expect(variance.breakdown_coverage_pct).toBeLessThan(100);
+  });
+
+  it("stage 3 — fixed cost found too: the residual shrinks again", () => {
+    const variance = computeReferenceVariance(
+      computed(),
+      legacy({ components: [MATERIAL, LABOUR, FIXED] }),
+      options,
+    );
+    expect(variance.explained_difference).toBe(-5.77);
+    expect(variance.unexplained_difference).toBe(0);
+  });
+
+  it("the residual is never absorbed — explained + unexplained always reconstructs it", () => {
+    for (const components of [[], [MATERIAL], [MATERIAL, LABOUR], [MATERIAL, LABOUR, FIXED]]) {
+      const variance = computeReferenceVariance(computed(), legacy({ components }), options);
+      expect(variance.explained_difference + variance.unexplained_difference).toBeCloseTo(
+        variance.variance_amount,
+        2,
+      );
+    }
+  });
+
+  it("unexplained can only reach zero through real components, never by construction", () => {
+    // A partial breakdown that covers most of the total still leaves a residual:
+    // the earlier bug was that ANY breakdown drove this to zero.
+    const variance = computeReferenceVariance(
+      computed(),
+      legacy({ components: [MATERIAL, LABOUR] }),
+      options,
+    );
+    expect(variance.unexplained_difference).not.toBe(0);
+  });
+
+  it("a complete breakdown that genuinely accounts for everything reaches zero", () => {
+    const variance = computeReferenceVariance(
+      computed(),
+      legacy({ breakdown_status: "complete", components: [MATERIAL, LABOUR, FIXED, 
+        { component_kind: "cost_element", component_key: "electricity", amount: 1 },
+        { component_kind: "cost_element", component_key: "depreciation", amount: 1 }] }),
+      options,
+    );
+    expect(variance.breakdown_status).toBe("complete");
+    expect(variance.unexplained_difference).toBe(0);
   });
 });

--- a/packages/shared/src/unit-economics.ts
+++ b/packages/shared/src/unit-economics.ts
@@ -1,0 +1,486 @@
+// @maiyuri/shared - Unit Economics (standard cost) types, schemas and the
+// single TypeScript source of truth for every derived number.
+//
+// This mirrors, formula for formula, the SQL in
+// supabase/migrations/20260822120000_std_cost_unit_economics.sql
+// (view v_std_cost_brick_type_computed). The editor needs live numbers for a
+// draft that has not been saved yet, which SQL cannot give it — so the formula
+// exists twice, and unit-economics.test.ts pins both to the same expected
+// values so they can never drift apart silently.
+//
+// The rule that makes the "chemical shows ₹80/kg while its own inputs say ₹74"
+// class of error impossible: nothing below is ever stored from user input.
+
+import { z } from "zod";
+
+export type StdCostVersionStatus = "draft" | "published" | "archived";
+
+/** The six raw materials the standard is built from (extensible). */
+export const STD_COST_RM_KEYS = [
+  "cement",
+  "chemical",
+  "msand_dust",
+  "msand_waste",
+  "red_soil",
+  "red_soil_gravel",
+] as const;
+
+export interface StdCostVersion {
+  id: string;
+  status: StdCostVersionStatus;
+  valid_from: string | null;
+  monthly_production_basis: number;
+  notes: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_by: string | null;
+  updated_at: string;
+  published_by: string | null;
+  published_at: string | null;
+}
+
+export interface StdCostRmPrice {
+  id?: string;
+  rm_key: string;
+  display_name: string;
+  purchase_amount: number;
+  purchase_unit_label: string;
+  purchase_unit_kg: number;
+}
+
+export interface StdCostRecipeLine {
+  rm_key: string;
+  kg_per_batch: number;
+}
+
+export interface StdCostBrickType {
+  id?: string;
+  brick_type: string;
+  odoo_product_match: string;
+  bricks_per_batch: number;
+  labor_cost_per_batch: number;
+  electricity_per_unit: number;
+  depreciation_per_unit: number;
+  sales_price: number | null;
+  loading_unloading_per_unit: number;
+  transport_per_unit: number;
+  commission_per_unit: number;
+  sort_order?: number;
+  recipe: StdCostRecipeLine[];
+}
+
+export interface StdCostFixedItem {
+  id?: string;
+  item_key: string;
+  display_name: string;
+  monthly_amount: number;
+}
+
+/** A published version as the History list shows it. */
+export interface StdCostVersionSummary extends StdCostVersion {
+  published_by_name: string | null;
+}
+
+/** Everything that makes up one version — what the editor loads and saves. */
+export interface StdCostBundle {
+  version: StdCostVersion;
+  rm_prices: StdCostRmPrice[];
+  brick_types: StdCostBrickType[];
+  fixed_items: StdCostFixedItem[];
+}
+
+// --------------------------------------------------------------- computed --
+
+export interface ComputedRmPrice extends StdCostRmPrice {
+  /** purchase_amount / purchase_unit_kg — never typed, always derived. */
+  cost_per_kg: number;
+}
+
+export interface ComputedBrickType {
+  brick_type: string;
+  odoo_product_match: string;
+  bricks_per_batch: number;
+  sales_price: number | null;
+  material_cost_per_batch: number;
+  material_cost_per_unit: number;
+  labor_cost_per_batch: number;
+  labor_cost_per_unit: number;
+  overhead_per_unit: number;
+  variable_cost_per_unit: number;
+  fixed_cost_per_unit: number;
+  total_cost_per_unit: number;
+  margin_per_unit: number | null;
+  bricks_per_cement_bag: number | null;
+  /** Recipe lines whose rm_key has no price row in this version. */
+  missing_rm_keys: string[];
+}
+
+export interface ComputedBundle {
+  monthly_fixed_total: number;
+  monthly_production_basis: number;
+  fixed_cost_per_unit: number;
+  rm_prices: ComputedRmPrice[];
+  brick_types: ComputedBrickType[];
+}
+
+/** Raw-material cost per kg. Zero-safe: an unusable unit weight yields 0. */
+export function computeRmCostPerKg(rm: {
+  purchase_amount: number;
+  purchase_unit_kg: number;
+}): number {
+  const kg = rm.purchase_unit_kg ?? 0;
+  if (!(kg > 0)) return 0;
+  return (rm.purchase_amount ?? 0) / kg;
+}
+
+/**
+ * Compute every derived number for a version. Full precision throughout —
+ * round only at display (`roundMoney`) or in the contract views.
+ */
+export function computeBundle(bundle: StdCostBundle): ComputedBundle {
+  const basis = bundle.version?.monthly_production_basis ?? 0;
+  const monthlyFixedTotal = (bundle.fixed_items ?? []).reduce(
+    (sum, item) => sum + (item.monthly_amount ?? 0),
+    0,
+  );
+  const fixedCostPerUnit = basis > 0 ? monthlyFixedTotal / basis : 0;
+
+  const rmPrices: ComputedRmPrice[] = (bundle.rm_prices ?? []).map((rm) => ({
+    ...rm,
+    cost_per_kg: computeRmCostPerKg(rm),
+  }));
+  const costPerKgByKey = new Map(rmPrices.map((rm) => [rm.rm_key, rm.cost_per_kg]));
+
+  const brickTypes = (bundle.brick_types ?? []).map((bt) =>
+    computeBrickType(bt, costPerKgByKey, fixedCostPerUnit),
+  );
+
+  return {
+    monthly_fixed_total: monthlyFixedTotal,
+    monthly_production_basis: basis,
+    fixed_cost_per_unit: fixedCostPerUnit,
+    rm_prices: rmPrices,
+    brick_types: brickTypes,
+  };
+}
+
+function computeBrickType(
+  bt: StdCostBrickType,
+  costPerKgByKey: Map<string, number>,
+  fixedCostPerUnit: number,
+): ComputedBrickType {
+  const perBatch = bt.bricks_per_batch ?? 0;
+  const recipe = bt.recipe ?? [];
+
+  const missing = recipe
+    .filter((line) => !costPerKgByKey.has(line.rm_key))
+    .map((line) => line.rm_key);
+
+  const materialPerBatch = recipe.reduce(
+    (sum, line) => sum + (line.kg_per_batch ?? 0) * (costPerKgByKey.get(line.rm_key) ?? 0),
+    0,
+  );
+
+  // A batch that makes no bricks has no per-unit cost; guard rather than divide.
+  const safeDivide = (value: number) => (perBatch > 0 ? value / perBatch : 0);
+
+  const materialPerUnit = safeDivide(materialPerBatch);
+  const laborPerUnit = safeDivide(bt.labor_cost_per_batch ?? 0);
+  const overheadPerUnit = (bt.electricity_per_unit ?? 0) + (bt.depreciation_per_unit ?? 0);
+  const variablePerUnit = materialPerUnit + laborPerUnit + overheadPerUnit;
+  const totalPerUnit = variablePerUnit + fixedCostPerUnit;
+
+  const salesPrice = bt.sales_price ?? null;
+  const marginPerUnit =
+    salesPrice === null
+      ? null
+      : salesPrice -
+        (bt.loading_unloading_per_unit ?? 0) -
+        (bt.transport_per_unit ?? 0) -
+        (bt.commission_per_unit ?? 0) -
+        totalPerUnit;
+
+  const cementKg = recipe.find((line) => line.rm_key === "cement")?.kg_per_batch ?? 0;
+
+  return {
+    brick_type: bt.brick_type,
+    odoo_product_match: bt.odoo_product_match,
+    bricks_per_batch: perBatch,
+    sales_price: salesPrice,
+    material_cost_per_batch: materialPerBatch,
+    material_cost_per_unit: materialPerUnit,
+    labor_cost_per_batch: bt.labor_cost_per_batch ?? 0,
+    labor_cost_per_unit: laborPerUnit,
+    overhead_per_unit: overheadPerUnit,
+    variable_cost_per_unit: variablePerUnit,
+    fixed_cost_per_unit: fixedCostPerUnit,
+    total_cost_per_unit: totalPerUnit,
+    margin_per_unit: marginPerUnit,
+    bricks_per_cement_bag: cementKg > 0 ? (perBatch * 50) / cementKg : null,
+    missing_rm_keys: missing,
+  };
+}
+
+/** Display rounding — 2 dp, and never "-0.00". */
+export function roundMoney(value: number | null | undefined, dp = 2): number {
+  if (value === null || value === undefined || !Number.isFinite(value)) return 0;
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded === 0 ? 0 : rounded;
+}
+
+// ------------------------------------------------------- publish gatekeeping
+
+export interface PublishBlocker {
+  brick_type: string | null;
+  message: string;
+}
+
+export interface PublishWarning {
+  label: string;
+  previous: number;
+  next: number;
+  change_pct: number;
+}
+
+/** A total moving more than this vs the published standard is worth a look. */
+export const STD_COST_WARN_THRESHOLD_PCT = 15;
+
+/**
+ * Hard blockers (PRD §7): no brick type may lack a cement recipe line, and no
+ * total cost may be zero or negative — both mean the inputs are wrong, and a
+ * published version cannot be edited afterwards.
+ */
+export function publishBlockers(bundle: StdCostBundle): PublishBlocker[] {
+  const computed = computeBundle(bundle);
+  const blockers: PublishBlocker[] = [];
+
+  if (computed.brick_types.length === 0) {
+    blockers.push({ brick_type: null, message: "No brick types defined" });
+  }
+  if (!(computed.monthly_production_basis > 0)) {
+    blockers.push({ brick_type: null, message: "Monthly production basis must be greater than 0" });
+  }
+
+  for (const bt of bundle.brick_types ?? []) {
+    const cement = (bt.recipe ?? []).find((line) => line.rm_key === "cement");
+    if (!cement || !(cement.kg_per_batch > 0)) {
+      blockers.push({
+        brick_type: bt.brick_type,
+        message: "No cement in the recipe — every brick type must consume cement",
+      });
+    }
+  }
+
+  for (const bt of computed.brick_types) {
+    if (!(bt.total_cost_per_unit > 0)) {
+      blockers.push({
+        brick_type: bt.brick_type,
+        message: `Total cost per unit is ${roundMoney(bt.total_cost_per_unit)} — must be greater than 0`,
+      });
+    }
+    if (bt.missing_rm_keys.length > 0) {
+      blockers.push({
+        brick_type: bt.brick_type,
+        message: `Recipe uses raw materials with no price: ${bt.missing_rm_keys.join(", ")}`,
+      });
+    }
+  }
+
+  return blockers;
+}
+
+/** Non-blocking: totals that moved more than 15% vs the published version. */
+export function publishWarnings(
+  draft: StdCostBundle,
+  published: StdCostBundle | null,
+): PublishWarning[] {
+  if (!published) return [];
+  const next = computeBundle(draft);
+  const previous = computeBundle(published);
+  const previousByType = new Map(previous.brick_types.map((bt) => [bt.brick_type, bt]));
+
+  const warnings: PublishWarning[] = [];
+  for (const bt of next.brick_types) {
+    const before = previousByType.get(bt.brick_type);
+    if (!before || !(before.total_cost_per_unit > 0)) continue;
+    const changePct =
+      ((bt.total_cost_per_unit - before.total_cost_per_unit) / before.total_cost_per_unit) * 100;
+    if (Math.abs(changePct) > STD_COST_WARN_THRESHOLD_PCT) {
+      warnings.push({
+        label: `${bt.brick_type} total cost/unit`,
+        previous: roundMoney(before.total_cost_per_unit),
+        next: roundMoney(bt.total_cost_per_unit),
+        change_pct: roundMoney(changePct, 1),
+      });
+    }
+  }
+  return warnings;
+}
+
+// -------------------------------------------------------------------- diff --
+
+export interface StdCostDiffRow {
+  section: "version" | "raw_material" | "brick_type" | "recipe" | "fixed_cost" | "computed";
+  group: string;
+  label: string;
+  before: number | string | null;
+  after: number | string | null;
+}
+
+function pushDiff(
+  rows: StdCostDiffRow[],
+  section: StdCostDiffRow["section"],
+  group: string,
+  label: string,
+  before: number | string | null | undefined,
+  after: number | string | null | undefined,
+) {
+  const a = before ?? null;
+  const b = after ?? null;
+  if (typeof a === "number" && typeof b === "number") {
+    if (roundMoney(a, 4) === roundMoney(b, 4)) return;
+  } else if (a === b) {
+    return;
+  }
+  rows.push({ section, group, label, before: a, after: b });
+}
+
+/**
+ * Number-by-number diff between two versions — "what changed between v3 and
+ * v4". Covers inputs AND the resulting computed totals, since the totals are
+ * what anyone downstream actually feels.
+ */
+export function diffBundles(before: StdCostBundle | null, after: StdCostBundle): StdCostDiffRow[] {
+  const rows: StdCostDiffRow[] = [];
+  if (!before) return rows;
+
+  pushDiff(rows, "version", "Version", "Monthly production basis",
+    before.version.monthly_production_basis, after.version.monthly_production_basis);
+
+  // raw materials
+  const beforeRm = new Map((before.rm_prices ?? []).map((rm) => [rm.rm_key, rm]));
+  const afterRm = new Map((after.rm_prices ?? []).map((rm) => [rm.rm_key, rm]));
+  for (const key of unionKeys(beforeRm, afterRm)) {
+    const a = beforeRm.get(key);
+    const b = afterRm.get(key);
+    const group = b?.display_name ?? a?.display_name ?? key;
+    pushDiff(rows, "raw_material", group, "Purchase amount", a?.purchase_amount ?? null, b?.purchase_amount ?? null);
+    pushDiff(rows, "raw_material", group, "Purchase unit (kg)", a?.purchase_unit_kg ?? null, b?.purchase_unit_kg ?? null);
+    pushDiff(rows, "raw_material", group, "Unit label", a?.purchase_unit_label ?? null, b?.purchase_unit_label ?? null);
+    pushDiff(rows, "raw_material", group, "Cost / kg",
+      a ? roundMoney(computeRmCostPerKg(a), 4) : null,
+      b ? roundMoney(computeRmCostPerKg(b), 4) : null);
+  }
+
+  // fixed costs
+  const beforeFixed = new Map((before.fixed_items ?? []).map((f) => [f.item_key, f]));
+  const afterFixed = new Map((after.fixed_items ?? []).map((f) => [f.item_key, f]));
+  for (const key of unionKeys(beforeFixed, afterFixed)) {
+    const a = beforeFixed.get(key);
+    const b = afterFixed.get(key);
+    pushDiff(rows, "fixed_cost", b?.display_name ?? a?.display_name ?? key, "Monthly amount",
+      a?.monthly_amount ?? null, b?.monthly_amount ?? null);
+  }
+
+  // brick types + recipes
+  const beforeBt = new Map((before.brick_types ?? []).map((bt) => [bt.brick_type, bt]));
+  const afterBt = new Map((after.brick_types ?? []).map((bt) => [bt.brick_type, bt]));
+  for (const key of unionKeys(beforeBt, afterBt)) {
+    const a = beforeBt.get(key);
+    const b = afterBt.get(key);
+    pushDiff(rows, "brick_type", key, "Odoo product match", a?.odoo_product_match ?? null, b?.odoo_product_match ?? null);
+    pushDiff(rows, "brick_type", key, "Bricks / batch", a?.bricks_per_batch ?? null, b?.bricks_per_batch ?? null);
+    pushDiff(rows, "brick_type", key, "Labour / batch", a?.labor_cost_per_batch ?? null, b?.labor_cost_per_batch ?? null);
+    pushDiff(rows, "brick_type", key, "Electricity / unit", a?.electricity_per_unit ?? null, b?.electricity_per_unit ?? null);
+    pushDiff(rows, "brick_type", key, "Depreciation / unit", a?.depreciation_per_unit ?? null, b?.depreciation_per_unit ?? null);
+    pushDiff(rows, "brick_type", key, "Sales price", a?.sales_price ?? null, b?.sales_price ?? null);
+    pushDiff(rows, "brick_type", key, "Loading / unloading", a?.loading_unloading_per_unit ?? null, b?.loading_unloading_per_unit ?? null);
+    pushDiff(rows, "brick_type", key, "Transport / unit", a?.transport_per_unit ?? null, b?.transport_per_unit ?? null);
+    pushDiff(rows, "brick_type", key, "Commission / unit", a?.commission_per_unit ?? null, b?.commission_per_unit ?? null);
+
+    const aRecipe = new Map((a?.recipe ?? []).map((line) => [line.rm_key, line.kg_per_batch]));
+    const bRecipe = new Map((b?.recipe ?? []).map((line) => [line.rm_key, line.kg_per_batch]));
+    for (const rmKey of unionKeys(aRecipe, bRecipe)) {
+      pushDiff(rows, "recipe", key, `${rmKey} kg / batch`,
+        aRecipe.get(rmKey) ?? null, bRecipe.get(rmKey) ?? null);
+    }
+  }
+
+  // computed totals — the part everyone downstream feels
+  const beforeComputed = new Map(computeBundle(before).brick_types.map((bt) => [bt.brick_type, bt]));
+  const afterComputed = new Map(computeBundle(after).brick_types.map((bt) => [bt.brick_type, bt]));
+  for (const key of unionKeys(beforeComputed, afterComputed)) {
+    const a = beforeComputed.get(key);
+    const b = afterComputed.get(key);
+    pushDiff(rows, "computed", key, "Variable cost / unit",
+      a ? roundMoney(a.variable_cost_per_unit) : null, b ? roundMoney(b.variable_cost_per_unit) : null);
+    pushDiff(rows, "computed", key, "Fixed cost / unit",
+      a ? roundMoney(a.fixed_cost_per_unit) : null, b ? roundMoney(b.fixed_cost_per_unit) : null);
+    pushDiff(rows, "computed", key, "Total cost / unit",
+      a ? roundMoney(a.total_cost_per_unit) : null, b ? roundMoney(b.total_cost_per_unit) : null);
+    pushDiff(rows, "computed", key, "Margin / unit",
+      a?.margin_per_unit === null || a === undefined ? null : roundMoney(a.margin_per_unit),
+      b?.margin_per_unit === null || b === undefined ? null : roundMoney(b.margin_per_unit));
+  }
+
+  return rows;
+}
+
+function unionKeys<V>(a: Map<string, V>, b: Map<string, V>): string[] {
+  return Array.from(new Set([...a.keys(), ...b.keys()]));
+}
+
+// ----------------------------------------------------------------- schemas --
+
+export const stdCostRmPriceSchema = z.object({
+  rm_key: z.string().min(1).max(64),
+  display_name: z.string().min(1).max(120),
+  purchase_amount: z.number().min(0).finite(),
+  purchase_unit_label: z.string().min(1).max(120),
+  purchase_unit_kg: z.number().positive().finite(),
+});
+
+export const stdCostRecipeLineSchema = z.object({
+  rm_key: z.string().min(1).max(64),
+  kg_per_batch: z.number().min(0).finite(),
+});
+
+export const stdCostBrickTypeSchema = z.object({
+  brick_type: z.string().min(1).max(64),
+  odoo_product_match: z.string().min(1).max(200),
+  bricks_per_batch: z.number().positive().finite(),
+  labor_cost_per_batch: z.number().min(0).finite(),
+  electricity_per_unit: z.number().min(0).finite(),
+  depreciation_per_unit: z.number().min(0).finite(),
+  sales_price: z.number().min(0).finite().nullable(),
+  loading_unloading_per_unit: z.number().min(0).finite(),
+  transport_per_unit: z.number().min(0).finite(),
+  commission_per_unit: z.number().min(0).finite(),
+  sort_order: z.number().int().min(0).optional(),
+  recipe: z.array(stdCostRecipeLineSchema).max(40),
+});
+
+export const stdCostFixedItemSchema = z.object({
+  item_key: z.string().min(1).max(64),
+  display_name: z.string().min(1).max(120),
+  monthly_amount: z.number().min(0).finite(),
+});
+
+/** Body of PUT /api/unit-economics/draft — the whole draft, replace-all. */
+export const stdCostDraftSchema = z.object({
+  version_id: z.string().uuid(),
+  monthly_production_basis: z.number().int().positive().max(10_000_000),
+  notes: z.string().max(2000).nullable().optional(),
+  rm_prices: z.array(stdCostRmPriceSchema).max(50),
+  brick_types: z.array(stdCostBrickTypeSchema).max(50),
+  fixed_items: z.array(stdCostFixedItemSchema).max(50),
+});
+
+export type StdCostDraftPayload = z.infer<typeof stdCostDraftSchema>;
+
+export const stdCostPublishSchema = z.object({
+  version_id: z.string().uuid(),
+  valid_from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "valid_from must be YYYY-MM-DD"),
+  notes: z.string().max(2000).nullable().optional(),
+});

--- a/packages/shared/src/unit-economics.ts
+++ b/packages/shared/src/unit-economics.ts
@@ -570,6 +570,16 @@ export interface StdCostReferenceComponent {
   amount: number;
 }
 
+/**
+ * 'partial'  — the components cover only part of the total. Coverage is shown,
+ *              and the unexplained residual stays live: this is the normal
+ *              state while a reconciliation is still being worked out.
+ * 'complete' — an explicit assertion that the components ARE the whole total.
+ *              Only then is equality enforced, because only then does a zero
+ *              residual mean anything.
+ */
+export type StdCostBreakdownStatus = "partial" | "complete";
+
 export interface StdCostReference {
   id?: string;
   brick_type: string;
@@ -579,6 +589,7 @@ export interface StdCostReference {
   reference_date: string;
   notes: string | null;
   is_active: boolean;
+  breakdown_status: StdCostBreakdownStatus;
   components: StdCostReferenceComponent[];
 }
 
@@ -606,9 +617,18 @@ export interface StdCostReferenceVariance {
   variance_pct: number | null;
   is_significant: boolean;
   has_component_breakdown: boolean;
+  breakdown_status: StdCostBreakdownStatus;
+  /** Σ of the cost_element reference amounts — how much of the total is described. */
+  breakdown_coverage: number;
+  breakdown_coverage_pct: number | null;
   /** Σ of cost_element differences — the part the breakdown accounts for. */
   explained_difference: number;
-  /** What no stored component explains. The whole variance when there is no breakdown. */
+  /**
+   * What no stored component explains. Equals the whole variance when nothing
+   * is known yet, and shrinks as components are discovered. Reaches zero only
+   * when a genuinely complete breakdown accounts for every rupee — never by
+   * being backed into.
+   */
   unexplained_difference: number;
   cost_elements: StdCostComponentVariance[];
   raw_materials: StdCostComponentVariance[];
@@ -616,6 +636,9 @@ export interface StdCostReferenceVariance {
 
 /** A variance beyond this deserves a flag on screen. */
 export const STD_COST_VARIANCE_SIGNIFICANT_PCT = 10;
+
+/** Rounding slack when checking a breakdown against its total (₹). */
+export const STD_COST_BREAKDOWN_TOLERANCE = 0.01;
 
 /**
  * Reconcile one computed brick type against one reference.
@@ -677,6 +700,8 @@ export function computeReferenceVariance(
 
   const varianceAmount = computed.total_cost_per_unit - reference.reference_cost;
   const explained = costElements.reduce((sum, row) => sum + (row.difference ?? 0), 0);
+  // How much of the benchmark total the stored elements actually describe.
+  const coverage = costElements.reduce((sum, row) => sum + row.reference_amount, 0);
   const variancePct =
     reference.reference_cost > 0 ? (varianceAmount / reference.reference_cost) * 100 : null;
 
@@ -694,10 +719,17 @@ export function computeReferenceVariance(
     is_significant:
       variancePct !== null && Math.abs(variancePct) > STD_COST_VARIANCE_SIGNIFICANT_PCT,
     has_component_breakdown: components.length > 0,
+    breakdown_status: reference.breakdown_status ?? "partial",
+    breakdown_coverage: roundMoney(coverage),
+    breakdown_coverage_pct:
+      reference.reference_cost > 0
+        ? roundMoney((coverage / reference.reference_cost) * 100, 1)
+        : null,
     explained_difference: roundMoney(explained),
-    // No breakdown → the whole variance is unexplained. That is the honest
-    // answer, and it is what makes a missing breakdown visible rather than
-    // looking like a reconciled zero.
+    // No breakdown → the whole variance is unexplained; a partial breakdown →
+    // only what it covers is explained. That is the honest answer, and it is
+    // what makes an incomplete reconciliation visible rather than looking like
+    // a reconciled zero.
     unexplained_difference: roundMoney(varianceAmount - explained),
     cost_elements: costElements,
     raw_materials: rawMaterials,
@@ -772,22 +804,38 @@ export const stdCostReferenceSchema = z
     reference_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "reference_date must be YYYY-MM-DD"),
     notes: z.string().max(2000).nullable().optional(),
     is_active: z.boolean().optional(),
+    breakdown_status: z.enum(["partial", "complete"]).optional(),
     components: z.array(stdCostReferenceComponentSchema).max(40).optional(),
   })
   .superRefine((value, ctx) => {
-    // A cost_element breakdown claims to BE the total. If it does not add up,
-    // the residual it produces would be meaningless — so refuse it here rather
-    // than let it quietly distort every variance downstream.
     const elements = (value.components ?? []).filter(
       (component) => component.component_kind === "cost_element",
     );
-    if (elements.length === 0) return;
     const sum = elements.reduce((total, component) => total + component.amount, 0);
-    if (Math.abs(sum - value.reference_cost) > 0.01) {
+
+    // Cost elements are exclusive parts of the total, so they can never sum
+    // beyond it — that is arithmetic, not a judgement call, and it holds in
+    // both states.
+    if (elements.length > 0 && sum > value.reference_cost + STD_COST_BREAKDOWN_TOLERANCE) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["components"],
-        message: `Cost element breakdown adds up to ${sum.toFixed(2)}, but the reference cost is ${value.reference_cost.toFixed(2)}`,
+        message: `Cost element breakdown adds up to ${sum.toFixed(2)}, more than the reference cost of ${value.reference_cost.toFixed(2)}`,
+      });
+    }
+
+    // Equality is required ONLY when the breakdown is declared complete. A
+    // partial breakdown covering part of the total is the normal working
+    // state, and forcing it to balance would drive the unexplained residual to
+    // zero by construction — destroying the number the whole exercise is for.
+    if (
+      (value.breakdown_status ?? "partial") === "complete" &&
+      Math.abs(sum - value.reference_cost) > STD_COST_BREAKDOWN_TOLERANCE
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["components"],
+        message: `Breakdown is marked complete but adds up to ${sum.toFixed(2)} against a reference cost of ${value.reference_cost.toFixed(2)} — mark it partial, or account for the remaining ${(value.reference_cost - sum).toFixed(2)}`,
       });
     }
     // cost_element keys are a closed set (the DB CHECKs it too) — catch it

--- a/packages/shared/src/unit-economics.ts
+++ b/packages/shared/src/unit-economics.ts
@@ -46,6 +46,14 @@ export interface StdCostRmPrice {
   purchase_amount: number;
   purchase_unit_label: string;
   purchase_unit_kg: number;
+  /**
+   * This input is in use but unconfirmed (e.g. a load weight nobody has
+   * weighed). It changes nothing about how the number is used — it records
+   * doubt so it can be chased, and so nobody "fixes" a variance by editing a
+   * formula instead of confirming the input.
+   */
+  needs_verification?: boolean;
+  verification_note?: string | null;
 }
 
 export interface StdCostRecipeLine {
@@ -439,6 +447,8 @@ export const stdCostRmPriceSchema = z.object({
   purchase_amount: z.number().min(0).finite(),
   purchase_unit_label: z.string().min(1).max(120),
   purchase_unit_kg: z.number().positive().finite(),
+  needs_verification: z.boolean().optional(),
+  verification_note: z.string().max(1000).nullable().optional(),
 });
 
 export const stdCostRecipeLineSchema = z.object({
@@ -484,3 +494,326 @@ export const stdCostPublishSchema = z.object({
   valid_from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "valid_from must be YYYY-MM-DD"),
   notes: z.string().max(2000).nullable().optional(),
 });
+
+// ==========================================================================
+// Reference (benchmark) costs — legacy sheet totals, manual benchmarks, past
+// actuals. Stored SEPARATELY from the standard and never fed back into it.
+//
+// The whole point: the computed cost is what the recipes and prices say, full
+// stop. A reference is a second opinion recorded next to it. The only
+// operation defined between them is subtraction, and the residual is reported
+// as UNEXPLAINED rather than absorbed. There is deliberately no code path here
+// that lets a reference influence computeBundle().
+//
+// Mirrors the SQL views v_std_cost_reference_variance and
+// v_std_cost_reference_component_variance.
+// ==========================================================================
+
+export type StdCostReferenceSource =
+  | "legacy_excel"
+  | "manual_benchmark"
+  | "historical_actual"
+  | "competitor"
+  | "other";
+
+export const STD_COST_REFERENCE_SOURCES: {
+  value: StdCostReferenceSource;
+  label: string;
+}[] = [
+  { value: "legacy_excel", label: "Legacy Excel" },
+  { value: "manual_benchmark", label: "Manual Benchmark" },
+  { value: "historical_actual", label: "Historical Actual" },
+  { value: "competitor", label: "Competitor" },
+  { value: "other", label: "Other" },
+];
+
+/**
+ * Cost elements are mutually exclusive and sum to the reference total; each
+ * maps 1:1 onto a computed number, which is what makes the residual meaningful.
+ */
+export type StdCostElementKey =
+  | "material"
+  | "labour"
+  | "electricity"
+  | "depreciation"
+  | "fixed"
+  | "other";
+
+export const STD_COST_ELEMENT_KEYS: StdCostElementKey[] = [
+  "material",
+  "labour",
+  "electricity",
+  "depreciation",
+  "fixed",
+  "other",
+];
+
+export const STD_COST_ELEMENT_LABELS: Record<StdCostElementKey, string> = {
+  material: "Raw material",
+  labour: "Labour",
+  electricity: "Electricity",
+  depreciation: "Depreciation",
+  fixed: "Fixed overhead",
+  other: "Other",
+};
+
+export interface StdCostReferenceComponent {
+  id?: string;
+  /**
+   * 'cost_element' rows are the exclusive breakdown of the total.
+   * 'raw_material' rows drill down INSIDE the material element (cement,
+   * chemical, …) and are never added to the cost_element sum — doing so would
+   * double-count material.
+   */
+  component_kind: "cost_element" | "raw_material";
+  component_key: string;
+  amount: number;
+}
+
+export interface StdCostReference {
+  id?: string;
+  brick_type: string;
+  reference_cost: number;
+  source: StdCostReferenceSource;
+  source_label: string | null;
+  reference_date: string;
+  notes: string | null;
+  is_active: boolean;
+  components: StdCostReferenceComponent[];
+}
+
+export interface StdCostComponentVariance {
+  component_kind: "cost_element" | "raw_material";
+  component_key: string;
+  label: string;
+  reference_amount: number;
+  /** null where the reference component has no computed counterpart. */
+  computed_amount: number | null;
+  difference: number | null;
+}
+
+export interface StdCostReferenceVariance {
+  reference_id: string | null;
+  brick_type: string;
+  source: StdCostReferenceSource;
+  source_label: string | null;
+  reference_date: string;
+  notes: string | null;
+  computed_cost_per_unit: number;
+  reference_cost: number;
+  /** computed − reference. Negative means the standard is below the benchmark. */
+  variance_amount: number;
+  variance_pct: number | null;
+  is_significant: boolean;
+  has_component_breakdown: boolean;
+  /** Σ of cost_element differences — the part the breakdown accounts for. */
+  explained_difference: number;
+  /** What no stored component explains. The whole variance when there is no breakdown. */
+  unexplained_difference: number;
+  cost_elements: StdCostComponentVariance[];
+  raw_materials: StdCostComponentVariance[];
+}
+
+/** A variance beyond this deserves a flag on screen. */
+export const STD_COST_VARIANCE_SIGNIFICANT_PCT = 10;
+
+/**
+ * Reconcile one computed brick type against one reference.
+ *
+ * `perUnitByRmKey` supplies the per-unit cost of each raw material for the
+ * raw_material drill-down; pass an empty map to skip that axis.
+ */
+export function computeReferenceVariance(
+  computed: ComputedBrickType,
+  reference: StdCostReference,
+  options?: {
+    electricityPerUnit?: number;
+    depreciationPerUnit?: number;
+    perUnitByRmKey?: Map<string, number>;
+  },
+): StdCostReferenceVariance {
+  const computedByElement: Record<StdCostElementKey, number | null> = {
+    material: computed.material_cost_per_unit,
+    labour: computed.labor_cost_per_unit,
+    electricity: options?.electricityPerUnit ?? null,
+    depreciation: options?.depreciationPerUnit ?? null,
+    fixed: computed.fixed_cost_per_unit,
+    // 'other' has no computed counterpart by definition — leaving it null keeps
+    // it visible as unmatched instead of reading as a zero difference.
+    other: null,
+  };
+
+  const components = reference.components ?? [];
+
+  const costElements: StdCostComponentVariance[] = components
+    .filter((component) => component.component_kind === "cost_element")
+    .map((component) => {
+      const key = component.component_key as StdCostElementKey;
+      const computedAmount = computedByElement[key] ?? null;
+      return {
+        component_kind: "cost_element" as const,
+        component_key: key,
+        label: STD_COST_ELEMENT_LABELS[key] ?? key,
+        reference_amount: component.amount,
+        computed_amount: computedAmount,
+        difference: computedAmount === null ? null : computedAmount - component.amount,
+      };
+    });
+
+  const perUnitByRmKey = options?.perUnitByRmKey ?? new Map<string, number>();
+  const rawMaterials: StdCostComponentVariance[] = components
+    .filter((component) => component.component_kind === "raw_material")
+    .map((component) => {
+      const computedAmount = perUnitByRmKey.get(component.component_key) ?? 0;
+      return {
+        component_kind: "raw_material" as const,
+        component_key: component.component_key,
+        label: component.component_key,
+        reference_amount: component.amount,
+        computed_amount: computedAmount,
+        difference: computedAmount - component.amount,
+      };
+    });
+
+  const varianceAmount = computed.total_cost_per_unit - reference.reference_cost;
+  const explained = costElements.reduce((sum, row) => sum + (row.difference ?? 0), 0);
+  const variancePct =
+    reference.reference_cost > 0 ? (varianceAmount / reference.reference_cost) * 100 : null;
+
+  return {
+    reference_id: reference.id ?? null,
+    brick_type: reference.brick_type,
+    source: reference.source,
+    source_label: reference.source_label,
+    reference_date: reference.reference_date,
+    notes: reference.notes,
+    computed_cost_per_unit: roundMoney(computed.total_cost_per_unit),
+    reference_cost: reference.reference_cost,
+    variance_amount: roundMoney(varianceAmount),
+    variance_pct: variancePct === null ? null : roundMoney(variancePct, 1),
+    is_significant:
+      variancePct !== null && Math.abs(variancePct) > STD_COST_VARIANCE_SIGNIFICANT_PCT,
+    has_component_breakdown: components.length > 0,
+    explained_difference: roundMoney(explained),
+    // No breakdown → the whole variance is unexplained. That is the honest
+    // answer, and it is what makes a missing breakdown visible rather than
+    // looking like a reconciled zero.
+    unexplained_difference: roundMoney(varianceAmount - explained),
+    cost_elements: costElements,
+    raw_materials: rawMaterials,
+  };
+}
+
+/**
+ * Per-unit cost of each raw material in a brick type's recipe — the input for
+ * the raw_material drill-down (e.g. "cement differs by ₹0.62").
+ */
+export function perUnitCostByRmKey(
+  brickType: StdCostBrickType,
+  rmPrices: StdCostRmPrice[],
+): Map<string, number> {
+  const costPerKg = new Map(rmPrices.map((rm) => [rm.rm_key, computeRmCostPerKg(rm)]));
+  const perBatch = brickType.bricks_per_batch ?? 0;
+  const result = new Map<string, number>();
+  if (!(perBatch > 0)) return result;
+  for (const line of brickType.recipe ?? []) {
+    result.set(
+      line.rm_key,
+      ((line.kg_per_batch ?? 0) * (costPerKg.get(line.rm_key) ?? 0)) / perBatch,
+    );
+  }
+  return result;
+}
+
+/** Reconcile a whole version against every active reference for its brick types. */
+export function computeAllReferenceVariances(
+  bundle: StdCostBundle,
+  references: StdCostReference[],
+): StdCostReferenceVariance[] {
+  const computed = computeBundle(bundle);
+  const computedByType = new Map(computed.brick_types.map((bt) => [bt.brick_type, bt]));
+  const inputByType = new Map((bundle.brick_types ?? []).map((bt) => [bt.brick_type, bt]));
+
+  return (references ?? [])
+    .filter((reference) => reference.is_active && computedByType.has(reference.brick_type))
+    .map((reference) => {
+      const computedBrickType = computedByType.get(reference.brick_type);
+      const input = inputByType.get(reference.brick_type);
+      if (!computedBrickType) throw new Error(`No computed brick type ${reference.brick_type}`);
+      return computeReferenceVariance(computedBrickType, reference, {
+        electricityPerUnit: input?.electricity_per_unit,
+        depreciationPerUnit: input?.depreciation_per_unit,
+        perUnitByRmKey: input ? perUnitCostByRmKey(input, bundle.rm_prices ?? []) : undefined,
+      });
+    });
+}
+
+// ------------------------------------------------------- reference schemas --
+
+export const stdCostReferenceComponentSchema = z.object({
+  component_kind: z.enum(["cost_element", "raw_material"]),
+  component_key: z.string().min(1).max(64),
+  amount: z.number().min(0).finite(),
+});
+
+export const stdCostReferenceSchema = z
+  .object({
+    id: z.string().uuid().optional(),
+    brick_type: z.string().min(1).max(64),
+    reference_cost: z.number().min(0).finite(),
+    source: z.enum([
+      "legacy_excel",
+      "manual_benchmark",
+      "historical_actual",
+      "competitor",
+      "other",
+    ]),
+    source_label: z.string().max(200).nullable().optional(),
+    reference_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "reference_date must be YYYY-MM-DD"),
+    notes: z.string().max(2000).nullable().optional(),
+    is_active: z.boolean().optional(),
+    components: z.array(stdCostReferenceComponentSchema).max(40).optional(),
+  })
+  .superRefine((value, ctx) => {
+    // A cost_element breakdown claims to BE the total. If it does not add up,
+    // the residual it produces would be meaningless — so refuse it here rather
+    // than let it quietly distort every variance downstream.
+    const elements = (value.components ?? []).filter(
+      (component) => component.component_kind === "cost_element",
+    );
+    if (elements.length === 0) return;
+    const sum = elements.reduce((total, component) => total + component.amount, 0);
+    if (Math.abs(sum - value.reference_cost) > 0.01) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["components"],
+        message: `Cost element breakdown adds up to ${sum.toFixed(2)}, but the reference cost is ${value.reference_cost.toFixed(2)}`,
+      });
+    }
+    // cost_element keys are a closed set (the DB CHECKs it too) — catch it
+    // here so the API answers with a field message, not a constraint error.
+    for (const component of elements) {
+      if (!STD_COST_ELEMENT_KEYS.includes(component.component_key as StdCostElementKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["components"],
+          message: `Unknown cost element "${component.component_key}" — expected one of ${STD_COST_ELEMENT_KEYS.join(", ")}`,
+        });
+      }
+    }
+
+    const seen = new Set<string>();
+    for (const component of value.components ?? []) {
+      const key = `${component.component_kind}:${component.component_key}`;
+      if (seen.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["components"],
+          message: `Duplicate component: ${component.component_key}`,
+        });
+      }
+      seen.add(key);
+    }
+  });
+
+export type StdCostReferencePayload = z.infer<typeof stdCostReferenceSchema>;

--- a/supabase/migrations/20260822120000_std_cost_unit_economics.sql
+++ b/supabase/migrations/20260822120000_std_cost_unit_economics.sql
@@ -1,0 +1,473 @@
+-- ============================================================================
+-- Unit Economics (Standard Cost) module
+--
+-- Replaces the "Mb Unit Economics" Google Sheet. Staff maintain raw-material
+-- prices, per-brick-type recipes, overheads and monthly fixed costs on a
+-- single mutable DRAFT; an admin PUBLISHES that draft as an immutable version
+-- with a valid_from date. The Maiyuri Intelligence Layer reads the published
+-- standard through the two frozen views at the bottom of this file.
+--
+-- The one rule that makes the "chemical is ₹80/kg on the sheet but ₹74/kg by
+-- its own inputs" class of bug impossible: NO DERIVED NUMBER IS EVER STORED
+-- FROM USER INPUT. cost_per_kg is a generated column; every per-unit cost is
+-- computed in v_std_cost_brick_type_computed below and mirrored exactly once
+-- in TypeScript (packages/shared/src/unit-economics.ts) for live editing.
+--
+-- Conventions follow the rest of the repo: TEXT + CHECK enums, RLS enabled
+-- with an authenticated-read policy, writes go through the service-role client
+-- in the API (which is the real gate — role checks live there), anon revoked.
+-- ============================================================================
+
+-- shared updated_at helper (idempotent — also defined by earlier migrations)
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+-- ---------------------------------------------------------------- versions --
+
+CREATE TABLE IF NOT EXISTS public.std_cost_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'published', 'archived')),
+  -- set at publish; the date this standard takes effect
+  valid_from DATE,
+  monthly_production_basis INTEGER NOT NULL DEFAULT 15000
+    CHECK (monthly_production_basis > 0),
+  notes TEXT,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  published_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  published_at TIMESTAMPTZ,
+  -- a published version is meaningless without the date it takes effect
+  CONSTRAINT std_cost_versions_published_has_valid_from
+    CHECK (status <> 'published' OR (valid_from IS NOT NULL AND published_at IS NOT NULL))
+);
+
+-- Exactly one draft at a time. (Partial unique index on the constant column:
+-- every draft row collides on status = 'draft'.)
+CREATE UNIQUE INDEX IF NOT EXISTS std_cost_versions_one_draft
+  ON public.std_cost_versions (status) WHERE status = 'draft';
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_versions_published
+  ON public.std_cost_versions (valid_from DESC, published_at DESC)
+  WHERE status = 'published';
+
+DROP TRIGGER IF EXISTS set_std_cost_versions_updated_at ON public.std_cost_versions;
+CREATE TRIGGER set_std_cost_versions_updated_at
+  BEFORE UPDATE ON public.std_cost_versions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ------------------------------------------------------- raw material master
+
+CREATE TABLE IF NOT EXISTS public.std_cost_rm_prices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  version_id UUID NOT NULL REFERENCES public.std_cost_versions(id) ON DELETE CASCADE,
+  -- 'cement','chemical','msand_dust','msand_waste','red_soil','red_soil_gravel'
+  rm_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  purchase_amount NUMERIC(12, 2) NOT NULL CHECK (purchase_amount >= 0),
+  -- '50 Kg Bag', 'Per Unit or 8000 Kgs', ...
+  purchase_unit_label TEXT NOT NULL,
+  purchase_unit_kg NUMERIC(12, 3) NOT NULL CHECK (purchase_unit_kg > 0),
+  -- DERIVED — generated, never writable
+  cost_per_kg NUMERIC(12, 4)
+    GENERATED ALWAYS AS (purchase_amount / purchase_unit_kg) STORED,
+  UNIQUE (version_id, rm_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_rm_prices_version
+  ON public.std_cost_rm_prices (version_id);
+
+-- ------------------------------------------------------------- brick types --
+
+CREATE TABLE IF NOT EXISTS public.std_cost_brick_types (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  version_id UUID NOT NULL REFERENCES public.std_cost_versions(id) ON DELETE CASCADE,
+  brick_type TEXT NOT NULL,             -- '8 CIB' | '6 CIB' | '8 MIB' | '6 MIB' (extensible)
+  -- ILIKE pattern onto the Odoo product name, e.g. 'CIB-10*8*5%'
+  odoo_product_match TEXT NOT NULL,
+  bricks_per_batch NUMERIC(6, 2) NOT NULL CHECK (bricks_per_batch > 0),
+  labor_cost_per_batch NUMERIC(10, 2) NOT NULL DEFAULT 0 CHECK (labor_cost_per_batch >= 0),
+  electricity_per_unit NUMERIC(10, 2) NOT NULL DEFAULT 0 CHECK (electricity_per_unit >= 0),
+  depreciation_per_unit NUMERIC(10, 2) NOT NULL DEFAULT 0 CHECK (depreciation_per_unit >= 0),
+  sales_price NUMERIC(10, 2) CHECK (sales_price IS NULL OR sales_price >= 0),
+  loading_unloading_per_unit NUMERIC(10, 2) DEFAULT 3 CHECK (loading_unloading_per_unit >= 0),
+  transport_per_unit NUMERIC(10, 2) DEFAULT 3 CHECK (transport_per_unit >= 0),
+  commission_per_unit NUMERIC(10, 2) DEFAULT 1 CHECK (commission_per_unit >= 0),
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (version_id, brick_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_brick_types_version
+  ON public.std_cost_brick_types (version_id);
+
+-- ----------------------------------------------------------- recipe lines ---
+
+CREATE TABLE IF NOT EXISTS public.std_cost_recipe_lines (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  brick_type_id UUID NOT NULL REFERENCES public.std_cost_brick_types(id) ON DELETE CASCADE,
+  rm_key TEXT NOT NULL,
+  kg_per_batch NUMERIC(12, 3) NOT NULL CHECK (kg_per_batch >= 0),
+  UNIQUE (brick_type_id, rm_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_recipe_lines_brick_type
+  ON public.std_cost_recipe_lines (brick_type_id);
+
+-- ------------------------------------------------------- monthly fixed cost -
+
+CREATE TABLE IF NOT EXISTS public.std_cost_fixed_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  version_id UUID NOT NULL REFERENCES public.std_cost_versions(id) ON DELETE CASCADE,
+  -- 'machine_repair','rent','misc','stacking_curing','manager_salary','marketing'
+  item_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  monthly_amount NUMERIC(12, 2) NOT NULL CHECK (monthly_amount >= 0),
+  UNIQUE (version_id, item_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_fixed_items_version
+  ON public.std_cost_fixed_items (version_id);
+
+-- ============================================================================
+-- Immutability: a published version and everything hanging off it is frozen.
+-- The app never edits published rows, but "immutable" is a promise to the
+-- Intelligence Layer, so the database enforces it rather than trusting code.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.std_cost_guard_published()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  v_status TEXT;
+  v_version UUID;
+BEGIN
+  IF TG_TABLE_NAME = 'std_cost_versions' THEN
+    -- Publishing (draft -> published) and archiving a published version are the
+    -- only transitions allowed; a published version's numbers never change.
+    IF TG_OP = 'DELETE' THEN
+      IF OLD.status = 'published' THEN
+        RAISE EXCEPTION 'Published standard cost versions cannot be deleted';
+      END IF;
+      RETURN OLD;
+    END IF;
+    IF OLD.status = 'published' AND NEW.status = 'published' THEN
+      IF (NEW.monthly_production_basis, NEW.valid_from, NEW.notes)
+         IS DISTINCT FROM (OLD.monthly_production_basis, OLD.valid_from, OLD.notes) THEN
+        RAISE EXCEPTION 'Published standard cost version % is immutable', OLD.id;
+      END IF;
+    ELSIF OLD.status = 'published' AND NEW.status = 'draft' THEN
+      RAISE EXCEPTION 'A published version cannot be turned back into a draft; create a new draft from it';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- child tables: resolve the owning version
+  IF TG_TABLE_NAME = 'std_cost_recipe_lines' THEN
+    SELECT bt.version_id INTO v_version FROM public.std_cost_brick_types bt
+      WHERE bt.id = COALESCE(NEW.brick_type_id, OLD.brick_type_id);
+  ELSE
+    v_version := COALESCE(NEW.version_id, OLD.version_id);
+  END IF;
+
+  SELECT status INTO v_status FROM public.std_cost_versions WHERE id = v_version;
+  IF v_status = 'published' THEN
+    RAISE EXCEPTION 'Version % is published and immutable (table %)', v_version, TG_TABLE_NAME;
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END $$;
+
+DROP TRIGGER IF EXISTS std_cost_versions_guard ON public.std_cost_versions;
+CREATE TRIGGER std_cost_versions_guard
+  BEFORE UPDATE OR DELETE ON public.std_cost_versions
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_guard_published();
+
+DROP TRIGGER IF EXISTS std_cost_rm_prices_guard ON public.std_cost_rm_prices;
+CREATE TRIGGER std_cost_rm_prices_guard
+  BEFORE INSERT OR UPDATE OR DELETE ON public.std_cost_rm_prices
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_guard_published();
+
+DROP TRIGGER IF EXISTS std_cost_brick_types_guard ON public.std_cost_brick_types;
+CREATE TRIGGER std_cost_brick_types_guard
+  BEFORE INSERT OR UPDATE OR DELETE ON public.std_cost_brick_types
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_guard_published();
+
+DROP TRIGGER IF EXISTS std_cost_recipe_lines_guard ON public.std_cost_recipe_lines;
+CREATE TRIGGER std_cost_recipe_lines_guard
+  BEFORE INSERT OR UPDATE OR DELETE ON public.std_cost_recipe_lines
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_guard_published();
+
+DROP TRIGGER IF EXISTS std_cost_fixed_items_guard ON public.std_cost_fixed_items;
+CREATE TRIGGER std_cost_fixed_items_guard
+  BEFORE INSERT OR UPDATE OR DELETE ON public.std_cost_fixed_items
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_guard_published();
+
+-- The publish path needs ONE controlled write of the published row (status,
+-- valid_from, published_by/at). It happens inside publish_std_cost_draft()
+-- below, which flips status draft -> published in a single UPDATE — allowed by
+-- the guard because OLD.status is still 'draft' at that moment.
+
+-- ============================================================================
+-- Computation — the single SQL source of truth (§6 of the PRD).
+-- Mirrored exactly in packages/shared/src/unit-economics.ts for live editing;
+-- packages/shared/src/unit-economics.test.ts pins both to the same numbers.
+-- Full precision here; rounding happens only at the contract views / display.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_std_cost_brick_type_computed
+WITH (security_invoker = true) AS
+WITH fixed_totals AS (
+  SELECT version_id, SUM(monthly_amount) AS monthly_fixed_total
+  FROM public.std_cost_fixed_items
+  GROUP BY version_id
+),
+material AS (
+  SELECT rl.brick_type_id,
+         -- Divide at full precision rather than through the stored 4-dp
+         -- cost_per_kg column, so this matches computeRmCostPerKg() exactly.
+         SUM(rl.kg_per_batch * (rm.purchase_amount / rm.purchase_unit_kg))
+           AS material_cost_per_batch,
+         MAX(rl.kg_per_batch) FILTER (WHERE rl.rm_key = 'cement') AS cement_kg_per_batch
+  FROM public.std_cost_recipe_lines rl
+  JOIN public.std_cost_brick_types bt ON bt.id = rl.brick_type_id
+  JOIN public.std_cost_rm_prices rm
+    ON rm.version_id = bt.version_id AND rm.rm_key = rl.rm_key
+  GROUP BY rl.brick_type_id
+)
+SELECT
+  bt.id                                   AS brick_type_id,
+  bt.version_id,
+  bt.brick_type,
+  bt.odoo_product_match,
+  bt.bricks_per_batch,
+  bt.sales_price,
+  bt.loading_unloading_per_unit,
+  bt.transport_per_unit,
+  bt.commission_per_unit,
+  bt.sort_order,
+  COALESCE(m.material_cost_per_batch, 0)                       AS material_cost_per_batch,
+  COALESCE(m.material_cost_per_batch, 0) / bt.bricks_per_batch AS material_cost_per_unit,
+  bt.labor_cost_per_batch,
+  bt.labor_cost_per_batch / bt.bricks_per_batch                AS labor_cost_per_unit,
+  bt.electricity_per_unit + bt.depreciation_per_unit           AS overhead_per_unit,
+  (COALESCE(m.material_cost_per_batch, 0) / bt.bricks_per_batch)
+    + (bt.labor_cost_per_batch / bt.bricks_per_batch)
+    + bt.electricity_per_unit + bt.depreciation_per_unit       AS variable_cost_per_unit,
+  COALESCE(f.monthly_fixed_total, 0) / v.monthly_production_basis AS fixed_cost_per_unit,
+  (COALESCE(m.material_cost_per_batch, 0) / bt.bricks_per_batch)
+    + (bt.labor_cost_per_batch / bt.bricks_per_batch)
+    + bt.electricity_per_unit + bt.depreciation_per_unit
+    + COALESCE(f.monthly_fixed_total, 0) / v.monthly_production_basis AS total_cost_per_unit,
+  CASE WHEN bt.sales_price IS NULL THEN NULL ELSE
+    bt.sales_price
+      - COALESCE(bt.loading_unloading_per_unit, 0)
+      - COALESCE(bt.transport_per_unit, 0)
+      - COALESCE(bt.commission_per_unit, 0)
+      - ((COALESCE(m.material_cost_per_batch, 0) / bt.bricks_per_batch)
+         + (bt.labor_cost_per_batch / bt.bricks_per_batch)
+         + bt.electricity_per_unit + bt.depreciation_per_unit
+         + COALESCE(f.monthly_fixed_total, 0) / v.monthly_production_basis)
+  END                                                          AS margin_per_unit,
+  CASE WHEN COALESCE(m.cement_kg_per_batch, 0) > 0
+       THEN bt.bricks_per_batch * 50 / m.cement_kg_per_batch
+  END                                                          AS bricks_per_cement_bag,
+  v.monthly_production_basis,
+  COALESCE(f.monthly_fixed_total, 0)                           AS monthly_fixed_total,
+  v.status,
+  v.valid_from,
+  v.published_at
+FROM public.std_cost_brick_types bt
+JOIN public.std_cost_versions v ON v.id = bt.version_id
+LEFT JOIN material m ON m.brick_type_id = bt.id
+LEFT JOIN fixed_totals f ON f.version_id = bt.version_id;
+
+-- ============================================================================
+-- FROZEN INTEGRATION CONTRACT (§8) — the Maiyuri Intelligence Layer reads
+-- exactly these two views. NEVER rename the views or their columns, and never
+-- change brick_type / product_match values without a downstream handshake.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_standard_costs_current
+WITH (security_invoker = true) AS
+SELECT c.brick_type,
+       c.odoo_product_match              AS product_match,
+       ROUND(c.variable_cost_per_unit, 2) AS variable_cost_per_unit,
+       ROUND(c.fixed_cost_per_unit, 2)    AS fixed_cost_per_unit,
+       ROUND(c.total_cost_per_unit, 2)    AS total_cost_per_unit,
+       ROUND(c.labor_cost_per_unit, 2)    AS labor_cost_per_unit,
+       c.bricks_per_batch,
+       c.monthly_production_basis,
+       c.sales_price,
+       c.valid_from,
+       c.published_at,
+       c.version_id
+FROM public.v_std_cost_brick_type_computed c
+WHERE c.status = 'published'
+  AND c.valid_from = (
+    SELECT MAX(valid_from) FROM public.std_cost_versions WHERE status = 'published'
+  );
+
+CREATE OR REPLACE VIEW public.v_standard_rm_prices_current
+WITH (security_invoker = true) AS
+SELECT rm.rm_key, rm.display_name, rm.purchase_amount, rm.purchase_unit_label,
+       rm.purchase_unit_kg, rm.cost_per_kg, v.valid_from, v.published_at
+FROM public.std_cost_rm_prices rm
+JOIN public.std_cost_versions v ON v.id = rm.version_id
+WHERE v.status = 'published'
+  AND v.valid_from = (
+    SELECT MAX(valid_from) FROM public.std_cost_versions WHERE status = 'published'
+  );
+
+COMMENT ON VIEW public.v_standard_costs_current IS
+  'FROZEN CONTRACT — read by the Maiyuri Intelligence Layer. Do not rename view or columns.';
+COMMENT ON VIEW public.v_standard_rm_prices_current IS
+  'FROZEN CONTRACT — read by the Maiyuri Intelligence Layer. Do not rename view or columns.';
+
+-- ============================================================================
+-- Publish — draft becomes an immutable published version, and a fresh draft is
+-- opened as a copy of it. Done in ONE function so it is atomic: there is never
+-- a moment with two drafts, or none.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.publish_std_cost_draft(
+  p_draft_id UUID,
+  p_valid_from DATE,
+  p_published_by UUID,
+  p_notes TEXT DEFAULT NULL
+) RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_new_draft UUID;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM std_cost_versions WHERE id = p_draft_id AND status = 'draft'
+  ) THEN
+    RAISE EXCEPTION 'Version % is not the open draft', p_draft_id;
+  END IF;
+
+  -- A later-or-equal valid_from would leave the contract views pointing at the
+  -- wrong version, so the standard must move forward in time.
+  IF EXISTS (
+    SELECT 1 FROM std_cost_versions
+    WHERE status = 'published' AND valid_from >= p_valid_from
+  ) THEN
+    RAISE EXCEPTION 'valid_from % must be after the currently published version', p_valid_from;
+  END IF;
+
+  UPDATE std_cost_versions
+     SET status = 'published',
+         valid_from = p_valid_from,
+         published_by = p_published_by,
+         published_at = now(),
+         notes = COALESCE(p_notes, notes)
+   WHERE id = p_draft_id;
+
+  -- Fresh draft, copied from what was just published.
+  INSERT INTO std_cost_versions (status, monthly_production_basis, notes, created_by, updated_by)
+  SELECT 'draft', monthly_production_basis, NULL, p_published_by, p_published_by
+  FROM std_cost_versions WHERE id = p_draft_id
+  RETURNING id INTO v_new_draft;
+
+  INSERT INTO std_cost_rm_prices
+    (version_id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg)
+  SELECT v_new_draft, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg
+  FROM std_cost_rm_prices WHERE version_id = p_draft_id;
+
+  INSERT INTO std_cost_fixed_items (version_id, item_key, display_name, monthly_amount)
+  SELECT v_new_draft, item_key, display_name, monthly_amount
+  FROM std_cost_fixed_items WHERE version_id = p_draft_id;
+
+  WITH copied AS (
+    INSERT INTO std_cost_brick_types
+      (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+       electricity_per_unit, depreciation_per_unit, sales_price, loading_unloading_per_unit,
+       transport_per_unit, commission_per_unit, sort_order)
+    SELECT v_new_draft, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+           electricity_per_unit, depreciation_per_unit, sales_price, loading_unloading_per_unit,
+           transport_per_unit, commission_per_unit, sort_order
+    FROM std_cost_brick_types WHERE version_id = p_draft_id
+    RETURNING id, brick_type
+  )
+  INSERT INTO std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch)
+  SELECT copied.id, rl.rm_key, rl.kg_per_batch
+  FROM copied
+  JOIN std_cost_brick_types old_bt
+    ON old_bt.version_id = p_draft_id AND old_bt.brick_type = copied.brick_type
+  JOIN std_cost_recipe_lines rl ON rl.brick_type_id = old_bt.id;
+
+  RETURN v_new_draft;
+END $$;
+
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) TO service_role;
+
+-- ============================================================================
+-- RLS. Authenticated staff READ everything (history is not a secret inside the
+-- company). NO write policy exists on any table: every mutation goes through
+-- the API on the service-role client, which enforces "staff edit the draft,
+-- only admins publish". anon can read nothing.
+-- ============================================================================
+
+ALTER TABLE public.std_cost_versions     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.std_cost_rm_prices    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.std_cost_brick_types  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.std_cost_recipe_lines ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.std_cost_fixed_items  ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS std_cost_versions_read ON public.std_cost_versions;
+CREATE POLICY std_cost_versions_read ON public.std_cost_versions
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS std_cost_rm_prices_read ON public.std_cost_rm_prices;
+CREATE POLICY std_cost_rm_prices_read ON public.std_cost_rm_prices
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS std_cost_brick_types_read ON public.std_cost_brick_types;
+CREATE POLICY std_cost_brick_types_read ON public.std_cost_brick_types
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS std_cost_recipe_lines_read ON public.std_cost_recipe_lines;
+CREATE POLICY std_cost_recipe_lines_read ON public.std_cost_recipe_lines
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS std_cost_fixed_items_read ON public.std_cost_fixed_items;
+CREATE POLICY std_cost_fixed_items_read ON public.std_cost_fixed_items
+  FOR SELECT TO authenticated USING (true);
+
+REVOKE ALL ON public.std_cost_versions     FROM anon;
+REVOKE ALL ON public.std_cost_rm_prices    FROM anon;
+REVOKE ALL ON public.std_cost_brick_types  FROM anon;
+REVOKE ALL ON public.std_cost_recipe_lines FROM anon;
+REVOKE ALL ON public.std_cost_fixed_items  FROM anon;
+REVOKE ALL ON public.v_std_cost_brick_type_computed FROM anon;
+REVOKE ALL ON public.v_standard_costs_current       FROM anon;
+REVOKE ALL ON public.v_standard_rm_prices_current   FROM anon;
+
+-- Explicit grants rather than relying on Supabase's default privileges for
+-- new objects, so the same migration is correct on any database.
+-- authenticated gets SELECT only: with RLS on and no write policy, every
+-- mutation has to come through the API's service-role client, where the
+-- "staff edit the draft, only management publishes" rule actually lives.
+GRANT SELECT ON public.std_cost_versions     TO authenticated;
+GRANT SELECT ON public.std_cost_rm_prices    TO authenticated;
+GRANT SELECT ON public.std_cost_brick_types  TO authenticated;
+GRANT SELECT ON public.std_cost_recipe_lines TO authenticated;
+GRANT SELECT ON public.std_cost_fixed_items  TO authenticated;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_versions     TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_rm_prices    TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_brick_types  TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_recipe_lines TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_fixed_items  TO service_role;
+
+-- The Intelligence Layer reads with the same role it already uses for
+-- public.leads. If that is a role other than service_role, it needs SELECT on
+-- these five base tables and a SELECT policy — the views are security_invoker,
+-- so they never hand out more access than the reader already has.
+-- authenticated staff read the same views in-app.
+GRANT SELECT ON public.v_std_cost_brick_type_computed TO authenticated, service_role;
+GRANT SELECT ON public.v_standard_costs_current       TO authenticated, service_role;
+GRANT SELECT ON public.v_standard_rm_prices_current   TO authenticated, service_role;

--- a/supabase/migrations/20260822120100_std_cost_seed_v1.sql
+++ b/supabase/migrations/20260822120100_std_cost_seed_v1.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- Unit Economics — seed the first published version from the retiring
+-- "Mb Unit Economics" Google Sheet, then open the working draft.
+--
+-- Seeded by publishing a draft through publish_std_cost_draft(), so go-live
+-- uses exactly the same code path staff will use every month afterwards.
+-- valid_from = CURRENT_DATE (the go-live date, by definition).
+--
+-- TWO INPUTS NEED RAM'S CONFIRMATION (§9 of the PRD contradicts itself):
+--   red_soil        — PRD says "4712.50 / 37050 kg (≈1.27/kg)". Those disagree
+--                     by 10x; 4712.50/37050 = 0.127. Seeded at 3705 kg so the
+--                     cost/kg matches the ≈1.27 the sheet actually costs with,
+--                     because that is the number the standard has been using.
+--   red_soil_gravel — PRD says "3600 / 28900-for-8 (≈0.80/kg)". Seeded at
+--                     4500 kg to match ≈0.80/kg. No recipe consumes this
+--                     material today, so no computed total depends on it.
+-- Both are one edit away in the app once Ram confirms the real load weight.
+--
+-- Computed totals vs the sheet's (surfaced, not fudged — PRD §9):
+--   8 CIB 27.06 vs 32.83 · 6 CIB 26.24 vs 31.80
+--   8 MIB 34.77 vs 36.12 · 6 MIB 27.94 vs 29.04
+-- The inputs below are the sheet's own inputs; where the totals differ, the
+-- sheet's totals were stale. Review with Ram at go-live.
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_draft UUID;
+  v_bt UUID;
+BEGIN
+  -- Idempotent: never seed over an existing standard.
+  IF EXISTS (SELECT 1 FROM public.std_cost_versions) THEN
+    RAISE NOTICE 'std_cost_versions already populated — skipping seed';
+    RETURN;
+  END IF;
+
+  INSERT INTO public.std_cost_versions (status, monthly_production_basis, notes)
+  VALUES ('draft', 15000,
+    'Seeded from the Mb Unit Economics Google Sheet at go-live. red_soil and '
+    'red_soil_gravel purchase_unit_kg are best-fit to the sheet''s per-kg cost '
+    'and need Ram''s confirmation of the real load weight.')
+  RETURNING id INTO v_draft;
+
+  -- ------------------------------------------------------ raw materials ----
+  INSERT INTO public.std_cost_rm_prices
+    (version_id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg)
+  VALUES
+    (v_draft, 'cement',          'Cement',          320.00,  '50 Kg Bag',                50),
+    (v_draft, 'chemical',        'Chemical',        1850.00, '25 Kg Can',                25),
+    (v_draft, 'msand_dust',      'M-Sand Dust',     4512.50, 'Per Unit or 8000 Kgs',     8000),
+    (v_draft, 'msand_waste',     'M-Sand Waste',    1937.50, 'Per Unit or 8000 Kgs',     8000),
+    (v_draft, 'red_soil',        'Red Soil',        4712.50, 'Per Load (kg to confirm)', 3705),
+    (v_draft, 'red_soil_gravel', 'Red Soil Gravel', 3600.00, 'Per Load (kg to confirm)', 4500);
+
+  -- ------------------------------------------------------- fixed costs ------
+  INSERT INTO public.std_cost_fixed_items
+    (version_id, item_key, display_name, monthly_amount)
+  VALUES
+    (v_draft, 'machine_repair',  'Machine Repair',    5000.00),
+    (v_draft, 'rent',            'Rent',              2500.00),
+    (v_draft, 'misc',            'Miscellaneous',     3000.00),
+    (v_draft, 'stacking_curing', 'Stacking & Curing', 3000.00),
+    (v_draft, 'manager_salary',  'Manager Salary',    60000.00),
+    (v_draft, 'marketing',       'Marketing',         5000.00);
+
+  -- ------------------------------------------------------- brick types ------
+  -- brick_type and odoo_product_match are part of the frozen downstream
+  -- contract: they join onto Odoo product names in the Intelligence Layer.
+  INSERT INTO public.std_cost_brick_types
+    (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+     electricity_per_unit, depreciation_per_unit, sales_price, sort_order)
+  VALUES (v_draft, '8 CIB', 'CIB-10*8*5%', 9, 63.00, 1.00, 1.00, 54.00, 1)
+  RETURNING id INTO v_bt;
+  INSERT INTO public.std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch) VALUES
+    (v_bt, 'cement', 8.5), (v_bt, 'chemical', 0.1),
+    (v_bt, 'msand_dust', 74), (v_bt, 'msand_waste', 49);
+
+  INSERT INTO public.std_cost_brick_types
+    (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+     electricity_per_unit, depreciation_per_unit, sales_price, sort_order)
+  VALUES (v_draft, '6 CIB', 'CIB-11*6*5%', 9, 54.00, 1.00, 1.00, 45.00, 2)
+  RETURNING id INTO v_bt;
+  INSERT INTO public.std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch) VALUES
+    (v_bt, 'cement', 9.4), (v_bt, 'chemical', 0.1),
+    (v_bt, 'msand_dust', 81.8), (v_bt, 'msand_waste', 13.7);
+
+  INSERT INTO public.std_cost_brick_types
+    (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+     electricity_per_unit, depreciation_per_unit, sales_price, sort_order)
+  VALUES (v_draft, '8 MIB', 'MIB-10*8*5%', 8, 56.00, 1.00, 1.50, 55.00, 3)
+  RETURNING id INTO v_bt;
+  INSERT INTO public.std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch) VALUES
+    (v_bt, 'cement', 9.165), (v_bt, 'chemical', 0.1),
+    (v_bt, 'msand_dust', 18.28), (v_bt, 'red_soil', 66);
+
+  INSERT INTO public.std_cost_brick_types
+    (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+     electricity_per_unit, depreciation_per_unit, sales_price, sort_order)
+  VALUES (v_draft, '6 MIB', 'MIB-10*6*5%', 11, 66.00, 1.00, 1.00, 46.00, 4)
+  RETURNING id INTO v_bt;
+  INSERT INTO public.std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch) VALUES
+    (v_bt, 'cement', 9), (v_bt, 'chemical', 0.1),
+    (v_bt, 'msand_dust', 25), (v_bt, 'red_soil', 65);
+
+  -- Publish as v1 and open the fresh working draft, via the real publish path.
+  PERFORM public.publish_std_cost_draft(v_draft, CURRENT_DATE, NULL,
+    'v1 — seeded from the Mb Unit Economics Google Sheet at go-live.');
+END $$;

--- a/supabase/migrations/20260822120200_std_cost_reference_costs.sql
+++ b/supabase/migrations/20260822120200_std_cost_reference_costs.sql
@@ -1,0 +1,313 @@
+-- ============================================================================
+-- Unit Economics — reference (benchmark) costs, kept SEPARATE from the standard
+--
+-- The computed standard is what it is: recipes × prices, no balancing factors,
+-- no plugs. But we still need to answer "why is 8 CIB ₹5.77 below the old
+-- costing?" — so legacy and benchmark numbers are stored ALONGSIDE the
+-- standard, never inside it.
+--
+-- Hard rule, enforced by construction: nothing in this file feeds any
+-- computation. std_cost_reference_costs is not referenced by
+-- v_std_cost_brick_type_computed, by the two frozen contract views, or by
+-- computeBundle() in TypeScript. A reference cost can only ever be DISPLAYED
+-- next to a computed cost and subtracted from it. Correcting a business input
+-- happens by editing the draft and publishing a new version — never by
+-- nudging a reference number until the variance disappears.
+--
+-- Two axes of component breakdown, both optional:
+--   'cost_element'  material · labour · electricity · depreciation · fixed ·
+--                   other — mutually exclusive, they sum to the reference
+--                   total, and each maps 1:1 onto a computed number. The
+--                   UNEXPLAINED residual is measured on this axis only.
+--   'raw_material'  cement · chemical · … — a drill-down INSIDE the material
+--                   element, so "cement consumption differs by ₹0.62" is
+--                   answerable. Deliberately NOT added to the cost_element
+--                   sum; doing so would double-count material.
+-- ============================================================================
+
+-- --------------------------------------------- inputs that need verifying ---
+-- An input can be in use and still be known-uncertain (the red soil load
+-- weight: 3,705 kg or 37,050 kg — a 10x difference in a real cost driver).
+-- Marking the INPUT is the honest way to carry that: the number stays what we
+-- believe it is, the doubt is recorded against it, and when the truth is known
+-- it is corrected through a normal publish that version history explains.
+ALTER TABLE public.std_cost_rm_prices
+  ADD COLUMN IF NOT EXISTS needs_verification BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE public.std_cost_rm_prices
+  ADD COLUMN IF NOT EXISTS verification_note TEXT;
+
+COMMENT ON COLUMN public.std_cost_rm_prices.needs_verification IS
+  'This input is in use but unconfirmed. Never a reason to alter a formula — correct the input and publish.';
+
+-- ------------------------------------------------------- reference costs ----
+
+CREATE TABLE IF NOT EXISTS public.std_cost_reference_costs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Matches std_cost_brick_types.brick_type by value, deliberately WITHOUT a
+  -- foreign key: a benchmark outlives any one version, and a legacy number for
+  -- a discontinued product is still worth keeping.
+  brick_type TEXT NOT NULL,
+  reference_cost NUMERIC(12, 4) NOT NULL CHECK (reference_cost >= 0),
+  source TEXT NOT NULL CHECK (source IN (
+    'legacy_excel', 'manual_benchmark', 'historical_actual', 'competitor', 'other'
+  )),
+  source_label TEXT,                    -- e.g. 'Mb Unit Economics sheet'
+  reference_date DATE NOT NULL,         -- what date this benchmark speaks for
+  notes TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (brick_type, source, reference_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_reference_costs_active
+  ON public.std_cost_reference_costs (brick_type, reference_date DESC) WHERE is_active;
+
+DROP TRIGGER IF EXISTS set_std_cost_reference_costs_updated_at ON public.std_cost_reference_costs;
+CREATE TRIGGER set_std_cost_reference_costs_updated_at
+  BEFORE UPDATE ON public.std_cost_reference_costs
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS public.std_cost_reference_components (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  reference_cost_id UUID NOT NULL
+    REFERENCES public.std_cost_reference_costs(id) ON DELETE CASCADE,
+  component_kind TEXT NOT NULL CHECK (component_kind IN ('cost_element', 'raw_material')),
+  component_key TEXT NOT NULL,
+  amount NUMERIC(12, 4) NOT NULL CHECK (amount >= 0),
+  -- cost_element keys are a closed set because each must map onto a computed
+  -- number; raw_material keys are open, matching std_cost_rm_prices.rm_key.
+  CONSTRAINT std_cost_reference_components_cost_element_key CHECK (
+    component_kind <> 'cost_element' OR component_key IN (
+      'material', 'labour', 'electricity', 'depreciation', 'fixed', 'other'
+    )
+  ),
+  UNIQUE (reference_cost_id, component_kind, component_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_std_cost_reference_components_parent
+  ON public.std_cost_reference_components (reference_cost_id);
+
+-- ============================================================================
+-- Variance views — computed standard vs reference, for the Intelligence Layer.
+-- Mirrored in computeReferenceVariance() in packages/shared for the live UI.
+-- ============================================================================
+
+-- Per-component differences. computed_amount is NULL where a reference
+-- component has no computed counterpart ('other'), so it stays visible as
+-- unmatched rather than silently reading as a zero difference.
+CREATE OR REPLACE VIEW public.v_std_cost_reference_component_variance
+WITH (security_invoker = true) AS
+WITH current_computed AS (
+  SELECT c.*, bt.electricity_per_unit, bt.depreciation_per_unit
+  FROM public.v_std_cost_brick_type_computed c
+  JOIN public.std_cost_brick_types bt ON bt.id = c.brick_type_id
+  WHERE c.status = 'published'
+    AND c.valid_from = (
+      SELECT MAX(valid_from) FROM public.std_cost_versions WHERE status = 'published'
+    )
+),
+recipe_per_unit AS (
+  SELECT bt.brick_type,
+         rl.rm_key,
+         (rl.kg_per_batch * (rm.purchase_amount / rm.purchase_unit_kg)) / bt.bricks_per_batch
+           AS cost_per_unit
+  FROM public.std_cost_recipe_lines rl
+  JOIN public.std_cost_brick_types bt ON bt.id = rl.brick_type_id
+  JOIN public.std_cost_rm_prices rm
+    ON rm.version_id = bt.version_id AND rm.rm_key = rl.rm_key
+  JOIN current_computed cc ON cc.brick_type_id = bt.id
+)
+SELECT
+  r.id                          AS reference_id,
+  r.brick_type,
+  r.source,
+  r.reference_date,
+  rc.component_kind,
+  rc.component_key,
+  rc.amount                     AS reference_amount,
+  CASE rc.component_kind
+    WHEN 'cost_element' THEN CASE rc.component_key
+      WHEN 'material'     THEN cc.material_cost_per_unit
+      WHEN 'labour'       THEN cc.labor_cost_per_unit
+      WHEN 'electricity'  THEN cc.electricity_per_unit
+      WHEN 'depreciation' THEN cc.depreciation_per_unit
+      WHEN 'fixed'        THEN cc.fixed_cost_per_unit
+      ELSE NULL                              -- 'other' has no counterpart
+    END
+    ELSE (SELECT rpu.cost_per_unit FROM recipe_per_unit rpu
+           WHERE rpu.brick_type = r.brick_type AND rpu.rm_key = rc.component_key)
+  END                           AS computed_amount,
+  CASE rc.component_kind
+    WHEN 'cost_element' THEN CASE rc.component_key
+      WHEN 'material'     THEN ROUND(cc.material_cost_per_unit - rc.amount, 4)
+      WHEN 'labour'       THEN ROUND(cc.labor_cost_per_unit - rc.amount, 4)
+      WHEN 'electricity'  THEN ROUND(cc.electricity_per_unit - rc.amount, 4)
+      WHEN 'depreciation' THEN ROUND(cc.depreciation_per_unit - rc.amount, 4)
+      WHEN 'fixed'        THEN ROUND(cc.fixed_cost_per_unit - rc.amount, 4)
+      ELSE NULL
+    END
+    ELSE ROUND(COALESCE((SELECT rpu.cost_per_unit FROM recipe_per_unit rpu
+                          WHERE rpu.brick_type = r.brick_type
+                            AND rpu.rm_key = rc.component_key), 0) - rc.amount, 4)
+  END                           AS difference
+FROM public.std_cost_reference_costs r
+JOIN public.std_cost_reference_components rc ON rc.reference_cost_id = r.id
+LEFT JOIN current_computed cc ON cc.brick_type = r.brick_type
+WHERE r.is_active;
+
+-- Headline reconciliation, one row per brick type per active reference.
+CREATE OR REPLACE VIEW public.v_std_cost_reference_variance
+WITH (security_invoker = true) AS
+WITH current_computed AS (
+  SELECT c.*
+  FROM public.v_std_cost_brick_type_computed c
+  WHERE c.status = 'published'
+    AND c.valid_from = (
+      SELECT MAX(valid_from) FROM public.std_cost_versions WHERE status = 'published'
+    )
+),
+explained AS (
+  -- Only the cost_element axis: the raw_material rows live INSIDE material and
+  -- adding them here would double-count.
+  SELECT reference_id, SUM(difference) AS explained_difference
+  FROM public.v_std_cost_reference_component_variance
+  WHERE component_kind = 'cost_element' AND difference IS NOT NULL
+  GROUP BY reference_id
+)
+SELECT
+  r.brick_type,
+  r.id                                        AS reference_id,
+  r.source,
+  r.source_label,
+  r.reference_date,
+  r.notes,
+  ROUND(cc.total_cost_per_unit, 2)            AS computed_cost_per_unit,
+  r.reference_cost,
+  ROUND(cc.total_cost_per_unit - r.reference_cost, 2) AS variance_amount,
+  CASE WHEN r.reference_cost > 0
+       THEN ROUND((cc.total_cost_per_unit - r.reference_cost) / r.reference_cost * 100, 2)
+  END                                         AS variance_pct,
+  ROUND(COALESCE(e.explained_difference, 0), 2)       AS explained_difference,
+  -- What the stored breakdown does NOT account for. With no breakdown at all
+  -- this equals the whole variance, which is the honest answer.
+  ROUND((cc.total_cost_per_unit - r.reference_cost) - COALESCE(e.explained_difference, 0), 2)
+                                              AS unexplained_difference,
+  EXISTS (SELECT 1 FROM public.std_cost_reference_components rc
+           WHERE rc.reference_cost_id = r.id)  AS has_component_breakdown,
+  cc.version_id,
+  cc.valid_from,
+  cc.published_at
+FROM public.std_cost_reference_costs r
+JOIN current_computed cc ON cc.brick_type = r.brick_type
+LEFT JOIN explained e ON e.reference_id = r.id
+WHERE r.is_active;
+
+COMMENT ON VIEW public.v_std_cost_reference_variance IS
+  'Computed standard vs stored benchmarks. Read by the Intelligence Layer for exception analysis. References never feed the computation.';
+
+-- ============================================================================
+-- publish_std_cost_draft() — carry the verification flags into the next draft.
+-- Otherwise a published-then-copied draft would quietly lose the record that an
+-- input is still unconfirmed.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.publish_std_cost_draft(
+  p_draft_id UUID,
+  p_valid_from DATE,
+  p_published_by UUID,
+  p_notes TEXT DEFAULT NULL
+) RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_new_draft UUID;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM std_cost_versions WHERE id = p_draft_id AND status = 'draft'
+  ) THEN
+    RAISE EXCEPTION 'Version % is not the open draft', p_draft_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM std_cost_versions
+    WHERE status = 'published' AND valid_from >= p_valid_from
+  ) THEN
+    RAISE EXCEPTION 'valid_from % must be after the currently published version', p_valid_from;
+  END IF;
+
+  UPDATE std_cost_versions
+     SET status = 'published',
+         valid_from = p_valid_from,
+         published_by = p_published_by,
+         published_at = now(),
+         notes = COALESCE(p_notes, notes)
+   WHERE id = p_draft_id;
+
+  INSERT INTO std_cost_versions (status, monthly_production_basis, notes, created_by, updated_by)
+  SELECT 'draft', monthly_production_basis, NULL, p_published_by, p_published_by
+  FROM std_cost_versions WHERE id = p_draft_id
+  RETURNING id INTO v_new_draft;
+
+  INSERT INTO std_cost_rm_prices
+    (version_id, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg,
+     needs_verification, verification_note)
+  SELECT v_new_draft, rm_key, display_name, purchase_amount, purchase_unit_label, purchase_unit_kg,
+         needs_verification, verification_note
+  FROM std_cost_rm_prices WHERE version_id = p_draft_id;
+
+  INSERT INTO std_cost_fixed_items (version_id, item_key, display_name, monthly_amount)
+  SELECT v_new_draft, item_key, display_name, monthly_amount
+  FROM std_cost_fixed_items WHERE version_id = p_draft_id;
+
+  WITH copied AS (
+    INSERT INTO std_cost_brick_types
+      (version_id, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+       electricity_per_unit, depreciation_per_unit, sales_price, loading_unloading_per_unit,
+       transport_per_unit, commission_per_unit, sort_order)
+    SELECT v_new_draft, brick_type, odoo_product_match, bricks_per_batch, labor_cost_per_batch,
+           electricity_per_unit, depreciation_per_unit, sales_price, loading_unloading_per_unit,
+           transport_per_unit, commission_per_unit, sort_order
+    FROM std_cost_brick_types WHERE version_id = p_draft_id
+    RETURNING id, brick_type
+  )
+  INSERT INTO std_cost_recipe_lines (brick_type_id, rm_key, kg_per_batch)
+  SELECT copied.id, rl.rm_key, rl.kg_per_batch
+  FROM copied
+  JOIN std_cost_brick_types old_bt
+    ON old_bt.version_id = p_draft_id AND old_bt.brick_type = copied.brick_type
+  JOIN std_cost_recipe_lines rl ON rl.brick_type_id = old_bt.id;
+
+  RETURN v_new_draft;
+END $$;
+
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_std_cost_draft(UUID, DATE, UUID, TEXT) TO service_role;
+
+-- ------------------------------------------------------------------- RLS ----
+
+ALTER TABLE public.std_cost_reference_costs      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.std_cost_reference_components ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS std_cost_reference_costs_read ON public.std_cost_reference_costs;
+CREATE POLICY std_cost_reference_costs_read ON public.std_cost_reference_costs
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS std_cost_reference_components_read ON public.std_cost_reference_components;
+CREATE POLICY std_cost_reference_components_read ON public.std_cost_reference_components
+  FOR SELECT TO authenticated USING (true);
+
+REVOKE ALL ON public.std_cost_reference_costs      FROM anon;
+REVOKE ALL ON public.std_cost_reference_components FROM anon;
+REVOKE ALL ON public.v_std_cost_reference_variance           FROM anon;
+REVOKE ALL ON public.v_std_cost_reference_component_variance FROM anon;
+
+GRANT SELECT ON public.std_cost_reference_costs      TO authenticated;
+GRANT SELECT ON public.std_cost_reference_components TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_reference_costs      TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.std_cost_reference_components TO service_role;
+GRANT SELECT ON public.v_std_cost_reference_variance           TO authenticated, service_role;
+GRANT SELECT ON public.v_std_cost_reference_component_variance TO authenticated, service_role;

--- a/supabase/migrations/20260822120200_std_cost_reference_costs.sql
+++ b/supabase/migrations/20260822120200_std_cost_reference_costs.sql
@@ -16,9 +16,13 @@
 --
 -- Two axes of component breakdown, both optional:
 --   'cost_element'  material · labour · electricity · depreciation · fixed ·
---                   other — mutually exclusive, they sum to the reference
---                   total, and each maps 1:1 onto a computed number. The
---                   UNEXPLAINED residual is measured on this axis only.
+--                   other — mutually exclusive parts of the reference total,
+--                   each mapping 1:1 onto a computed number. The UNEXPLAINED
+--                   residual is measured on this axis only. (A later migration,
+--                   ..._partial_breakdown.sql, adds breakdown_status so these
+--                   may cover only PART of the total while a reconciliation is
+--                   still in progress; equality is required only when the
+--                   breakdown is declared complete.)
 --   'raw_material'  cement · chemical · … — a drill-down INSIDE the material
 --                   element, so "cement consumption differs by ₹0.62" is
 --                   answerable. Deliberately NOT added to the cost_element

--- a/supabase/migrations/20260822120300_std_cost_reference_seed.sql
+++ b/supabase/migrations/20260822120300_std_cost_reference_seed.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- Seed the legacy benchmarks from the retiring "Mb Unit Economics" sheet, and
+-- mark the two unconfirmed inputs.
+--
+-- These totals go into std_cost_reference_costs — NOT into the standard. The
+-- computed standard keeps saying what the recipes and prices say; the sheet's
+-- totals sit next to it as a benchmark, and the difference becomes a question
+-- the Intelligence Layer can be asked, rather than a number anyone is tempted
+-- to reverse-engineer.
+--
+-- No component breakdown is seeded because the sheet did not publish one. That
+-- is deliberate: every rupee of variance shows as UNEXPLAINED until someone
+-- supplies a real breakdown. An invented breakdown that happened to sum to the
+-- gap would be exactly the balancing factor this design exists to prevent.
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_draft UUID;
+BEGIN
+  -- ---------------------------------------- legacy sheet totals as benchmarks
+  INSERT INTO public.std_cost_reference_costs
+    (brick_type, reference_cost, source, source_label, reference_date, notes)
+  VALUES
+    ('8 CIB', 32.83, 'legacy_excel', 'Mb Unit Economics sheet', CURRENT_DATE,
+     'Total cost/unit as the sheet displayed it at go-live. The sheet''s own inputs do not compute to this.'),
+    ('6 CIB', 31.80, 'legacy_excel', 'Mb Unit Economics sheet', CURRENT_DATE,
+     'Total cost/unit as the sheet displayed it at go-live. The sheet''s own inputs do not compute to this.'),
+    ('8 MIB', 36.12, 'legacy_excel', 'Mb Unit Economics sheet', CURRENT_DATE,
+     'Total cost/unit as the sheet displayed it at go-live. The sheet''s own inputs do not compute to this.'),
+    ('6 MIB', 29.04, 'legacy_excel', 'Mb Unit Economics sheet', CURRENT_DATE,
+     'Total cost/unit as the sheet displayed it at go-live. The sheet''s own inputs do not compute to this.')
+  ON CONFLICT (brick_type, source, reference_date) DO NOTHING;
+
+  -- ------------------------------------------- flag the unconfirmed inputs ---
+  -- Applied to the OPEN DRAFT only: published versions are immutable, and the
+  -- flag is an attribute of the input, so it travels forward on each publish.
+  SELECT id INTO v_draft FROM public.std_cost_versions WHERE status = 'draft';
+  IF v_draft IS NULL THEN
+    RAISE NOTICE 'No open draft — skipping verification flags';
+    RETURN;
+  END IF;
+
+  UPDATE public.std_cost_rm_prices
+     SET needs_verification = true,
+         verification_note =
+           'Load weight unconfirmed. The source gives both 37,050 kg and approx 1.27/kg, '
+           'which disagree by 10x; 3,705 kg is in use because it matches the per-kg cost '
+           'the standard has been costing with. Confirm the real load weight, then correct '
+           'it here and publish — do not adjust any formula to compensate.'
+   WHERE version_id = v_draft AND rm_key = 'red_soil';
+
+  UPDATE public.std_cost_rm_prices
+     SET needs_verification = true,
+         verification_note =
+           'Load weight unconfirmed. The source gives 3600 for "28900-for-8" and approx 0.80/kg; '
+           '4,500 kg is in use because it matches the stated per-kg cost. No recipe consumes '
+           'this material today, so no computed total depends on it.'
+   WHERE version_id = v_draft AND rm_key = 'red_soil_gravel';
+END $$;

--- a/supabase/migrations/20260822120400_std_cost_reference_partial_breakdown.sql
+++ b/supabase/migrations/20260822120400_std_cost_reference_partial_breakdown.sql
@@ -1,0 +1,180 @@
+-- ============================================================================
+-- Reference costs: support PARTIAL component breakdowns.
+--
+-- The previous rule required a cost_element breakdown to sum exactly to the
+-- benchmark total. That made the residual zero by construction the moment any
+-- breakdown existed:
+--
+--   unexplained = total_variance − Σ(component variances)
+--
+-- and if the reference components sum to the reference total, those component
+-- variances necessarily sum to the total variance. The number meant to say
+-- "we still don't know why" could only ever say zero.
+--
+-- It also blocked the workflow reconciliation actually follows: you discover
+-- one component at a time, and the unexplained amount shrinks as you go.
+--
+--   Total variance:    -5.77
+--   Explained so far:  -4.65   (material -3.20, labour -1.45)
+--   Still unexplained: -1.12   <- the whole point
+--
+-- So breakdown_status now distinguishes:
+--   'partial'  (default) - rows may cover only part of the total. Coverage is
+--              shown as 24.10 / 32.83 and the residual stays live.
+--   'complete' - the user asserts the breakdown IS the whole total; only then
+--              is equality enforced, within a 0.01 tolerance.
+--
+-- Deliberately NOT added: any automatic "balancing" component. The residual is
+-- reported, never absorbed.
+-- ============================================================================
+
+ALTER TABLE public.std_cost_reference_costs
+  ADD COLUMN IF NOT EXISTS breakdown_status TEXT NOT NULL DEFAULT 'partial'
+    CHECK (breakdown_status IN ('partial', 'complete'));
+
+COMMENT ON COLUMN public.std_cost_reference_costs.breakdown_status IS
+  'partial: components may cover only part of the total, residual stays visible. complete: components must equal the total (0.01 tolerance).';
+
+-- ---------------------------------------------------------------------------
+-- Enforcement, deferred to commit.
+--
+-- Components are written as a set (delete-all then insert-all), so a row-by-row
+-- check would fire mid-write against a half-built breakdown. A DEFERRABLE
+-- INITIALLY DEFERRED constraint trigger evaluates once, at COMMIT, when the
+-- breakdown is whole.
+--
+-- Two rules:
+--   always     - cost elements may not exceed the total. They are exclusive
+--                parts of it; summing beyond it is arithmetically impossible,
+--                not a judgement call.
+--   'complete' - they must equal the total, or the completeness claim is false
+--                and the zero residual it produces would be a lie.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.std_cost_check_breakdown()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  v_reference_id UUID;
+  v_total NUMERIC;
+  v_status TEXT;
+  v_sum NUMERIC;
+  v_tolerance CONSTANT NUMERIC := 0.01;
+BEGIN
+  -- Branch rather than a CASE expression: PL/pgSQL resolves the record fields
+  -- in every arm of a CASE, so naming reference_cost_id there fails outright
+  -- when NEW is a std_cost_reference_costs row that has no such field.
+  IF TG_TABLE_NAME = 'std_cost_reference_costs' THEN
+    v_reference_id := COALESCE(NEW.id, OLD.id);
+  ELSE
+    v_reference_id := COALESCE(NEW.reference_cost_id, OLD.reference_cost_id);
+  END IF;
+
+  SELECT reference_cost, breakdown_status INTO v_total, v_status
+  FROM public.std_cost_reference_costs WHERE id = v_reference_id;
+
+  -- The parent may have been deleted in this same transaction (cascade).
+  IF v_total IS NULL THEN RETURN NULL; END IF;
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_sum
+  FROM public.std_cost_reference_components
+  WHERE reference_cost_id = v_reference_id AND component_kind = 'cost_element';
+
+  IF v_sum > v_total + v_tolerance THEN
+    RAISE EXCEPTION
+      'Cost element breakdown (%) exceeds the reference cost (%) - elements are exclusive parts of the total',
+      ROUND(v_sum, 2), ROUND(v_total, 2);
+  END IF;
+
+  IF v_status = 'complete' AND ABS(v_sum - v_total) > v_tolerance THEN
+    RAISE EXCEPTION
+      'Breakdown is marked complete but adds up to % against a reference cost of % - mark it partial, or account for the remaining %',
+      ROUND(v_sum, 2), ROUND(v_total, 2), ROUND(v_total - v_sum, 2);
+  END IF;
+
+  RETURN NULL;
+END $$;
+
+DROP TRIGGER IF EXISTS std_cost_reference_components_breakdown_check
+  ON public.std_cost_reference_components;
+CREATE CONSTRAINT TRIGGER std_cost_reference_components_breakdown_check
+  AFTER INSERT OR UPDATE OR DELETE ON public.std_cost_reference_components
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_check_breakdown();
+
+DROP TRIGGER IF EXISTS std_cost_reference_costs_breakdown_check
+  ON public.std_cost_reference_costs;
+CREATE CONSTRAINT TRIGGER std_cost_reference_costs_breakdown_check
+  AFTER INSERT OR UPDATE ON public.std_cost_reference_costs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION public.std_cost_check_breakdown();
+
+-- ---------------------------------------------------------------------------
+-- Variance view gains coverage, so "how much of this benchmark do we actually
+-- understand yet" is answerable without recomputing it downstream.
+-- ---------------------------------------------------------------------------
+-- Dropped rather than replaced: CREATE OR REPLACE VIEW cannot insert columns
+-- into the middle of the column list. Nothing else depends on this view.
+DROP VIEW IF EXISTS public.v_std_cost_reference_variance;
+
+CREATE VIEW public.v_std_cost_reference_variance
+WITH (security_invoker = true) AS
+WITH current_computed AS (
+  SELECT c.*
+  FROM public.v_std_cost_brick_type_computed c
+  WHERE c.status = 'published'
+    AND c.valid_from = (
+      SELECT MAX(valid_from) FROM public.std_cost_versions WHERE status = 'published'
+    )
+),
+explained AS (
+  -- cost_element axis only: raw_material rows live INSIDE material and adding
+  -- them here would double-count.
+  SELECT reference_id, SUM(difference) AS explained_difference
+  FROM public.v_std_cost_reference_component_variance
+  WHERE component_kind = 'cost_element' AND difference IS NOT NULL
+  GROUP BY reference_id
+),
+coverage AS (
+  SELECT reference_cost_id, SUM(amount) AS breakdown_coverage
+  FROM public.std_cost_reference_components
+  WHERE component_kind = 'cost_element'
+  GROUP BY reference_cost_id
+)
+SELECT
+  r.brick_type,
+  r.id                                        AS reference_id,
+  r.source,
+  r.source_label,
+  r.reference_date,
+  r.notes,
+  ROUND(cc.total_cost_per_unit, 2)            AS computed_cost_per_unit,
+  r.reference_cost,
+  ROUND(cc.total_cost_per_unit - r.reference_cost, 2) AS variance_amount,
+  CASE WHEN r.reference_cost > 0
+       THEN ROUND((cc.total_cost_per_unit - r.reference_cost) / r.reference_cost * 100, 2)
+  END                                         AS variance_pct,
+  ROUND(COALESCE(e.explained_difference, 0), 2)       AS explained_difference,
+  -- What no stored component accounts for. Shrinks as components are
+  -- discovered; equals the whole variance when nothing is known yet.
+  ROUND((cc.total_cost_per_unit - r.reference_cost) - COALESCE(e.explained_difference, 0), 2)
+                                              AS unexplained_difference,
+  r.breakdown_status,
+  ROUND(COALESCE(cov.breakdown_coverage, 0), 2)       AS breakdown_coverage,
+  CASE WHEN r.reference_cost > 0
+       THEN ROUND(COALESCE(cov.breakdown_coverage, 0) / r.reference_cost * 100, 2)
+  END                                         AS breakdown_coverage_pct,
+  EXISTS (SELECT 1 FROM public.std_cost_reference_components rc
+           WHERE rc.reference_cost_id = r.id)  AS has_component_breakdown,
+  cc.version_id,
+  cc.valid_from,
+  cc.published_at
+FROM public.std_cost_reference_costs r
+JOIN current_computed cc ON cc.brick_type = r.brick_type
+LEFT JOIN explained e ON e.reference_id = r.id
+LEFT JOIN coverage cov ON cov.reference_cost_id = r.id
+WHERE r.is_active;
+
+COMMENT ON VIEW public.v_std_cost_reference_variance IS
+  'Computed standard vs stored benchmarks. Read by the Intelligence Layer for exception analysis. References never feed the computation; unexplained_difference is reported, never absorbed.';
+
+GRANT SELECT ON public.v_std_cost_reference_variance TO authenticated, service_role;
+REVOKE ALL ON public.v_std_cost_reference_variance FROM anon;

--- a/supabase/migrations/20260822120500_std_cost_function_search_path.sql
+++ b/supabase/migrations/20260822120500_std_cost_function_search_path.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- Pin search_path on the two Unit Economics trigger functions.
+--
+-- Supabase's database linter flags functions with a role-mutable search_path
+-- (lint 0011). Both of these are SECURITY INVOKER trigger functions, so the
+-- exposure is smaller than for a SECURITY DEFINER function, but a caller can
+-- still prepend a schema and change which table an unqualified name resolves
+-- to. Pinning it is free and removes the warning.
+--
+-- publish_std_cost_draft() already sets it (it is SECURITY DEFINER, where this
+-- matters most) and is revoked from anon and authenticated.
+-- ============================================================================
+
+ALTER FUNCTION public.std_cost_guard_published() SET search_path = public;
+ALTER FUNCTION public.std_cost_check_breakdown() SET search_path = public;


### PR DESCRIPTION
## Summary

Replaces the "Mb Unit Economics" Google Sheet with a module in the app. Staff maintain raw-material prices, per-brick-type recipes, overheads and monthly fixed costs on a single mutable draft; management publishes it as an immutable, dated version; the Maiyuri Intelligence Layer reads the published standard directly from Postgres.

Legacy and benchmark numbers are stored **separately** from the standard so the gap against the old sheet becomes queryable data rather than a note in a doc.

**The database migrations in this PR are already applied to production** (`pailepomvvwjkrhkwdqt`), authorised separately. They are additive and nothing existing reads the new tables, so merging changes no current behaviour — it ships the `/unit-economics` screen.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- **Schema** (6 migrations): versions, raw-material prices, brick types, recipe lines, monthly fixed items, plus reference costs and their component breakdowns. Immutability triggers on published versions, a partial unique index enforcing exactly one draft, and an atomic `publish_std_cost_draft()` that freezes the draft and opens the next one in a single transaction.
- **Frozen contract**: `v_standard_costs_current` and `v_standard_rm_prices_current`, read by the Intelligence Layer. Never rename these views or their columns; `brick_type` and `product_match` join onto Odoo product names downstream.
- **Single source of truth for every derived number**: `cost_per_kg` is a generated column and every per-unit cost is computed in `v_std_cost_brick_type_computed`, mirrored formula-for-formula in `packages/shared/src/unit-economics.ts` so the editor can show live numbers for an unsaved draft. A test pins both to the same values. Nothing derived is ever stored from user input.
- **Reference costs**: benchmarks stored beside the standard, never inside it. `computeBundle()` takes no reference argument and the computed views don't touch the benchmark tables, so a benchmark cannot reach a published cost. Two breakdown axes — `cost_element` (exclusive, the axis the residual is measured on) and `raw_material` (a drill-down inside material, never re-added).
- **Partial reconciliation**: `breakdown_status` separates `partial` (components may cover part of the total; residual stays live) from `complete` (must balance within ₹0.01). Requiring every breakdown to balance would drive the unexplained residual to zero by construction. No automatic balancing component exists — the residual is reported, never absorbed.
- **Unconfirmed inputs**: `needs_verification` + `verification_note` on raw materials record doubt without changing how the number is used, and survive every publish.
- **UI**: `/unit-economics` with four tabs — draft editor (derived values read-only and visually distinct, recomputed per keystroke), Reconciliation, Publish (old→new diff, >15% move warnings), History (any-two-version diff). Nav entry for founder, owner, accountant.
- **API**: `GET` overview, `PUT` draft (any staff), `POST` publish (founder/owner only), version read + diff, revert, benchmark CRUD.
- **Docs**: `docs/UNIT_ECONOMICS.md` covering the model, the frozen contract, permissions, and go-live state.

## Testing

- [x] Unit tests pass (`bun test`) — 553 total, 78 new in `@maiyuri/shared`, plus the web suite
- [x] TypeScript types check (`bun typecheck`)
- [x] Linting passes (`bun lint`)
- [x] Manual testing performed

Beyond the standard gates, the SQL was executed rather than only reviewed — a local Postgres 16 instance for development, and read-only checks plus one rolled-back transaction against production:

- All six migrations apply cleanly to an empty database and are idempotent on re-run
- SQL and TypeScript agree to 10 decimal places on every computed total, and to 4 dp on every component variance
- Progressive reconciliation walked in the database, matching TypeScript at each stage: −5.77 → −2.57 → −1.12 → 0.00, coverage 0 → 48.8 → 74.5 → 93.9%
- Guards verified by attempting to violate them: two drafts, editing/deleting a published version, writing `cost_per_kg`, publishing backwards in time, a breakdown exceeding its total, and marking a short breakdown complete — all refused
- RLS: `anon` denied on all seven tables and all four views; a staff write attempted as `authenticated` affected 0 rows (the grant exists via Supabase defaults — RLS is the actual gate); `authenticated` cannot execute the publish function
- Full workflow smoke-tested in production inside a transaction and rolled back: edit → publish → contract view followed to the new standard → fresh draft opened → verification flags carried forward

Two defects were found only by running the code, not by reading it: the computed view multiplied through the 4-dp stored `cost_per_kg` instead of dividing at full precision, and a trigger used a `CASE` expression across two table shapes, which PL/pgSQL rejects because it resolves record fields in every arm.

## Screenshots (if applicable)

None — a preview deployment is the better look at this, which is part of why this PR exists.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues

None.

## Notes for review

Two things need a human decision, both documented in `docs/UNIT_ECONOMICS.md`:

1. **Two seeded inputs are best-fit guesses.** The source contradicts itself on both, and each was seeded to match the per-kg cost the standard has actually been costing with, then flagged `needs_verification`:

   | Material | Source says | In use | Why |
   |---|---|---|---|
   | `red_soil` | `4712.50 / 37050 kg (≈1.27/kg)` | 4712.50 / **3705 kg** = 1.2719/kg | 4712.50/37050 is 0.127 — off by 10× from the stated ≈1.27 |
   | `red_soil_gravel` | `3600 / 28900-for-8 (≈0.80/kg)` | 3600 / **4500 kg** = 0.80/kg | matches the stated ≈0.80; no recipe consumes it |

2. **Computed totals differ from the sheet's**, using the sheet's own inputs. Seeded as `legacy_excel` benchmarks with no component breakdown, so every rupee reads as unexplained until real figures exist:

   | Brick type | Computed | Legacy sheet | Variance |
   |---|---|---|---|
   | 8 CIB | 27.06 | 32.83 | −5.77 (−17.6%) |
   | 6 CIB | 26.24 | 31.80 | −5.56 (−17.5%) |
   | 8 MIB | 34.77 | 36.12 | −1.35 (−3.7%) |
   | 6 MIB | 27.94 | 29.04 | −1.10 (−3.8%) |

   Both CIB products sit around −17.5% and both MIB around −3.8%, which points at a CIB-specific assumption rather than a general arithmetic error — exactly the exception analysis the reconciliation views exist to support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dsmi9hoZxkoCDrFKmV7uCV)_